### PR TITLE
[new feature] use both CliTransactionDisplay and demands.transaction_display

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -10,8 +10,8 @@
 %global py3pluginpath %{python3_sitelib}/dnf-plugins
 
 Name:		dnf
-Version:	1.0.2
-Release:	2%{?snapshot}%{?dist}
+Version:	1.1.0
+Release:	1%{?snapshot}%{?dist}
 Summary:	Package manager forked from Yum, using libsolv as a dependency resolver
 # For a breakdown of the licensing, see PACKAGE-LICENSING
 License:	GPLv2+ and GPLv2 and GPL

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -582,12 +582,13 @@ class Base(object):
         # put back our depcheck callback
         self.ds_callback = dscb
         # setup our rpm ts callback
-        if display is None:
-            cb = dnf.yum.rpmtrans.RPMTransaction(self)
-        else:
-            cb = dnf.yum.rpmtrans.RPMTransaction(self, display=display)
+        displays = []
+        if display is not None:
+            displays.append(display)
+        cb = dnf.yum.rpmtrans.RPMTransaction(self, displays=displays)
         if self.conf.debuglevel < 2:
-            cb.display.output = False
+            for display in cb.displays:
+                display.output = False
 
         logger.info(_('Running transaction'))
         lock = dnf.lock.build_rpmdb_lock(self.conf.persistdir)

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -30,6 +30,7 @@ from dnf.yum import history
 from dnf.yum import misc
 from dnf.yum import rpmsack
 from functools import reduce
+import collections
 import dnf.callback
 import dnf.comps
 import dnf.conf
@@ -528,8 +529,10 @@ class Base(object):
             raise exc
         return got_transaction
 
-    def do_transaction(self, display=None):
+    def do_transaction(self, display=()):
         # :api
+        if not isinstance(display, collections.Sequence):
+            display = [display]
 
         persistor = self.group_persistor
         if persistor:
@@ -582,13 +585,10 @@ class Base(object):
         # put back our depcheck callback
         self.ds_callback = dscb
         # setup our rpm ts callback
-        displays = []
-        if display is not None:
-            displays.append(display)
-        cb = dnf.yum.rpmtrans.RPMTransaction(self, displays=displays)
+        cb = dnf.yum.rpmtrans.RPMTransaction(self, displays=display)
         if self.conf.debuglevel < 2:
-            for display in cb.displays:
-                display.output = False
+            for display_ in cb.displays:
+                display_.output = False
 
         logger.info(_('Running transaction'))
         lock = dnf.lock.build_rpmdb_lock(self.conf.persistdir)

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -28,6 +28,7 @@ from . import output
 from dnf.cli import CliError
 from dnf.i18n import ucd, _
 
+import collections
 import datetime
 import dnf
 import dnf.cli.commands
@@ -146,7 +147,7 @@ class BaseCli(dnf.Base):
             return None
         return self.group_persistor.diff()
 
-    def do_transaction(self, display='DEFAULT'):
+    def do_transaction(self, display=()):
         """Take care of package downloading, checking, user
         confirmation and actually running the transaction.
 
@@ -214,8 +215,9 @@ class BaseCli(dnf.Base):
             # Check GPG signatures
             self.gpgsigcheck(downloadpkgs)
 
-        if display is 'DEFAULT':
-            display = output.CliTransactionDisplay()
+        if not isinstance(display, collections.Sequence):
+            display = [display]
+        display = [output.CliTransactionDisplay()] + list(display)
         super(BaseCli, self).do_transaction(display)
         if trans:
             msg = self.output.post_transaction_output(trans)

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -150,7 +150,7 @@ class BaseCli(dnf.Base):
         """Take care of package downloading, checking, user
         confirmation and actually running the transaction.
 
-        :param display: a `TransactionDisplay` object
+        :param display: `TransactionDisplay` object(s)
         :return: a numeric return code, and optionally a list of
            errors.  A negative return code indicates that errors
            occurred in the pre-transaction checks

--- a/dnf/cli/demand.py
+++ b/dnf/cli/demand.py
@@ -1,7 +1,7 @@
 # demand.py
 # Demand sheet and related classes.
 #
-# Copyright (C) 2014  Red Hat, Inc.
+# Copyright (C) 2014-2015  Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -56,4 +56,4 @@ class DemandSheet(object):
     fresh_metadata = _BoolDefault(True)
     freshest_metadata = _BoolDefault(False)
 
-    transaction_display = output.CliTransactionDisplay()
+    transaction_display = None

--- a/dnf/cli/main.py
+++ b/dnf/cli/main.py
@@ -1,5 +1,5 @@
 # Copyright 2005 Duke University
-# Copyright (C) 2012-2013  Red Hat, Inc.
+# Copyright (C) 2012-2015  Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -161,8 +161,11 @@ def resolving(cli, base):
     base.plugins.run_resolved()
 
     # Run the transaction
+    displays = []
+    if cli.demands.transaction_display is not None:
+        displays.append(cli.demands.transaction_display)
     try:
-        base.do_transaction(display=cli.demands.transaction_display)
+        base.do_transaction(display=displays)
     except dnf.cli.CliError as exc:
         logger.error(ucd(exc))
         return 1

--- a/doc/api_base.rst
+++ b/doc/api_base.rst
@@ -1,5 +1,5 @@
 ..
-  Copyright (C) 2014  Red Hat, Inc.
+  Copyright (C) 2014-2015  Red Hat, Inc.
 
   This copyrighted material is made available to anyone wishing to use,
   modify, copy, or redistribute it subject to the terms and conditions of
@@ -80,7 +80,7 @@
 
   .. method:: do_transaction([display])
 
-    Perform the resolved transaction. Use the optional `display` object to report the progress.
+    Perform the resolved transaction. Use the optional `display` object(s) to report the progress.
 
   .. method:: download_packages(pkglist, progress=None)
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -21,6 +21,14 @@
 
 .. contents::
 
+======================
+Upcoming Release Notes
+======================
+
+API additions in X.X.0:
+
+:meth:`dnf.Base.do_transaction` now accepts multiple displays.
+
 ===================
 1.0.2 Release Notes
 ===================


### PR DESCRIPTION
Tested with this plugin:

```python
import dnf.cli.output

class Disp(dnf.yum.rpmtrans.TransactionDisplay):
    def event(self, package, action, te_current, te_total, ts_current, ts_total):
        if te_current == te_total:
            print('event')
    def scriptout(self, msgs):
        print('scriptout')
    def verify_tsi_package(self, pkg, count, total):
        print('verify')
    def errorlog(self, msg):
        print('error')
    def filelog(self, package, action):
        print('filelog')

class Command(dnf.cli.Command):
    aliases = ['foo']
    def configure(self, args):
        self.cli.demands.available_repos = True
        self.cli.demands.sack_activation = True
        self.cli.demands.resolving = True
        self.cli.demands.root_user = True
        self.cli.demands.transaction_display = Disp()
    def run(self, args):
        for arg in args:
            self.base.install(arg)

class Plugin(dnf.Plugin):
    name = 'foo'
    def __init__(self, base, cli):
        super(Plugin, self).__init__(base, cli)
        if cli:
            cli.register_command(Command)
```

I'd also consider changing `demands.transaction_display` to `demands.transaction_displays`.