### PR TITLE
clean: 'dnf clean all' should also clean presto and updateinfo solvx files

### DIFF
--- a/dnf/cli/commands/clean.py
+++ b/dnf/cli/commands/clean.py
@@ -61,6 +61,8 @@ def _clean_binary_cache(repos, cachedir):
         basename = os.path.join(cachedir, repo.id)
         files.append(basename + ".solv")
         files.append(basename + "-filenames.solvx")
+        files.append(basename + "-presto.solvx")
+        files.append(basename + "-updateinfo.solvx")
     files = [f for f in files if os.access(f, os.F_OK)]
 
     return _clean_filelist('dbcache', files)


### PR DESCRIPTION
I observed that when I did "dnf clean all", I was still having some solvx files in cache directory. I looked into source code of clean.py where _clean_binary_cache() function says clean all .solv and .solvx cache files. I see presto and updateinfo is missing to be removed in code.

Hence submitting this request to remove presto and updateinfo solvx files as well.