### PR TITLE
conf: Add 'arch' option to override arch detected from running system.

### DIFF
--- a/dnf/conf/substitutions.py
+++ b/dnf/conf/substitutions.py
@@ -26,9 +26,10 @@ import os
 
 class Substitutions(dict):
 
-    def __init__(self):
+    def __init__(self, arch=None):
         super(Substitutions, self).__init__()
-        arch = hawkey.detect_arch()
+        if arch is None:
+            arch = hawkey.detect_arch()
         self['arch'] = arch
         self['basearch'] = dnf.arch.basearch(arch)
         self._update_from_env()

--- a/dnf/sack.py
+++ b/dnf/sack.py
@@ -83,6 +83,7 @@ def build_sack(base):
     # create the dir ourselves so we have the permissions under control:
     dnf.util.ensure_dir(cachedir)
     return Sack(pkgcls=dnf.package.Package, pkginitval=base,
+                arch=base.conf.substitutions["arch"],
                 cachedir=cachedir, rootdir=base.conf.installroot,
                 logfile=os.path.join(base.conf.logdir, dnf.const.LOG_HAWKEY))
 

--- a/dnf/yum/config.py
+++ b/dnf/yum/config.py
@@ -703,9 +703,9 @@ class YumConf(BaseConfig):
     pluginconfpath = ListOption([dnf.const.PLUGINCONFPATH])  # :api
     persistdir = Option(dnf.const.PERSISTDIR) # :api
 
-    def __init__(self):
+    def __init__(self, arch=None):
         super(YumConf, self).__init__()
-        self.substitutions = dnf.conf.substitutions.Substitutions()
+        self.substitutions = dnf.conf.substitutions.Substitutions(arch)
 
     def _var_replace(self, option):
         path = getattr(self, option)

--- a/doc/api_conf.rst
+++ b/doc/api_conf.rst
@@ -23,6 +23,11 @@ Configurable settings of the :class:`dnf.Base` object are stored into a :class:`
 
 .. class:: dnf.conf.Conf
 
+  .. method:: __init__(arch=None)
+
+    Arch passed to :attr:`dnf.conf.Conf.substitutions` and :attr:`dnf.Base.sack`.
+    If not specified, arch is detected from running system.
+
   .. attribute:: assumeyes
 
     Boolean option, if set to ``True`` on any user input asking for confirmation


### PR DESCRIPTION
Provided arch is passed to dnf.conf.Conf.substitutions and dnf.Base.sack (in build_sack() function).