### PR TITLE
Add DemandSheet.transaction_display

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -148,10 +148,11 @@ class BaseCli(dnf.Base):
             return None
         return self.group_persistor.diff()
 
-    def do_transaction(self):
+    def do_transaction(self, display='DEFAULT'):
         """Take care of package downloading, checking, user
         confirmation and actually running the transaction.
 
+        :param display: a `TransactionDisplay` object
         :return: a numeric return code, and optionally a list of
            errors.  A negative return code indicates that errors
            occurred in the pre-transaction checks
@@ -215,7 +216,8 @@ class BaseCli(dnf.Base):
             # Check GPG signatures
             self.gpgsigcheck(downloadpkgs)
 
-        display = output.CliTransactionDisplay()
+        if display is 'DEFAULT':
+            display = output.CliTransactionDisplay()
         super(BaseCli, self).do_transaction(display)
         if trans:
             msg = self.output.post_transaction_output(trans)

--- a/dnf/cli/demand.py
+++ b/dnf/cli/demand.py
@@ -20,6 +20,8 @@
 
 from __future__ import unicode_literals
 
+from . import output
+
 class _BoolDefault(object):
     def __init__(self, default):
         self.default = default
@@ -53,3 +55,5 @@ class DemandSheet(object):
     cacheonly = _BoolDefault(False)
     fresh_metadata = _BoolDefault(True)
     freshest_metadata = _BoolDefault(False)
+
+    transaction_display = output.CliTransactionDisplay()

--- a/dnf/cli/main.py
+++ b/dnf/cli/main.py
@@ -157,7 +157,7 @@ def resolving(cli, base):
 
     # Run the transaction
     try:
-        base.do_transaction()
+        base.do_transaction(display=cli.demands.transaction_display)
     except dnf.cli.CliError as exc:
         logger.error(ucd(exc))
         return 1


### PR DESCRIPTION
This commit adds Base.transaction_display, which should be either None
or an instance of dnf.yum.rpmtrans.TransactionDisplay (or a subclass
thereof).

If Base.do_transaction() is called without a 'display' argument,
it will use self.transaction_display as the default value.

It defaults to None. BaseCli sets it to output.CliTransactionDisplay().

Moving it to an attribute allows Plugins and/or Commands to add their
own TransactionDisplay - for example, fedup or offline-updates could use
this to send status info to plymouth during the upgrade transaction.