### PR TITLE
dnf.arch: Restore functionality that was in yum's rpmUtils.arch.

### DIFF
--- a/dnf/arch.py
+++ b/dnf/arch.py
@@ -1,7 +1,7 @@
 # arch.py
 # Manipulating the machine architecture string.
 #
-# Copyright (C) 2014  Red Hat, Inc.
+# Copyright (C) 2014-2015  Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -21,29 +21,437 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-def _invert(dct):
-    return {v: k for k in dct for v in dct[k]}
 
-_BASEARCH_MAP = _invert({
-    'aarch64' : ('aarch64',),
-    'alpha'   : ('alpha', 'alphaev4', 'alphaev45', 'alphaev5', 'alphaev56',
-                 'alphaev6', 'alphaev67', 'alphaev68', 'alphaev7', 'alphapca56'),
-    'arm'     : ('armv5tejl', 'armv5tel', 'armv6l', 'armv7l'),
-    'armhfp'  : ('armv6hl', 'armv7hl', 'armv7hnl'),
-    'i386'    : ('i386', 'athlon', 'geode', 'i386', 'i486', 'i586', 'i686'),
-    'ia64'    : ('ia64',),
-    'noarch'  : ('noarch',),
-    'ppc'     : ('ppc',),
-    'ppc64'   : ('ppc64', 'ppc64iseries', 'ppc64p7', 'ppc64pseries'),
-    'ppc64le' : ('ppc64le',),
-    's390'    : ('s390',),
-    's390x'   : ('s390x',),
-    'sh3'     : ('sh3',),
-    'sh4'     : ('sh4', 'sh4a'),
-    'sparc'   : ('sparc', 'sparc64', 'sparc64v', 'sparcv8', 'sparcv9',
-                 'sparcv9v'),
-    'x86_64'  : ('x86_64', 'amd64', 'ia32e'),
-})
+"""
+ARCHES
+======
+
+Notes
+-----
+ * more significant architectures must go first
+   for example: i686 -> i586 -> i486 -> i386
+ * group arches by basearch for better readability
+
+Format
+------
+{
+    "arch": architecture name
+    "basearch": base architecture, yum's $basearch
+    "multilib_arch": multilib architecture name or None
+    "parent": [optional] override ARCHES ordering by direct specification of parent arch
+}
+
+Differences to rpmUtils.arch
+----------------------------
+ * sparc64v and sparc64 basearch changed from 'sparc' to 'sparc64'
+"""
+
+
+ARCHES = [
+    # basearch: src
+    {
+        "arch": "src",
+        "basearch": "src",
+        "multilib_arch": None,
+    },
+    {
+        "arch": "nosrc",
+        "basearch": "src",
+        "multilib_arch": None,
+    },
+
+    # basearch: noarch
+    {
+        "arch": "noarch",
+        "basearch": "noarch",
+        "multilib_arch": None,
+    },
+
+    # basearch: aarch64
+    {
+        "arch": "aarch64",
+        "basearch": "aarch64",
+        "multilib_arch": None,
+    },
+
+    # basearch: alpha
+    {
+        "arch": "alphaev7",
+        "basearch": "alpha",
+        "multilib_arch": None,
+    },
+    {
+        "arch": "alphaev68",
+        "basearch": "alpha",
+        "multilib_arch": None,
+    },
+    {
+        "arch": "alphaev67",
+        "basearch": "alpha",
+        "multilib_arch": None,
+    },
+    {
+        "arch": "alphaev6",
+        "basearch": "alpha",
+        "multilib_arch": None,
+    },
+    {
+        "arch": "alphapca56",
+        "basearch": "alpha",
+        "multilib_arch": None,
+    },
+    {
+        "arch": "alphaev56",
+        "basearch": "alpha",
+        "multilib_arch": None,
+    },
+    {
+        "arch": "alphaev5",
+        "basearch": "alpha",
+        "multilib_arch": None,
+    },
+    {
+        "arch": "alphaev45",
+        "basearch": "alpha",
+        "multilib_arch": None,
+    },
+    {
+        "arch": "alphaev4",
+        "basearch": "alpha",
+        "multilib_arch": None,
+    },
+    {
+        "arch": "alpha",
+        "basearch": "alpha",
+        "multilib_arch": None,
+    },
+
+    # basearch: arm
+    {
+        "arch": "armv7l",
+        "basearch": "arm",
+        "multilib_arch": None,
+    },
+    {
+        "arch": "armv6l",
+        "basearch": "arm",
+        "multilib_arch": None,
+    },
+    {
+        "arch": "armv5tejl",
+        "basearch": "arm",
+        "multilib_arch": None,
+    },
+    {
+        "arch": "armv5tel",
+        "basearch": "arm",
+        "multilib_arch": None,
+    },
+
+    # basearch: arm64
+    {
+        "arch": "arm64",
+        "basearch": "arm64",
+        "multilib_arch": None,
+    },
+
+    # basearch: armhfp
+    {
+        "arch": "armv7hnl",
+        "basearch": "armhfp",
+        "multilib_arch": None,
+    },
+    {
+        "arch": "armv7hl",
+        "basearch": "armhfp",
+        "multilib_arch": None,
+    },
+    {
+        "arch": "armv6hl",
+        "basearch": "armhfp",
+        "multilib_arch": None,
+    },
+
+    # basearch: i386
+    {
+        "arch": "athlon",
+        "basearch": "i386",
+        "multilib_arch": None,
+        "parent": "i686",  # athlon is not entirely compatible with geode
+    },
+    {
+        "arch": "geode",
+        "basearch": "i386",
+        "multilib_arch": None,
+    },
+    {
+        "arch": "i686",
+        "basearch": "i386",
+        "multilib_arch": None,
+    },
+    {
+        "arch": "i586",
+        "basearch": "i386",
+        "multilib_arch": None,
+    },
+    {
+        "arch": "i486",
+        "basearch": "i386",
+        "multilib_arch": None,
+    },
+    {
+        "arch": "i386",
+        "basearch": "i386",
+        "multilib_arch": None,
+    },
+
+    # basearch: ia64
+    {
+        "arch": "ia64",
+        "basearch": "ia64",
+        "multilib_arch": None,
+    },
+
+    # basearch: ppc
+    {
+        "arch": "ppc",
+        "basearch": "ppc",
+        "multilib_arch": None,
+    },
+
+    # basearch: ppc64
+    {
+        "arch": "ppc64p7",
+        "basearch": "ppc64",
+        "multilib_arch": "ppc",
+        "parent": "ppc64",  # ppc64p7 is not entirely compatible with ppc64pseries and ppc64iseries
+    },
+    {
+        "arch": "ppc64pseries",
+        "basearch": "ppc64",
+        "multilib_arch": "ppc",
+        "parent": "ppc64",  # ppc64pseries is not entirely compatible with ppc64iseries
+    },
+    {
+        "arch": "ppc64iseries",
+        "basearch": "ppc64",
+        "multilib_arch": "ppc",
+    },
+    {
+        "arch": "ppc64",
+        "basearch": "ppc64",
+        "multilib_arch": "ppc",
+    },
+
+    # basearch: ppc64le
+    {
+        "arch": "ppc64le",
+        "basearch": "ppc64le",
+        "multilib_arch": None,
+    },
+
+    # basearch: s390
+    {
+        "arch": "s390",
+        "basearch": "s390",
+        "multilib_arch": None,
+    },
+
+    # basearch: s390x
+    {
+        "arch": "s390x",
+        "basearch": "s390x",
+        "multilib_arch": "s390",
+    },
+
+    # basearch: sh3
+    {
+        "arch": "sh3",
+        "basearch": "sh3",
+        "multilib_arch": None,
+    },
+
+    # basearch: sh4
+    {
+        "arch": "sh4a",
+        "basearch": "sh4",
+        "multilib_arch": None,
+    },
+    {
+        "arch": "sh4",
+        "basearch": "sh4",
+        "multilib_arch": None,
+    },
+
+    # basearch: sparc
+    {
+        "arch": "sparc64v",
+        "basearch": "sparc64",
+        "multilib_arch": "sparcv9v",
+    },
+    {
+        "arch": "sparc64",
+        "basearch": "sparc64",
+        "multilib_arch": "sparcv9",
+    },
+    {
+        "arch": "sparcv9v",
+        "basearch": "sparc",
+        "multilib_arch": None,
+    },
+    {
+        "arch": "sparcv9",
+        "basearch": "sparc",
+        "multilib_arch": None,
+    },
+    {
+        "arch": "sparcv8",
+        "basearch": "sparc",
+        "multilib_arch": None,
+    },
+    {
+        "arch": "sparc",
+        "basearch": "sparc",
+        "multilib_arch": None,
+    },
+
+    # basearch: x86_64
+    {
+        "arch": "amd64",
+        "basearch": "x86_64",
+        "multilib_arch": "athlon",
+        "parent": "x86_64",  # amd64 is not entirely compatible with ia32e
+    },
+    {
+        "arch": "ia32e",
+        "basearch": "x86_64",
+        "multilib_arch": "athlon",
+    },
+    {
+        "arch": "x86_64",
+        "basearch": "x86_64",
+        "multilib_arch": "athlon",
+    },
+]
+
+
+def _find_arch(arch):
+    for i in ARCHES:
+        if i["arch"] == arch:
+            return i
+    raise ValueError("Unknown arch: %s" % arch)
+
+
+def _find_basearch(arch):
+    for i in ARCHES:
+        if i["basearch"] == arch:
+            return i
+    raise ValueError("Unknown basearch: %s" % arch)
+
+
+def is_valid_arch(arch):
+    try:
+        _find_arch(arch)
+    except ValueError:
+        return False
+    return True
+
+
+def is_valid_basearch(arch):
+    try:
+        _find_basearch(arch)
+    except ValueError:
+        return False
+    return True
+
+
+def _find_arches(arch, just_compatible=True):
+    if arch is None:
+        return []
+    arch_data = _find_arch(arch)
+    result = []
+    found = False
+    for i in ARCHES:
+        if i["basearch"] != arch_data["basearch"]:
+            continue
+        if just_compatible:
+            if i["arch"] == arch:
+                found = True
+            if found:
+                result.append(i)
+                parent_arch = i.get("parent", None)
+                if parent_arch:
+                    return result + _find_arches(parent_arch, just_compatible)
+        else:
+            result.append(i)
+    return result
+
+
+class Arch(object):
+
+    def __init__(self, arch, basearch=False, just_compatible=True):
+        if basearch:
+            arch = _find_basearch(arch)["arch"]
+            just_compatible = False
+
+        self.arch = arch
+        self.just_compatible = just_compatible
+
+        arch_data = _find_arch(self.arch)
+        self.basearch = arch_data["basearch"]
+        self.multilib_arch = arch_data["multilib_arch"]
+
+        self.native_arches = [i["arch"] for i in _find_arches(self.arch, self.just_compatible)]
+        self.multilib_arches = [i["arch"] for i in _find_arches(self.multilib_arch, self.just_compatible)]
+        self.noarch_arches = [i["arch"] for i in _find_arches("noarch", just_compatible=False)]
+        self.source_arches = [i["arch"] for i in _find_arches("src", just_compatible=False)]
+
+        if self.is_noarch:
+            self.arches = self.noarch_arches[:]
+        elif self.is_source:
+            self.arches = self.source_arches[:]
+        else:
+            self.arches = self.native_arches + self.multilib_arches + self.noarch_arches
+
+    @property
+    def is_multilib(self):
+        return bool(self.multilib_arch)
+
+    @property
+    def is_noarch(self):
+        return bool(self.basearch == "noarch")
+
+    @property
+    def is_source(self):
+        return bool(self.basearch == "src")
+
+    def __str__(self):
+        return self.arch
+
+    def __lt__(self, other):
+        if self.is_multilib:
+            # multilib arch has complete arch list
+            a = Arch(self.basearch, basearch=True, just_compatible=False)
+        else:
+            a = Arch(other.basearch, basearch=True, just_compatible=False)
+
+        if self.arch not in a.arches or other.arch not in a.arches:
+            raise ValueError("Cannot compare incompatible arches: %s, %s" % (self.arch, other.arch))
+
+        return a.arches.index(self.arch) - a.arches.index(other.arch)
+
+    def __gt__(self, other):
+        return other < self
+
+    def __eq__(self, other):
+        return self.arch == other.arch
+
+
+# compatibility with previous DNF implementation
+
+
+_BASEARCH_MAP = dict([(i["arch"], i["basearch"]) for i in ARCHES if i["basearch"] != "src"])
+
 
 def basearch(arch):
-    return _BASEARCH_MAP[arch]
+    return Arch(arch).basearch

--- a/tests/test_arch.py
+++ b/tests/test_arch.py
@@ -22,7 +22,7 @@ import dnf.arch
 import tests.support
 
 
-class ArchTest(tests.support.TestCase):
+class FunctionsTest(tests.support.TestCase):
 
     def test_basearch(self):
         fn = dnf.arch.basearch
@@ -31,5 +31,206 @@ class ArchTest(tests.support.TestCase):
         self.assertEqual(fn('i686'), 'i386')
         self.assertEqual(fn('noarch'), 'noarch')
         self.assertEqual(fn('ppc64iseries'), 'ppc64')
-        self.assertEqual(fn('sparc64v'), 'sparc')
+        self.assertEqual(fn('sparc64v'), 'sparc64')
         self.assertEqual(fn('x86_64'), 'x86_64')
+
+    def test_is_valid_arch(self):
+        self.assertTrue(dnf.arch.is_valid_arch("i386"))
+        self.assertTrue(dnf.arch.is_valid_arch("i686"))
+        self.assertTrue(dnf.arch.is_valid_arch("x86_64"))
+        self.assertFalse(dnf.arch.is_valid_arch("armhfp"))
+        self.assertFalse(dnf.arch.is_valid_arch("foo"))
+
+    def test_is_valid_basearch(self):
+        self.assertTrue(dnf.arch.is_valid_basearch("i386"))
+        self.assertFalse(dnf.arch.is_valid_basearch("i686"))
+        self.assertTrue(dnf.arch.is_valid_basearch("x86_64"))
+        self.assertTrue(dnf.arch.is_valid_basearch("armhfp"))
+        self.assertFalse(dnf.arch.is_valid_basearch("foo"))
+
+
+class ArchTest(tests.support.TestCase):
+
+    def test_src(self):
+        a = dnf.arch.Arch("src")
+        self.assertEqual(a.arches, ["src", "nosrc"])
+        self.assertEqual(a.native_arches, ["src", "nosrc"])
+        self.assertEqual(a.multilib_arches, [])
+        self.assertEqual(a.noarch_arches, ["noarch"])
+        self.assertEqual(a.source_arches, ["src", "nosrc"])
+        self.assertEqual(a.is_multilib, False)
+        self.assertEqual(a.is_noarch, False)
+        self.assertEqual(a.is_source, True)
+
+    def test_noarch(self):
+        a = dnf.arch.Arch("noarch")
+        self.assertEqual(a.arches, ["noarch"])
+        self.assertEqual(a.native_arches, ["noarch"])
+        self.assertEqual(a.multilib_arches, [])
+        self.assertEqual(a.noarch_arches, ["noarch"])
+        self.assertEqual(a.source_arches, ["src", "nosrc"])
+        self.assertEqual(a.is_multilib, False)
+        self.assertEqual(a.is_noarch, True)
+        self.assertEqual(a.is_source, False)
+
+    def test_i386(self):
+        a = dnf.arch.Arch("i386")
+        self.assertEqual(a.arches, ["i386", "noarch"])
+        self.assertEqual(a.native_arches, ["i386"])
+        self.assertEqual(a.multilib_arches, [])
+        self.assertEqual(a.noarch_arches, ["noarch"])
+        self.assertEqual(a.source_arches, ["src", "nosrc"])
+        self.assertEqual(a.is_multilib, False)
+        self.assertEqual(a.is_noarch, False)
+        self.assertEqual(a.is_source, False)
+
+    def test_i686(self):
+        a = dnf.arch.Arch("i686")
+        self.assertEqual(a.arches, ["i686", "i586", "i486", "i386", "noarch"])
+        self.assertEqual(a.native_arches, ["i686", "i586", "i486", "i386"])
+        self.assertEqual(a.multilib_arches, [])
+        self.assertEqual(a.noarch_arches, ["noarch"])
+        self.assertEqual(a.source_arches, ["src", "nosrc"])
+        self.assertEqual(a.is_multilib, False)
+        self.assertEqual(a.is_noarch, False)
+        self.assertEqual(a.is_source, False)
+
+    def test_i686_all(self):
+        a = dnf.arch.Arch("i686", just_compatible=False)
+        self.assertEqual(a.arches, ["athlon", "geode", "i686", "i586", "i486", "i386", "noarch"])
+        self.assertEqual(a.native_arches, ["athlon", "geode", "i686", "i586", "i486", "i386"])
+        self.assertEqual(a.multilib_arches, [])
+        self.assertEqual(a.noarch_arches, ["noarch"])
+        self.assertEqual(a.source_arches, ["src", "nosrc"])
+        self.assertEqual(a.is_multilib, False)
+        self.assertEqual(a.is_noarch, False)
+        self.assertEqual(a.is_source, False)
+
+    def test_x86_64(self):
+        a = dnf.arch.Arch("x86_64")
+        self.assertEqual(a.arches, ["x86_64", "athlon", "i686", "i586", "i486", "i386", "noarch"])
+        self.assertEqual(a.native_arches, ["x86_64"])
+        self.assertEqual(a.multilib_arches, ["athlon", "i686", "i586", "i486", "i386"])
+        self.assertEqual(a.noarch_arches, ["noarch"])
+        self.assertEqual(a.source_arches, ["src", "nosrc"])
+        self.assertEqual(a.is_multilib, True)
+        self.assertEqual(a.is_noarch, False)
+        self.assertEqual(a.is_source, False)
+
+    def test_x86_64_all(self):
+        a = dnf.arch.Arch("x86_64", just_compatible=False)
+        self.assertEqual(a.arches, ["amd64", "ia32e", "x86_64", "athlon", "geode", "i686", "i586", "i486", "i386", "noarch"])
+        self.assertEqual(a.native_arches, ["amd64", "ia32e", "x86_64"])
+        self.assertEqual(a.multilib_arches, ["athlon", "geode", "i686", "i586", "i486", "i386"])
+        self.assertEqual(a.noarch_arches, ["noarch"])
+        self.assertEqual(a.source_arches, ["src", "nosrc"])
+        self.assertEqual(a.is_multilib, True)
+        self.assertEqual(a.is_noarch, False)
+        self.assertEqual(a.is_source, False)
+
+    def test_armhfp(self):
+        a = dnf.arch.Arch("armhfp", basearch=True)
+        self.assertEqual(a.arches, ["armv7hnl", "armv7hl", "armv6hl", "noarch"])
+        self.assertEqual(a.native_arches, ["armv7hnl", "armv7hl", "armv6hl"])
+        self.assertEqual(a.multilib_arches, [])
+        self.assertEqual(a.noarch_arches, ["noarch"])
+        self.assertEqual(a.source_arches, ["src", "nosrc"])
+        self.assertEqual(a.is_multilib, False)
+        self.assertEqual(a.is_noarch, False)
+        self.assertEqual(a.is_source, False)
+
+    def test_sparc(self):
+        a = dnf.arch.Arch("sparc")
+        self.assertEqual(a.arches, ["sparc", "noarch"])
+        self.assertEqual(a.native_arches, ["sparc"])
+        self.assertEqual(a.multilib_arches, [])
+        self.assertEqual(a.noarch_arches, ["noarch"])
+        self.assertEqual(a.source_arches, ["src", "nosrc"])
+        self.assertEqual(a.is_multilib, False)
+        self.assertEqual(a.is_noarch, False)
+        self.assertEqual(a.is_source, False)
+
+    def test_sparcv8(self):
+        a = dnf.arch.Arch("sparcv8")
+        self.assertEqual(a.arches, ["sparcv8", "sparc", "noarch"])
+        self.assertEqual(a.native_arches, ["sparcv8", "sparc"])
+        self.assertEqual(a.multilib_arches, [])
+        self.assertEqual(a.noarch_arches, ["noarch"])
+        self.assertEqual(a.source_arches, ["src", "nosrc"])
+        self.assertEqual(a.is_multilib, False)
+        self.assertEqual(a.is_noarch, False)
+        self.assertEqual(a.is_source, False)
+
+    def test_sparcv9(self):
+        a = dnf.arch.Arch("sparcv9")
+        self.assertEqual(a.arches, ["sparcv9", "sparcv8", "sparc", "noarch"])
+        self.assertEqual(a.native_arches, ["sparcv9", "sparcv8", "sparc"])
+        self.assertEqual(a.multilib_arches, [])
+        self.assertEqual(a.noarch_arches, ["noarch"])
+        self.assertEqual(a.source_arches, ["src", "nosrc"])
+        self.assertEqual(a.is_multilib, False)
+        self.assertEqual(a.is_noarch, False)
+        self.assertEqual(a.is_source, False)
+
+    def test_sparcv9v(self):
+        a = dnf.arch.Arch("sparcv9v")
+        self.assertEqual(a.arches, ["sparcv9v", "sparcv9", "sparcv8", "sparc", "noarch"])
+        self.assertEqual(a.native_arches, ["sparcv9v", "sparcv9", "sparcv8", "sparc"])
+        self.assertEqual(a.multilib_arches, [])
+        self.assertEqual(a.noarch_arches, ["noarch"])
+        self.assertEqual(a.source_arches, ["src", "nosrc"])
+        self.assertEqual(a.is_multilib, False)
+        self.assertEqual(a.is_noarch, False)
+        self.assertEqual(a.is_source, False)
+
+    def test_sparc64(self):
+        a = dnf.arch.Arch("sparc64")
+        self.assertEqual(a.arches, ["sparc64", "sparcv9", "sparcv8", "sparc", "noarch"])
+        self.assertEqual(a.native_arches, ["sparc64"])
+        self.assertEqual(a.multilib_arches, ["sparcv9", "sparcv8", "sparc"])
+        self.assertEqual(a.noarch_arches, ["noarch"])
+        self.assertEqual(a.source_arches, ["src", "nosrc"])
+        self.assertEqual(a.is_multilib, True)
+        self.assertEqual(a.is_noarch, False)
+        self.assertEqual(a.is_source, False)
+
+    def test_sparc64v(self):
+        a = dnf.arch.Arch("sparc64v")
+        self.assertEqual(a.arches, ["sparc64v", "sparc64", "sparcv9v", "sparcv9", "sparcv8", "sparc", "noarch"])
+        self.assertEqual(a.native_arches, ["sparc64v", "sparc64"])
+        self.assertEqual(a.multilib_arches, ["sparcv9v", "sparcv9", "sparcv8", "sparc"])
+        self.assertEqual(a.noarch_arches, ["noarch"])
+        self.assertEqual(a.source_arches, ["src", "nosrc"])
+        self.assertEqual(a.is_multilib, True)
+        self.assertEqual(a.is_noarch, False)
+        self.assertEqual(a.is_source, False)
+
+    def test_cmp(self):
+        a_i386 = dnf.arch.Arch("i386")
+        a_i686 = dnf.arch.Arch("i686")
+        a_x86_64 = dnf.arch.Arch("x86_64")
+        a_ppc64 = dnf.arch.Arch("ppc64")
+
+        self.assertTrue(a_i386 == a_i386)
+
+        self.assertFalse(a_i386 > a_i386)
+        self.assertFalse(a_i386 < a_i386)
+
+        self.assertTrue(a_i386 >= a_i386)
+        self.assertTrue(a_i386 <= a_i386)
+
+        self.assertTrue(a_i386 < a_i686)
+        self.assertTrue(a_i686 > a_i386)
+
+        self.assertTrue(a_i386 <= a_i686)
+        self.assertTrue(a_i686 >= a_i386)
+
+        self.assertTrue(a_i386 < a_x86_64)
+        self.assertTrue(a_x86_64 > a_i386)
+
+        self.assertTrue(a_i386 <= a_x86_64)
+        self.assertTrue(a_x86_64 >= a_i386)
+
+        self.assertTrue(a_x86_64 != a_ppc64)
+        self.assertRaises(ValueError, a_x86_64.__lt__, a_ppc64)
+        self.assertRaises(ValueError, a_x86_64.__gt__, a_ppc64)


### PR DESCRIPTION
Other projects such as pungi or lorax don't have to implement arch module any more.