### PR TITLE
bash-completion: Fixes for install, update, info

### DIFF
--- a/etc/bash_completion.d/dnf-completion.bash
+++ b/etc/bash_completion.d/dnf-completion.bash
@@ -74,7 +74,7 @@ _dnf()
                 if [ -r '/var/cache/dnf/available.cache' ]; then
                     COMPREPLY=( $( compgen -W '$( grep -E ^$cur /var/cache/dnf/available.cache )' -- "$cur" ) )
                 else
-                    COMPREPLY=( $( compgen -W '$( dnf --cacheonly list $cur* 2>/dev/null | cut -d' ' -f1 )' -- "$cur" ) )
+                    COMPREPLY=( $( compgen -W '$( dnf --cacheonly list "$cur*" 2>/dev/null | cut -d" " -f1 )' -- "$cur" ) )
                 fi
                 [[ $command != "info" ]] && ext='@(rpm)' || ext=''
                 ;;


### PR DESCRIPTION
Fix wrong quoting which caused completion for install, update and info
commands to fail: Don't use ' quotes inside ' quotes and quote $cur\* as
"$cur*" to avoid pathname expansion.

https://bugzilla.redhat.com/show_bug.cgi?id=1151231
