### PR TITLE
define opts and parser in Command.__init__()

### DIFF
--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -159,6 +159,8 @@ class Command(object):
 
     def __init__(self, cli):
         self.cli = cli # :api
+        self.opts = None
+        self.parser = None
 
     @property
     def base(self):


### PR DESCRIPTION
all plugin commands which add commandline options need this to silence pylint warnings
W0201: download: 64,8: Attribute 'parser' defined outside __init__
W0201: download: 76,8: Attribute 'opts' defined outside __init__

otherwise they all need to redefine __init__ with
    def __init__(self, cli):
        super(MyCommand, self).__init__(cli)
        self.opts = None
        self.parser = None