### PR TITLE
api: mark mandatory, default, optional_packages as api and add api doc

### DIFF
--- a/dnf/comps.py
+++ b/dnf/comps.py
@@ -127,6 +127,7 @@ class Group(Forwarder):
 
     @property
     def default_packages(self):
+        # :api
         return self._packages_of_type(libcomps.PACKAGE_TYPE_DEFAULT)
 
     def mark(self, packages):
@@ -145,10 +146,12 @@ class Group(Forwarder):
 
     @property
     def mandatory_packages(self):
+        # :api
         return self._packages_of_type(libcomps.PACKAGE_TYPE_MANDATORY)
 
     @property
     def optional_packages(self):
+        # :api
         return self._packages_of_type(libcomps.PACKAGE_TYPE_OPTIONAL)
 
     @property

--- a/doc/api_comps.rst
+++ b/doc/api_comps.rst
@@ -80,4 +80,34 @@
 
 .. class:: dnf.comps.Group
 
-    Has the same set of attributes as :class:`dnf.comps.Category`.
+  .. attribute:: id
+
+    Unique identifier of the category.
+
+  .. attribute:: name
+
+    Name of the category.
+
+  .. attribute:: ui_name
+
+    The name of the group translated to the language given by the current locale.
+
+  .. attribute:: ui_description
+
+    The description of the group translated to the language given by the current locale.
+
+  .. attribute:: mandatory_packages
+
+    List of all mandatory packages in the group as :class:`libcomps.Package`
+
+  .. attribute:: default_packages
+
+    List of all default packages in the group as :class:`libcomps.Package`
+
+  .. attribute:: optional_packages
+
+    List of all optional packages in the group as :class:`libcomps.Package`
+    
+  .. note:: :class:`libcomps.Package` is not vell documented, the object has a name attribute containing the package name
+  
+  


### PR DESCRIPTION
dnf.comps.Groups are not very usefull, if there is no way to get the packages they contains
so i have marked mandatory, default, optional_packages as api.

If you like i can change the code to return a list of package names, instead of the undocumented libcomps.package pbjects, but that will need some changes in the cli too :)
