### PR TITLE
configurable maximum number of parallel downloads (RhBug:1230975)

### DIFF
--- a/dnf/repo.py
+++ b/dnf/repo.py
@@ -163,13 +163,14 @@ class _DetailedLibrepoError(Exception):
 
 
 class _Handle(librepo.Handle):
-    def __init__(self, gpgcheck, max_mirror_tries):
+    def __init__(self, gpgcheck, max_mirror_tries, max_parallel_downloads=None):
         super(_Handle, self).__init__()
         self.gpgcheck = gpgcheck
         self.maxmirrortries = max_mirror_tries
         self.interruptible = True
         self.repotype = librepo.LR_YUMREPO
         self.useragent = dnf.const.USER_AGENT
+        self.maxparalleldownloads = max_parallel_downloads
         self.yumdlist = [
             "primary", "filelists", "prestodelta", "group_gz", "updateinfo"]
 
@@ -581,7 +582,8 @@ class Repo(dnf.yum.config.RepoConf):
         return self._handle_new_remote(self.pkgdir, mirror_setup=False)
 
     def _handle_new_remote(self, destdir, mirror_setup=True):
-        h = _Handle(self.repo_gpgcheck, self.max_mirror_tries)
+        h = _Handle(self.repo_gpgcheck, self.max_mirror_tries,
+                    self.max_parallel_downloads)
         h.varsub = _subst2tuples(self.substitutions)
         h.destdir = destdir
         self._set_ip_resolve(h)

--- a/dnf/yum/config.py
+++ b/dnf/yum/config.py
@@ -778,6 +778,7 @@ class YumConf(BaseConfig):
             mapper={'4': 'ipv4', '6': 'ipv6'})
     throttle = ThrottleOption(0)
     timeout = SecondsOption(120)
+    max_parallel_downloads = IntOption(None, range_min=1)
 
     metadata_expire = SecondsOption(60 * 60 * 48)    # 48 hours
     metadata_timer_sync = SecondsOption(60 * 60 * 3) #  3 hours
@@ -916,6 +917,7 @@ class RepoConf(BaseConfig):
     ip_resolve = Inherit(YumConf.ip_resolve)
     throttle = Inherit(YumConf.throttle)
     timeout = Inherit(YumConf.timeout)
+    max_parallel_downloads = Inherit(YumConf.max_parallel_downloads)
 
     metadata_expire = Inherit(YumConf.metadata_expire)
     cost = IntOption(1000)

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -282,6 +282,11 @@ configuration.
 
     Determines how DNF resolves host names. Set this to '4'/'IPv4' or '6'/'IPv6' to resolve to IPv4 or IPv6 addresses only. By default, DNF resolves to either addresses.
 
+``max_parallel_downloads``
+    integer
+
+    Maximum number of simultaneous package downloads. Defaults to 3.
+
 .. _metadata_expire-label:
 
 ``metadata_expire``


### PR DESCRIPTION
Reported-by: Jargon Scott <jfedora-a@halibutdepot.org>
Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1230975
Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>