### PR TITLE
dnf-automatic: Do not delete downloaded files in download but not apply mode

### DIFF
--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -160,6 +160,7 @@ def main(args):
             base.download_packages(trans.install_set)
             emitters.notify_downloaded()
             if not conf.commands.apply_updates:
+                base.conf.keepcache = True
                 emitters.commit()
                 return 0
 

--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -128,7 +128,7 @@ def main(args):
 
     try:
         conf = AutomaticConfig(opts.conf_path)
-        with dnf.Base() as base:
+        with dnf.cli.cli.BaseCli() as base:
             cli = dnf.cli.Cli(base)
             cli.read_conf_file(conf.commands.base_config_file,
                                overrides=conf.base_overrides)

--- a/etc/dnf/automatic.conf
+++ b/etc/dnf/automatic.conf
@@ -9,6 +9,8 @@ random_sleep = 300
 download_updates = yes
 
 # Whether updates should be applied when they are available.
+# Note that if this is set to no, downloaded packages will be left in the
+# cache regardless of the keepcache setting.
 apply_updates = no
 
 


### PR DESCRIPTION
With download_updates = yes and apply_updates = no, dnf-automatic deletes the files it just downloaded at end of the run which is hardly useful.