### PR TITLE
bash-completion: handle sqlite errors

### DIFF
--- a/etc/bash_completion.d/dnf-completion.bash
+++ b/etc/bash_completion.d/dnf-completion.bash
@@ -110,8 +110,9 @@ END
                 fi
                 ;;
             remove|erase)
-                if [ -r $cache_file ]; then
-                    COMPREPLY=( $( compgen -W '$( sqlite3 $cache_file "select pkg from installed WHERE pkg LIKE \"$cur%\"" )' ) )
+                [ -r $cache_file ] && installed=$( sqlite3 $cache_file "select pkg from installed WHERE pkg LIKE \"$cur%\"" 2>/dev/null )
+                if [ $? -eq 0 ]; then
+                    COMPREPLY=( $( compgen -W '$( echo $installed )' ) )
                 else
                     COMPREPLY=( $( compgen -W '$( python << END
 import hawkey


### PR DESCRIPTION
Because 'available' table creates when sack is requested we can guarantee
that packages.db will contains 'available' table when file exists.

'installed' table creates when transaction runs, so we can't guarantee if
packages.db exists 'installed' table will also exists.

We will check if table exists we will load it.

Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>