### PR TITLE
completion_helper: fix tb if list XXX is not known arg (RhBug:1220040)

### DIFF
--- a/dnf/cli/completion_helper.py
+++ b/dnf/cli/completion_helper.py
@@ -89,6 +89,8 @@ class ListCompletionCommand(dnf.cli.commands.ListCommand):
                 pkgs = self.available(self.base, args[1])
             elif args[0] == "updates":
                 pkgs = self.updates(self.base, args[1])
+            else:
+                return
             for pkg in pkgs:
                 print(str(pkg))
 


### PR DESCRIPTION
```python
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/dnf/cli/completion_helper.py", line 189, in <module>
    main(sys.argv[1:])
  File "/usr/lib/python2.7/site-packages/dnf/cli/completion_helper.py", line 185, in main
    cli.run()
  File "/usr/lib/python2.7/site-packages/dnf/cli/cli.py", line 1077, in run
    return self.command.run(self.base.extcmds)
  File "/usr/lib/python2.7/site-packages/dnf/cli/completion_helper.py", line 92, in run
    for pkg in pkgs:
UnboundLocalError: local variable 'pkgs' referenced before assignment
```
Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1220040
Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>