### PR TITLE
set load_updateinfo to True only if it's available

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -115,7 +115,8 @@ class Base(object):
         else:
             logger.debug("not found updateinfo for: %s" % repo.name)
         self._sack.load_yum_repo(hrepo, build_cache=True, load_filelists=True,
-                                 load_presto=repo.deltarpm, load_updateinfo=True)
+                                 load_presto=repo.deltarpm,
+                                 load_updateinfo=bool(repo.updateinfo_fn))
 
     def _setup_excludes_includes(self):
         disabled = set(self.conf.disable_excludes)


### PR DESCRIPTION
I think load_updateinfo should be set to True only if repo.updateinfo_fn is set
and updateinfo metadata is available for the repo in dnf.base.Base._add_repo_to_sack().
