### PR TITLE
repodict: Preserve repo ordering by inheriting from OrderedDict.

### DIFF
--- a/dnf/repodict.py
+++ b/dnf/repodict.py
@@ -21,10 +21,11 @@
 from __future__ import unicode_literals
 from dnf.exceptions import ConfigError
 import dnf.util
+import collections
 import fnmatch
 
 
-class RepoDict(dict):
+class RepoDict(collections.OrderedDict):
     # :api
     def add(self, repo):
         # :api


### PR DESCRIPTION
Hawkey queries do not support repo priority and return first
occurence of a package. OrderedDict preserves repo ordering and
therefore is's possible to emulate repo priority by adding repos
in a particular order.