### PR TITLE
refactor: put DistoSyncCommand into its own file

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -34,6 +34,7 @@ import dnf.cli.commands.group
 import dnf.cli.commands.install
 import dnf.cli.commands.reinstall
 import dnf.cli.commands.upgrade
+import dnf.cli.commands.distrosync
 import dnf.cli.demand
 import dnf.cli.option_parser
 import dnf.conf
@@ -1035,7 +1036,7 @@ class Cli(object):
         self.register_command(dnf.cli.commands.reinstall.ReinstallCommand)
         self.register_command(dnf.cli.commands.downgrade.DowngradeCommand)
         self.register_command(dnf.cli.commands.HistoryCommand)
-        self.register_command(dnf.cli.commands.DistroSyncCommand)
+        self.register_command(dnf.cli.commands.distrosync.DistroSyncCommand)
 
     def _configure_cachedir(self):
         # perform the CLI-specific cachedir tricks

--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -281,45 +281,6 @@ class UpgradeToCommand(Command):
         patterns = self.parse_extcmds(extcmds)
         return self.base.upgrade_userlist_to(patterns)
 
-class DistroSyncCommand(Command):
-    """A class containing methods needed by the cli to execute the
-    distro-synch command.
-    """
-
-    aliases = ('distribution-synchronization', 'distro-sync')
-    activate_sack = True
-    resolve = True
-    writes_rpmdb = True
-
-    @staticmethod
-    def get_usage():
-        """Return a usage string for this command.
-
-        :return: a usage string for this command
-        """
-        return _("[PACKAGE...]")
-
-    @staticmethod
-    def get_summary():
-        """Return a one line summary of this command.
-
-        :return: a one line summary of this command
-        """
-        return _("Synchronize installed packages to the latest available versions")
-
-    def doCheck(self, basecmd, extcmds):
-        """Verify that conditions are met so that this command can run.
-        These include that the program is being run by the root user,
-        and that there are enabled repositories with gpg keys.
-
-        :param basecmd: the name of the command
-        :param extcmds: the command line arguments passed to *basecmd*
-        """
-        checkGPGKey(self.base, self.cli)
-        checkEnabledRepo(self.base, extcmds)
-
-    def run(self, extcmds):
-        return self.base.distro_sync_userlist(extcmds)
 
 class InfoCommand(Command):
     """A class containing methods needed by the cli to execute the

--- a/dnf/cli/commands/distrosync.py
+++ b/dnf/cli/commands/distrosync.py
@@ -1,0 +1,64 @@
+# distrosync.py
+# distro-sync CLI command.
+#
+# Copyright (C) 2012-2014  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+from __future__ import absolute_import
+from .. import commands
+from dnf.yum.i18n import _
+
+
+class DistroSyncCommand(commands.Command):
+    """A class containing methods needed by the cli to execute the
+    distro-synch command.
+    """
+
+    aliases = ('distro-sync', 'distribution-synchronization')
+    activate_sack = True
+    resolve = True
+    writes_rpmdb = True
+
+    @staticmethod
+    def get_usage():
+        """Return a usage string for this command.
+
+        :return: a usage string for this command
+        """
+        return _("[PACKAGE...]")
+
+    @staticmethod
+    def get_summary():
+        """Return a one line summary of this command.
+
+        :return: a one line summary of this command
+        """
+        return _("Synchronize installed packages to the latest available versions")
+
+    def doCheck(self, basecmd, extcmds):
+        """Verify that conditions are met so that this command can run.
+        These include that the program is being run by the root user,
+        and that there are enabled repositories with gpg keys.
+
+        :param basecmd: the name of the command
+        :param extcmds: the command line arguments passed to *basecmd*
+        """
+        commands.checkGPGKey(self.base, self.cli)
+        commands.checkEnabledRepo(self.base, extcmds)
+
+    def run(self, extcmds):
+        return self.base.distro_sync_userlist(extcmds)


### PR DESCRIPTION
I have also changed the order of the aliases, so disto-sync is the primary there will be shown
as far as i can see distibution-syncronization is an deprecated alias and it is make the dnf usage list look bad
