### PR TITLE
Fix wrong cache directory path used to clean up binary cache

### DIFF
--- a/dnf/cli/commands/clean.py
+++ b/dnf/cli/commands/clean.py
@@ -176,7 +176,7 @@ class CleanCommand(commands.Command):
         logger.info(msg)
 
         persistdir = self.base.conf.persistdir
-        cachedir = self.base.conf.persistdir
+        cachedir = self.base.conf.cachedir
         if 'all' in userlist:
             logger.info(_('Cleaning up Everything'))
             pkgcode, pkgresults = _clean_packages(repos)


### PR DESCRIPTION
This PR fixes the wrong cache directory path used to clean up binary cache files.
Seems bug was introduced in 75a4221.
