### PR TITLE
Add includepkgs tag

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -138,6 +138,11 @@ class Base(object):
                 pkgs = self.sack.query().filter(reponame=r.id).\
                     filter_autoglob(name=excl)
                 self.sack.add_excludes(pkgs)
+            for incl in r.includepkgs:
+                pkgs = self.sack.query().filter(reponame=r.id).\
+                    filter_autoglob(name=incl)
+                self.sack.add_includepkgs(pkgs)
+	    self.sack.eval_includepkgs(self)
 
     def _store_persistent_data(self):
         def check_expired(repo):

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -96,6 +96,13 @@ one main section. The repository sections define the configuration for each
     same package can be downloaded from two or more repositories, the repository
     with the lowest cost is preferred.
 
+``includepkgs``
+    list
+
+    Inverse of exclude for repositories. Dnf include only package in the repo,
+    that match this list. If there is exclude tag both of them are used.
+
+
 ``skip_if_unavailable``
     boolean
 


### PR DESCRIPTION
This patch adds the possibility to use includepkgs tag in configuration files - see dnf.conf(8) manual page.
It uses new hawkey api (self.sack.add_includepkgs and self.sack.eval_includepkgs functions)

Signed-off-by: Ivana Hutarova Varekova varekova@redhat.com
