### PR TITLE
api: added ucd and ucd_input

### DIFF
--- a/dnf/i18n.py
+++ b/dnf/i18n.py
@@ -100,6 +100,7 @@ def ucd_input(ucstring):
         (raw_input() won't check sys.stdout.encoding as e.g. print does, see
         test_i18n.TestInput.test_assumption()).
     """
+    # :api
     if not isinstance(ucstring, unicode):
         raise TypeError("input() accepts Unicode strings")
     if PY3:
@@ -110,6 +111,7 @@ def ucd_input(ucstring):
 
 def ucd(obj):
     """ Like the builtin unicode() but tries to use a reasonable encoding. """
+    # :api
     if PY3:
         if is_py3bytes(obj):
             return str(obj, _guess_encoding())


### PR DESCRIPTION
This should be IMO part of API in response to recent dnf-core-plugins bugs. Then I could add to plugins documentation how to use it on strings read outside dnf. From brief look I have seen `raw_input` (in copr plugin) and and `str` calls that should be replaced with `ucd`. I would also make compulsory  line `from __future__ import unicode_literals` to each plugin.
