### PR TITLE
[1/2] RhBug: 977753

### DIFF
--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -860,7 +860,7 @@ class YumOutput:
         print(_("Size        : %s") % self.format_number(float(pkg.size)))
         print(_("Repo        : %s") % to_unicode(pkg.repoid))
         if 'from_repo' in yumdb_info:
-            print(_("From repo   : %s") % to_unicode(yumdb_info.from_repo))
+            print(_("From repo   : %s") % to_unicode(pkg.yumdb_info.from_repo))
         if self.conf.verbose:
             # :hawkey does not support changelog information
             # print(_("Committer   : %s") % to_unicode(pkg.committer))


### PR DESCRIPTION
We forgot "pkg." in repository output.py..
$ dnf info nano && dnf info vim-common && dnf install vim-common
Installed Packages
...
Repo        : @System
...

Available Packages
...
Repo        : updates-testing
...

...
Installing:
 vim-common         x86_64     2:7.3.944-1.fc19       updates-testing     5.5 M
 vim-filesystem     x86_64     2:7.3.944-1.fc19       updates-testing      12 k
...
