### PR TITLE
bash-completion: fix completing  without dnf-plugins-core (RhBug:1151231)

### DIFF
--- a/etc/bash_completion.d/dnf-completion.bash
+++ b/etc/bash_completion.d/dnf-completion.bash
@@ -74,7 +74,8 @@ _dnf()
                 if [ -r '/var/cache/dnf/available.cache' ]; then
                     COMPREPLY=( $( compgen -W '$( grep -E ^$cur /var/cache/dnf/available.cache )' -- "$cur" ) )
                 else
-                    COMPREPLY=( $( compgen -W '$( dnf --cacheonly list $cur* 2>/dev/null | cut -d' ' -f1 )' -- "$cur" ) )
+                    COMPREPLY=( $( compgen -W "$( dnf --cacheonly list $cur\* 2>/dev/null | \
+                            awk '/Available Packages/{y=1; next} /Cleaning/{y=0} y != 0 {print $1}' )" -- "$cur" ) )
                 fi
                 [[ $command != "info" ]] && ext='@(rpm)' || ext=''
                 ;;


### PR DESCRIPTION
dnf list is printing some info which we should not parse (especially
with debug - `Cleaning` string). We want use only packages from output.
Let's find string `Available Packages` and print all packages before
next info string `Cleaning`. If user will have some custom plugins which
will modify `list` command - completion will be break, but we can
guarantee that with `dnf` and with/without dnf-plugins-core it will work
OK.

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1151231
Signed-off-by: Igor Gnatenko i.gnatenko.brain@gmail.com
