### PR TITLE
refactor: avoid to clear the installed cache twice

### DIFF
--- a/dnf/cli/commands/updateinfo.py
+++ b/dnf/cli/commands/updateinfo.py
@@ -54,7 +54,6 @@ class UpdateInfoCommand(commands.Command):
     def __init__(self, cli):
         """Initialize the command."""
         super(UpdateInfoCommand, self).__init__(cli)
-        self._ina2evr_cache = None
         self.clear_installed_cache()
 
     def refresh_installed_cache(self):


### PR DESCRIPTION
The removed line does same thing as the method 'clear_installed_cache' does.