### PR TITLE
fix: dnf clean shold also clean a local repo (file://..)  (RhBug: 107487...

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1064,8 +1064,6 @@ class Base(object):
         filelist = []
         for ext in exts:
             for repo in self.repos.iter_enabled():
-                if repo.local:
-                    continue
                 path = getattr(repo, pathattr)
                 if os.path.exists(path) and os.path.isdir(path):
                     filelist = misc.getFileList(path, ext, filelist)


### PR DESCRIPTION
fixes issue with dnf clean <something> don't clean a local repo with
baseurl=file://path/to/repo

only way to do it today, is 

rm -rf /var/cache/dnf/i386/20/<repo_id>
