### PR TITLE
fix: traceback in history info <name> (RhBug: 1149952)

### DIFF
--- a/dnf/yum/packages.py
+++ b/dnf/yum/packages.py
@@ -87,7 +87,7 @@ def parsePackages(pkgs, usercommands, casematch=0):
                 foundit = 0
                 for item in trylist:
                     if regex.match(item):
-                        matched |= pkgdict[item]
+                        matched.update(pkgdict[item])
                         del pkgdict[item]
                         foundit = 1
 


### PR DESCRIPTION
Set |= need 2 sets, update take any iterable
