### PR TITLE
bash-completion: new completion from scratch (RhBug:1070902)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,6 +41,7 @@ DNF AUTHORS
     Albert Uchytil <auchytil@redhat.com>
     Ales Kozumplik <ales@redhat.com>
     Elad Alfassa <elad@fedoraproject.org>
+    Igor Gnatenko <i.gnatenko.brain@gmail.com>
     Jan Silhan <jsilhan@redhat.com>
     Kevin Kofler <kevin.kofler@chello.at>
     Panu Matilainen <pmatilai@redhat.com>

--- a/etc/bash_completion.d/dnf-completion.bash
+++ b/etc/bash_completion.d/dnf-completion.bash
@@ -1,146 +1,107 @@
+# dnf completion                                          -*- shell-script -*-
 #
-#  bash completion support for dnf's console commands.
-#  Based on zif's bash completion code
+# This file is part of dnf.
 #
-#  Copyright (C) 2008 - 2010 James Bowes <jbowes@repl.ca>
-#  Copyright (C) 2010 Richard Hughes <richard@hughsie.com>
-#  Copyright © 2013 Elad Alfassa <elad@fedoraproject.org>
+# Copyright 2013 (C) Elad Alfassa <elad@fedoraproject.org>
+# Copyright 2014 (C) Igor Gnatenko <i.gnatenko.brain@gmail.com>
 #
-#  This program is free software; you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
-#  (at your option) any later version.
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 #
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software
-#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
-#  02110-1301  USA
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301  USA
 
-
-__dnf_commandlist="$(compgen -W "`dnf help | sed -e "s/\(  \)\+.*$//g" -e "/^$/d" -e "/^[A-Z ]/d" -e "/:/d"`")"
-# s/\(  \)\+.*$//g : remove description for commands
-# /^$/d            : remove blank lines
-# /^[A-Z ]/d       : remove lines starts with capital letter or with space (all commands in help starts without spaces)
-# /:/d             : remove lines which contains ':' (now we have only commands, so commands can't contain this sym)
-
-__dnfcomp ()
+_dnf()
 {
-    local all c s=$'\n' IFS=' '$'\t'$'\n'
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    if [ $# -gt 2 ]; then
-        cur="$3"
-    fi
-    for c in $1; do
-        case "$c$4" in
-        *.)    all="$all$c$4$s" ;;
-        *)     all="$all$c$4 $s" ;;
-        esac
-    done
-    IFS=$s
-    COMPREPLY=($(compgen -P "$2" -W "$all" -- "$cur"))
-    return
-}
+    local commandlist="$( compgen -W '$( dnf help | cut -d" " -s -f1 | sed -e "/^[A-Z]/d" -e "/:/d" )' )"
 
-_dnf ()
-{
-    local i c=1 command
-    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local cur prev words cword
+    _init_completion -s || return
 
-    while [ $c -lt $COMP_CWORD ]; do
-        i="${COMP_WORDS[c]}"
-        case "$i" in
-        --version|--help|--verbose|-h) ;;
-        *) command="$i"; break ;;
-        esac
-        c=$((++c))
-    done
-    if [[ "$command" == "install" || "$command" == "update" || "$command" == "info" ]]; then
-        if [ -r '/var/cache/dnf/available.cache' ]; then
-            COMPREPLY=($(compgen -W "`grep -E ^$cur /var/cache/dnf/available.cache`" -- "$cur"))
-            return
-        else
-            COMPREPLY=($(compgen -W "`dnf list --cacheonly 2>/dev/null | cut -d' ' -f1 | grep -E ^$cur`" -- "$cur"))
-            return
+    local commandix command
+    for (( commandix=1; commandix < cword; commandix++ )); do
+        if [[ ${words[commandix]} != -* ]]; then
+            if [[ ${words[commandix-1]} != -* ]]; then
+                command=${words[commandix]}
+            fi
+            break
         fi
-    fi
-    if [[ "$command" == "remove" || "$command" == "erase" ]]; then
-        if [ -r '/var/cache/dnf/installed.cache' ]; then
-            COMPREPLY=($(compgen -W "`grep -E ^$cur /var/cache/dnf/installed.cache`" -- "$cur"))
-            return
-        else
-            COMPREPLY=($(compgen -W "`rpm -qav --qf '%{NAME}.%{ARCH}\n' | grep -E ^$cur`" -- "$cur"))
-            return
-        fi
-    fi
-    if [[ "$command" == "help" ]]; then
-      COMPREPLY=($(compgen -W "`echo $__dnf_commandlist`" -- "$cur"))
-        return
-    fi
+    done
 
-    if [ $c -eq $COMP_CWORD -a -z "$command" ]; then
-        case "${COMP_WORDS[COMP_CWORD]}" in
-        --*=*) COMPREPLY=() ;;
-        --*)   __dnfcomp "
-            --allowerasing
-            --best
-            --cacheonly
-            --config
-            --randomwait
-            --debuglevel
-            --debugsolver
-            --showduplicates
-            --errorlevel
-            --rpmverbosity
-            --quiet
-            --verbose
-            --assumeyes
-            --assumeno
-            --version
-            --installroot
-            --enablerepo
-            --disablerepo
-            --exclude
-            --disableexcludes
-            --obsoletes
-            --noplugins
-            --nogpgcheck
-            --disableplugin
-            --color
-            --releasever
-            --setopt
-            --refresh
-            --help
-            "
-            ;;
-        -*) __dnfcomp "
-            -b
-            -C
-            -c
-            -R
-            -d
-            -e
-            -q
-            -v
-            -y
-            -x
-            -4
-            -6
-            -h
-            "
-            ;;
-        *)     __dnfcomp "$__dnf_commandlist" ;;
-        esac
-        return
-    fi
+    # How many'th non-option arg (1-based) for $command are we completing?
+    local i nth=1
+    for (( i=commandix+1; i < cword; i++ )); do
+        [[ ${words[i]} == -* ]] || (( nth++ ))
+    done
 
-    case "$command" in
-    *)           COMPREPLY=() ;;
+    case $prev in
+        -h|--help|--version)
+            return
+            ;;
+        --enablerepo)
+            COMPREPLY=( $( compgen -W '$( dnf --cacheonly repolist disabled | sed -e "1d" )' -- "$cur" ) )
+            ;;
+        --disablerepo )
+            COMPREPLY=( $( compgen -W '$( dnf --cacheonly repolist enabled | sed -e "1d" | cut -d" " -f1 | tr -d "*" )' -- "$cur" ) )
+            ;;
+        *)
+            ;;
     esac
-}
 
-complete -o default -o nospace -F _dnf dnf
+    $split && return
+
+    if [[ $command ]]; then
+
+        case $command in
+            install|update|info)
+                if [ -r '/var/cache/dnf/available.cache' ]; then
+                    COMPREPLY=( $( compgen -W '$( grep -E ^$cur /var/cache/dnf/available.cache )' -- "$cur" ) )
+                else
+                    COMPREPLY=( $( compgen -W '$( dnf --cacheonly list 2>/dev/null | cut -d' ' -f1 | grep -E ^$cur )' -- "$cur" ) )
+                fi
+                [[ $command != "info" ]] && ext='@(rpm)' || ext=''
+                ;;
+            remove|erase)
+                if [ -r '/var/cache/dnf/installed.cache' ]; then
+                    COMPREPLY=( $( compgen -W '$( grep -E ^$cur /var/cache/dnf/installed.cache )' -- "$cur" ) )
+                else
+                    COMPREPLY=( $( compgen -W '$( rpm -qav --qf "%{NAME}.%{ARCH}\n" | grep -E ^$cur )' -- "$cur" ) )
+                fi
+                ext=''
+                ;;
+            help)
+                case $nth in
+                    1)
+                        COMPREPLY=( $( compgen -W '$( echo $commandlist )' -- "$cur" ) )
+                        ;;
+                    *)
+                        ;;
+                esac
+                ext=''
+                ;;
+            *)
+                ext=''
+                ;;
+        esac
+        [[ ${#COMPREPLY[@]} -eq 0 ]] && [[ -n $ext ]] && _filedir $ext
+        return
+
+    fi
+
+    if [[ $cur == -* ]]; then
+        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "$cur" ) )
+        [[ $COMPREPLY == *= ]] && compopt -o nospace
+    elif [[ ! $command ]]; then
+        [[ $prev != -* ]] && COMPREPLY=( $( compgen -W '$( echo $commandlist )' -- "$cur" ) )
+    fi
+} &&
+complete -F _dnf dnf


### PR DESCRIPTION
Features:
  `--enablerepo`:
    completes by disabled repos (`dnf repolist disabled`)
  `--disablerepo`:
    completes by enabled repos (`dnf repolist enabled`)
  `install|update`:
    completes by available pkgs and if local path used (e.g. `./`),
    completes from local files which ends with `.rpm`
  `help`:
    complete only one command. I.e. `help help<TAB><TAB>` will complete
    nothing
  All options/args generates automatically

Used Elad Alfassa elad@fedoraproject.org code for completing
`install`, `remove|erase`, `update`, `info` commands.

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1070902
