### PR TITLE
Fix wrong mention of --duplicates option for dnf repoquery

### DIFF
--- a/doc/cli_vs_yum.rst
+++ b/doc/cli_vs_yum.rst
@@ -357,12 +357,12 @@ Original Yum tool          New DNF command                       Package
 Detailed table for ``package-cleanup`` replacement:
 
 ================================        =============================
-``package-cleanup --dupes``             ``dnf repoquery --duplicates``
+``package-cleanup --dupes``             ``dnf repoquery --duplicated``
 ``package-cleanup --leaves``            ``dnf list autoremove``
 ``package-cleanup --orphans``           ``dnf list extras``
 ``package-cleanup --oldkernels``        ``dnf repoquery --installonly``
 ``package-cleanup --problems``          ``dnf repoquery --unsatisfied``
-``package-cleanup --cleandupes``        ``dnf remove $(dnf repoquery --duplicates --latest-limit -1 -q)``
+``package-cleanup --cleandupes``        ``dnf remove $(dnf repoquery --duplicated --latest-limit -1 -q)``
 ``package-cleanup --oldkernels``        ``dnf remove $(dnf repoquery --installonly --latest-limit -3 -q)``
 ================================        =============================
 


### PR DESCRIPTION
In Fedora 22 the actual option seems to be '--duplicated'. With a D instead of S.