### PR TITLE
add reinstall to bash_completion

### DIFF
--- a/etc/bash_completion.d/dnf-completion.bash
+++ b/etc/bash_completion.d/dnf-completion.bash
@@ -109,7 +109,7 @@ END
                     fi
                 fi
                 ;;
-            remove|erase|downgrade)
+            remove|erase|downgrade|reinstall)
                 if [[ "$cur" == \.* ]] || [[ "$cur" == \/* ]]; then
                     [[ $command != "info" ]] && ext='@(rpm)' || ext=''
                 else


### PR DESCRIPTION
This PR adds reinstall as the list of supported commands to be autocompleted, reinstall should show the same completion list as remove since it can only act on already installed packages.