### PR TITLE
Remove sudo from dnf-completion.bash

### DIFF
--- a/etc/bash_completion.d/dnf-completion.bash
+++ b/etc/bash_completion.d/dnf-completion.bash
@@ -80,7 +80,7 @@ _dnf ()
             COMPREPLY=($(compgen -W "`egrep ^$cur /var/cache/dnf/available.cache`" -- "$cur"))
             return
         else
-            COMPREPLY=($(compgen -W "`sudo dnf list --cacheonly 2>/dev/null | cut -d' ' -f1 | egrep ^$cur`" -- "$cur"))
+            COMPREPLY=($(compgen -W "`dnf list --cacheonly 2>/dev/null | cut -d' ' -f1 | egrep ^$cur`" -- "$cur"))
             return
         fi
     fi


### PR DESCRIPTION
This sudo call was a relic from when the cache was not world readable. It's not needed anymore, and it also causes issues in some setups.

RhBug:1073457
