### PR TITLE
Repo.name has dafault value of repo ID (RhBug:1215560)

### DIFF
--- a/dnf/repo.py
+++ b/dnf/repo.py
@@ -441,6 +441,7 @@ class Repo(dnf.yum.config.RepoConf):
         self._md_pload = MDPayload(dnf.callback.NullDownloadProgress())
         self.basecachedir = cachedir
         self.id = id_ # :api
+        self.name = self.id
         self.key_import = _NullKeyImport()
         self.metadata = None # :api
         self.sync_strategy = self.DEFAULT_SYNC

--- a/doc/api_repos.rst
+++ b/doc/api_repos.rst
@@ -86,7 +86,7 @@ Repository Configuration
 
   .. attribute:: name
 
-    A string with the repo's name.
+    A string with the repo's name. By default it has value of repo's ID.
 
   .. attribute:: pkgdir
 


### PR DESCRIPTION
How do you like this approach? ~~The name was required for `__repr__` method too.~~ This solution  doesn't change API.
/cc @ignatenkobrain