### PR TITLE
use LANG=C when invoking 'dnf help' and 'sed' with regular expressions

### DIFF
--- a/etc/bash_completion.d/dnf-completion.bash
+++ b/etc/bash_completion.d/dnf-completion.bash
@@ -29,7 +29,7 @@ _dnf_help_command()
 
 _dnf()
 {
-    local commandlist="$( compgen -W '$( dnf help | cut -d" " -s -f1 | sed -e "/^[A-Z]/d" -e "/:/d" )' )"
+    local commandlist="$( compgen -W '$( LANG=C dnf help | cut -d" " -s -f1 | LANG=C sed -e "/^[A-Z]/d" -e "/:/d" )' )"
 
     local cur prev words cword
     _init_completion -s || return


### PR DESCRIPTION
For the completion script to work properly with different languages, you need to specify LANG=C when invoking sed, because depending on current LANG environment variable, regular expressions (ranges like [a-z]) does not work correctly.
It is probably good idea to use LANG=C when invoking "dnf help" too, because some translations could also break the completion.
