### PR TITLE
notify about skipped packages + give hints

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -1,4 +1,4 @@
-%global hawkey_version 0.5.5
+%global hawkey_version 0.5.9
 %global librepo_version 1.7.16
 %global libcomps_version 0.1.6
 %global rpm_version 4.12.0

--- a/dnf/cli/main.py
+++ b/dnf/cli/main.py
@@ -89,6 +89,11 @@ def main(args):
     except dnf.exceptions.LockError as e:
         logger.critical(e.value)
         return 1
+    except dnf.exceptions.DepsolveError as e:
+        ex_Error(e)
+        logger.info(_("(try to add '--allowerasing' to command line to "
+                      "replace conflicting packages)"))
+        return 1
     except dnf.exceptions.Error as e:
         return ex_Error(e)
     except IOError as e:

--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -928,7 +928,7 @@ class Output(object):
             out[0:0] = self._banner(col_data, (_('Group'), _('Packages'), '', ''))
         return '\n'.join(out)
 
-    def _skipped_upgrades(self):
+    def _skipped_conflicts(self):
         def is_better_version((pkg1, pkg2)):
             if not pkg2 or (pkg1 and pkg1 > pkg2):
                 return False
@@ -941,6 +941,15 @@ class Output(object):
         """Return a string representation of the transaction in an
         easy-to-read format.
         """
+
+        forward_actions = {
+            hawkey.UPGRADE,
+            hawkey.UPGRADE_ALL,
+            hawkey.DISTUPGRADE,
+            hawkey.DISTUPGRADE_ALL,
+            hawkey.DOWNGRADE,
+            hawkey.INSTALL
+        }
 
         if transaction is None:
             return None
@@ -988,11 +997,11 @@ class Output(object):
             pkglist_lines.append((action, lines))
 
         # show skipped packages
-        if not self.conf.best and hawkey.UPGRADE in self.base._goal.actions:
+        if not self.conf.best and forward_actions & self.base._goal.actions:
             lines = []
-            for pkg in self._skipped_upgrades():
+            for pkg in self._skipped_conflicts():
                 a_wid = _add_line(lines, data, a_wid, pkg, [])
-            skip_str = "Skipping upgrades (dependency issues):\n" + \
+            skip_str = "Skipping packages with dependency issues:\n" + \
                 "(add '--best --allowerasing' to command line " \
                 "to force their upgrade)"
             pkglist_lines.append((skip_str, lines))

--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -1001,9 +1001,9 @@ class Output(object):
             lines = []
             for pkg in self._skipped_conflicts():
                 a_wid = _add_line(lines, data, a_wid, pkg, [])
-            skip_str = "Skipping packages with dependency issues:\n" + \
-                "(add '--best --allowerasing' to command line " \
-                "to force their upgrade)"
+            skip_str = _("Skipping packages with dependency issues:\n"
+                         "(add '%s' to command line "
+                         "to force their upgrade)") % "--best --allowerasing"
             pkglist_lines.append((skip_str, lines))
 
         if not data['n']:


### PR DESCRIPTION
This patch should improve user experience during upgrade by showing them
the skipped packages while providing the hint to force it's
installation. The size of the package and the repository comlumn seems
to be irrelevant. It doesn't print the package versions because for packages
having more than one update available the output becomes chaotic. So
only unique package names and architectures are printed.

how the output look like:
```
# dnf update --assumeno
Last metadata expiration check performed 20:00:43 ago on Tue Jun 30 17:04:16 2015.
Dependencies resolved.
================================================
 Package
        Arch   Version      Repository     Size
================================================
Upgrading:
 VirtualBox-4.3
        x86_64 4.3.28_100309_fedora18-1
                            virtualbox     68 M
 bjnplugin
        x86_64 2.100.85.8-1 bluejeans     4.2 M
 google-chrome-stable
        x86_64 43.0.2357.130-1
                            google-chrome  46 M
 rbjnplugin
        x86_64 2.90.616.8-1 bluejeans     4.1 M
 sqlite i686   3.8.3-1.fc19 updates       416 k

Skipping conflicting upgrades:
 rpm-devel.x86_64, rpm-build.x86_64, rpm-python.x86_64, rpm.x86_64, rpm-build-libs.x86_64, rpm-libs.x86_64
(add `--best --allowerasing` to command line to force their upgrade)

Transaction Summary
================================================
Upgrade  5 Packages

Total download size: 123 M
Operation aborted.
```
the update before this patch:
```
# dnf update --assumeno
Last metadata expiration check performed 20:03:39 ago on Tue Jun 30 17:04:16 2015.
Dependencies resolved.
================================================
 Package
        Arch   Version      Repository     Size
================================================
Upgrading:
 VirtualBox-4.3
        x86_64 4.3.28_100309_fedora18-1
                            virtualbox     68 M
 bjnplugin
        x86_64 2.100.85.8-1 bluejeans     4.2 M
 google-chrome-stable
        x86_64 43.0.2357.130-1
                            google-chrome  46 M
 rbjnplugin
        x86_64 2.90.616.8-1 bluejeans     4.1 M
 sqlite i686   3.8.3-1.fc19 updates       416 k

Transaction Summary
================================================
Upgrade  5 Packages

Total download size: 123 M
Operation aborted.
```
check-update output:
```
# dnf check-update
Last metadata expiration check performed 20:05:06 ago on Tue Jun 30 17:04:16 2015.

VirtualBox-4.3.x86_64 4.3.26_98988_fedora18-1
                                      virtualbox
VirtualBox-4.3.x86_64 4.3.28_100309_fedora18-1
                                      virtualbox
bjnplugin.x86_64      2.90.595.5-1    bluejeans 
bjnplugin.x86_64      2.90.616.8-1    bluejeans 
bjnplugin.x86_64      2.90.658.8-1    bluejeans 
bjnplugin.x86_64      2.100.38.8-1    bluejeans 
bjnplugin.x86_64      2.100.41.8-1    bluejeans 
bjnplugin.x86_64      2.100.85.8-1    bluejeans 
google-chrome-stable.x86_64
                      43.0.2357.130-1 google-chrome
rbjnplugin.x86_64     2.90.616.8-1    bluejeans 
rpm.x86_64            4.11.3-1.fc19   updates   
rpm-build.x86_64      4.11.3-1.fc19   updates   
rpm-build-libs.x86_64 4.11.3-1.fc19   updates   
rpm-devel.x86_64      4.11.3-1.fc19   updates   
rpm-libs.x86_64       4.11.3-1.fc19   updates   
rpm-python.x86_64     4.11.3-1.fc19   updates   
sqlite.i686           3.8.3-1.fc19    updates   
```