### PR TITLE
fixed locale path in spec file

### DIFF
--- a/package/dnf.spec.in
+++ b/package/dnf.spec.in
@@ -26,6 +26,7 @@ BuildRequires:  python-nose
 BuildRequires:  python-sphinx
 BuildRequires:  rpm-python
 BuildRequires:  systemd
+BuildRequires:  gettext
 Requires:	deltarpm
 Requires:	libreport-filesystem
 Requires:	python-hawkey >= %{hawkey_version}


### PR DESCRIPTION
according to Radek, dnf in CI can not be build ("error: File not found by glob: /builddir/build/BUILDROOT/dnf-0.4.18-99.560.20140317git87f840a.fc20.x86_64/usr/share/locale/*/LC_MESSAGES/dnf.mo"). This could maybe fix this. This and previous version can be build and run on my local machine with no problems. Otherwise it could be with jenkins environment settings.
