### PR TITLE
util: make user_run_dir() working for suided programs

### DIFF
--- a/dnf/util.py
+++ b/dnf/util.py
@@ -267,7 +267,9 @@ def urlopen(absurl, repo=None, mode='w+b', **kwargs):
 
 def user_run_dir():
     uid = str(os.getuid())
-    return os.path.join(dnf.const.USER_RUNDIR, uid, dnf.const.PROGRAM_NAME)
+    res = os.path.join(dnf.const.USER_RUNDIR, uid, dnf.const.PROGRAM_NAME)
+    if not os.path.exists(res):
+        return os.path.join(dnf.const.TMPDIR, "%s-run-user-%s" % (dnf.const.PROGRAM_NAME, uid));
 
 
 class tmpdir(object):


### PR DESCRIPTION
If a program is run from a suided binary, pam does not create the
/run/user/$UID directory and the program may not have sufficient rights
to create it.

This commit adds a check for existence of the user run directory to
user_run_dir() function and if the directory does not exist, returns
'/var/tmp/dnf-user-run-$UID' directory instead.

Signed-off-by: Jakub Filak <jfilak@redhat.com>