### PR TITLE
[new feature] add dnf.callback.TransactionProgress

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -10,8 +10,8 @@
 %global py3pluginpath %{python3_sitelib}/dnf-plugins
 
 Name:		dnf
-Version:	1.0.2
-Release:	2%{?snapshot}%{?dist}
+Version:	1.1.0
+Release:	1%{?snapshot}%{?dist}
 Summary:	Package manager forked from Yum, using libsolv as a dependency resolver
 # For a breakdown of the licensing, see PACKAGE-LICENSING
 License:	GPLv2+ and GPLv2 and GPL

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -582,12 +582,13 @@ class Base(object):
         # put back our depcheck callback
         self.ds_callback = dscb
         # setup our rpm ts callback
-        if display is None:
-            cb = dnf.yum.rpmtrans.RPMTransaction(self)
-        else:
-            cb = dnf.yum.rpmtrans.RPMTransaction(self, display=display)
+        displays = []
+        if display is not None:
+            displays.append(display)
+        cb = dnf.yum.rpmtrans.RPMTransaction(self, displays=displays)
         if self.conf.debuglevel < 2:
-            cb.display.output = False
+            for display in cb.displays:
+                display.output = False
 
         logger.info(_('Running transaction'))
         lock = dnf.lock.build_rpmdb_lock(self.conf.persistdir)

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -30,6 +30,7 @@ from dnf.yum import history
 from dnf.yum import misc
 from dnf.yum import rpmsack
 from functools import reduce
+import collections
 import dnf.callback
 import dnf.comps
 import dnf.conf
@@ -528,8 +529,10 @@ class Base(object):
             raise exc
         return got_transaction
 
-    def do_transaction(self, display=None):
+    def do_transaction(self, display=()):
         # :api
+        if not isinstance(display, collections.Sequence):
+            display = [display]
 
         persistor = self.group_persistor
         if persistor:
@@ -582,13 +585,10 @@ class Base(object):
         # put back our depcheck callback
         self.ds_callback = dscb
         # setup our rpm ts callback
-        displays = []
-        if display is not None:
-            displays.append(display)
-        cb = dnf.yum.rpmtrans.RPMTransaction(self, displays=displays)
+        cb = dnf.yum.rpmtrans.RPMTransaction(self, displays=display)
         if self.conf.debuglevel < 2:
-            for display in cb.displays:
-                display.output = False
+            for display_ in cb.displays:
+                display_.output = False
 
         logger.info(_('Running transaction'))
         lock = dnf.lock.build_rpmdb_lock(self.conf.persistdir)

--- a/dnf/callback.py
+++ b/dnf/callback.py
@@ -102,4 +102,16 @@ class Depsolve(object):
 
 # :deprecated in 1.1.0, eligible for dropping in 2.0
 # de facto API - never documented but used by Anaconda thanks to us
-LoggingTransactionDisplay = dnf.yum.rpmtrans.LoggingTransactionDisplay
+class LoggingTransactionDisplay(dnf.yum.rpmtrans.LoggingTransactionDisplay):
+
+    def event(self, package, action, te_current, te_total, ts_current, ts_total):
+        # Compatibility: Originally, "progress" was "event". Let's define it in
+        # case somebody extends it.
+        pass
+
+    def progress(self, package, action, ti_done, ti_total, ts_done, ts_total):
+        super(LoggingTransactionDisplay, self).progress(
+            package, action, ti_done, ti_total, ts_done, ts_total)
+        # Compatibility: Originally, "progress" was "event". Let's call it in
+        # case somebody overrides it.
+        self.event(package, action, ti_done, ti_total, ts_done, ts_total)

--- a/dnf/callback.py
+++ b/dnf/callback.py
@@ -104,6 +104,17 @@ class Depsolve(object):
 # de facto API - never documented but used by Anaconda thanks to us
 class LoggingTransactionDisplay(dnf.yum.rpmtrans.LoggingTransactionDisplay):
 
+    def error(self, message):
+        super(LoggingTransactionDisplay, self).error(message)
+        # Compatibility: Originally, "error" was "errorlog". Let's call it in
+        # case somebody overrides it.
+        self.errorlog(message)
+
+    def errorlog(self, msg):
+        # Compatibility: Originally, "error" was "errorlog". Let's define it in
+        # case somebody extends it.
+        pass
+
     def event(self, package, action, te_current, te_total, ts_current, ts_total):
         # Compatibility: Originally, "progress" was "event". Let's define it in
         # case somebody extends it.

--- a/dnf/callback.py
+++ b/dnf/callback.py
@@ -21,11 +21,22 @@
 from __future__ import unicode_literals
 import dnf.yum.rpmtrans
 
+PKG_CLEANUP = dnf.yum.rpmtrans.TransactionDisplay.PKG_CLEANUP  # :api
+PKG_DOWNGRADE = dnf.yum.rpmtrans.TransactionDisplay.PKG_DOWNGRADE  # :api
+PKG_INSTALL = dnf.yum.rpmtrans.TransactionDisplay.PKG_INSTALL  # :api
+PKG_OBSOLETE = dnf.yum.rpmtrans.TransactionDisplay.PKG_OBSOLETE  # :api
+PKG_REINSTALL = dnf.yum.rpmtrans.TransactionDisplay.PKG_REINSTALL  # :api
+PKG_REMOVE = dnf.yum.rpmtrans.TransactionDisplay.PKG_ERASE  # :api
+PKG_UPGRADE = dnf.yum.rpmtrans.TransactionDisplay.PKG_UPGRADE  # :api
+PKG_VERIFY = dnf.yum.rpmtrans.TransactionDisplay.PKG_VERIFY  # :api
+
 STATUS_OK = None # :api
 STATUS_FAILED = 1 # :api
 STATUS_ALREADY_EXISTS = 2 # :api
 STATUS_MIRROR = 3  # :api
 STATUS_DRPM = 4    # :api
+
+TRANS_POST = dnf.yum.rpmtrans.TransactionDisplay.TRANS_POST  # :api
 
 
 class KeyImport(object):
@@ -126,3 +137,6 @@ class LoggingTransactionDisplay(dnf.yum.rpmtrans.LoggingTransactionDisplay):
         # Compatibility: Originally, "progress" was "event". Let's call it in
         # case somebody overrides it.
         self.event(package, action, ti_done, ti_total, ts_done, ts_total)
+
+
+TransactionProgress = dnf.yum.rpmtrans.TransactionDisplay  # :api

--- a/dnf/callback.py
+++ b/dnf/callback.py
@@ -1,7 +1,7 @@
 # callbacks.py
 # Abstract interfaces to communicate progress on tasks.
 #
-# Copyright (C) 2014  Red Hat, Inc.
+# Copyright (C) 2014-2015  Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -100,5 +100,6 @@ class Depsolve(object):
     def end(self):
         pass
 
-# alias for RPM transaction callback that logs things to a file
+# :deprecated in 1.1.0, eligible for dropping in 2.0
+# de facto API - never documented but used by Anaconda thanks to us
 LoggingTransactionDisplay = dnf.yum.rpmtrans.LoggingTransactionDisplay

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -151,7 +151,7 @@ class BaseCli(dnf.Base):
         """Take care of package downloading, checking, user
         confirmation and actually running the transaction.
 
-        :param display: `TransactionDisplay` object(s)
+        :param display: `rpm.callback.TransactionProgress` object(s)
         :return: a numeric return code, and optionally a list of
            errors.  A negative return code indicates that errors
            occurred in the pre-transaction checks

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -28,6 +28,7 @@ from . import output
 from dnf.cli import CliError
 from dnf.i18n import ucd, _
 
+import collections
 import datetime
 import dnf
 import dnf.cli.commands
@@ -146,7 +147,7 @@ class BaseCli(dnf.Base):
             return None
         return self.group_persistor.diff()
 
-    def do_transaction(self, display='DEFAULT'):
+    def do_transaction(self, display=()):
         """Take care of package downloading, checking, user
         confirmation and actually running the transaction.
 
@@ -214,8 +215,9 @@ class BaseCli(dnf.Base):
             # Check GPG signatures
             self.gpgsigcheck(downloadpkgs)
 
-        if display is 'DEFAULT':
-            display = output.CliTransactionDisplay()
+        if not isinstance(display, collections.Sequence):
+            display = [display]
+        display = [output.CliTransactionDisplay()] + list(display)
         super(BaseCli, self).do_transaction(display)
         if trans:
             msg = self.output.post_transaction_output(trans)

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -150,7 +150,7 @@ class BaseCli(dnf.Base):
         """Take care of package downloading, checking, user
         confirmation and actually running the transaction.
 
-        :param display: a `TransactionDisplay` object
+        :param display: `TransactionDisplay` object(s)
         :return: a numeric return code, and optionally a list of
            errors.  A negative return code indicates that errors
            occurred in the pre-transaction checks

--- a/dnf/cli/demand.py
+++ b/dnf/cli/demand.py
@@ -1,7 +1,7 @@
 # demand.py
 # Demand sheet and related classes.
 #
-# Copyright (C) 2014  Red Hat, Inc.
+# Copyright (C) 2014-2015  Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -56,4 +56,4 @@ class DemandSheet(object):
     fresh_metadata = _BoolDefault(True)
     freshest_metadata = _BoolDefault(False)
 
-    transaction_display = output.CliTransactionDisplay()
+    transaction_display = None

--- a/dnf/cli/main.py
+++ b/dnf/cli/main.py
@@ -1,5 +1,5 @@
 # Copyright 2005 Duke University
-# Copyright (C) 2012-2013  Red Hat, Inc.
+# Copyright (C) 2012-2015  Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -161,8 +161,11 @@ def resolving(cli, base):
     base.plugins.run_resolved()
 
     # Run the transaction
+    displays = []
+    if cli.demands.transaction_display is not None:
+        displays.append(cli.demands.transaction_display)
     try:
-        base.do_transaction(display=cli.demands.transaction_display)
+        base.do_transaction(display=displays)
     except dnf.cli.CliError as exc:
         logger.error(ucd(exc))
         return 1

--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -2214,13 +2214,6 @@ class CliTransactionDisplay(LoggingTransactionDisplay):
             wid2 = pnl
         return fmt, wid1, wid2
 
-    def verify_tsi_package(self, pkg, count, total):
-        percent = 100
-        process = _('Verifying')
-        wid1 = max(exact_width(process), self._max_action_width())
-        self._out_progress(
-            100, 100, count, total, percent, process, ucd(pkg), wid1)
-
 def progressbar(current, total, name=None):
     """Output the current status to the terminal using a simple
     text progress bar consisting of 50 # marks.

--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -1,5 +1,5 @@
 # Copyright 2005 Duke University
-# Copyright (C) 2012-2013  Red Hat, Inc.
+# Copyright (C) 2012-2015  Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -2098,7 +2098,7 @@ class CliTransactionDisplay(LoggingTransactionDisplay):
         self.mark = "#"
         self.marks = 22
 
-    def event(self, package, action, te_current, te_total, ts_current, ts_total):
+    def progress(self, package, action, ti_done, ti_total, ts_done, ts_total):
         """Output information about an rpm operation.  This may
         include a text progress bar.
 
@@ -2106,11 +2106,11 @@ class CliTransactionDisplay(LoggingTransactionDisplay):
         :param action: the type of action that is taking place.  Valid
            values are given by
            :func:`rpmtrans.LoggingTransactionDisplay.action.keys()`
-        :param te_current: a number representing the amount of work
+        :param ti_done: a number representing the amount of work
            already done in the current transaction
-        :param te_total: a number representing the total amount of work
+        :param ti_total: a number representing the total amount of work
            to be done in the current transaction
-        :param ts_current: the number of the current transaction in
+        :param ts_done: the number of the current transaction in
            transaction set
         :param ts_total: the total number of transactions in the
            transaction set
@@ -2123,12 +2123,12 @@ class CliTransactionDisplay(LoggingTransactionDisplay):
 
         pkgname = ucd(package)
         self.lastpackage = package
-        if te_total == 0:
+        if ti_total == 0:
             percent = 0
         else:
-            percent = (te_current*long(100))//te_total
-        self._out_event(te_current, te_total, ts_current, ts_total,
-                        percent, process, pkgname, wid1)
+            percent = (ti_done*long(100))//ti_total
+        self._out_progress(ti_done, ti_total, ts_done, ts_total,
+                           percent, process, pkgname, wid1)
 
     def _max_action_width(self):
         if not hasattr(self, '_max_action_wid_cache'):
@@ -2141,10 +2141,10 @@ class CliTransactionDisplay(LoggingTransactionDisplay):
         wid1 = self._max_action_wid_cache
         return wid1
 
-    def _out_event(self, te_current, te_total, ts_current, ts_total,
-                   percent, process, pkgname, wid1):
-        if self.output and (sys.stdout.isatty() or te_current == te_total):
-            (fmt, wid1, wid2) = self._makefmt(percent, ts_current, ts_total,
+    def _out_progress(self, ti_done, ti_total, ts_done, ts_total,
+                      percent, process, pkgname, wid1):
+        if self.output and (sys.stdout.isatty() or ti_done == ti_total):
+            (fmt, wid1, wid2) = self._makefmt(percent, ts_done, ts_total,
                                               progress=sys.stdout.isatty(),
                                               pkgname=pkgname, wid1=wid1)
             pkgname = ucd(pkgname)
@@ -2154,7 +2154,7 @@ class CliTransactionDisplay(LoggingTransactionDisplay):
                 sys.stdout.write(msg)
                 sys.stdout.flush()
                 self.lastmsg = msg
-            if te_current == te_total:
+            if ti_done == ti_total:
                 print(" ")
 
     def scriptout(self, msgs):
@@ -2166,12 +2166,12 @@ class CliTransactionDisplay(LoggingTransactionDisplay):
             sys.stdout.write(ucd(msgs))
             sys.stdout.flush()
 
-    def _makefmt(self, percent, ts_current, ts_total, progress=True,
+    def _makefmt(self, percent, ts_done, ts_total, progress=True,
                  pkgname=None, wid1=15):
         l = len(str(ts_total))
         size = "%s.%s" % (l, l)
         fmt_done = "%" + size + "s/%" + size + "s"
-        done = fmt_done % (ts_current, ts_total)
+        done = fmt_done % (ts_done, ts_total)
 
         #  This should probably use TerminLine, but we don't want to dep. on
         # that. So we kind do an ok job by hand ... at least it's dynamic now.
@@ -2218,7 +2218,8 @@ class CliTransactionDisplay(LoggingTransactionDisplay):
         percent = 100
         process = _('Verifying')
         wid1 = max(exact_width(process), self._max_action_width())
-        self._out_event(100, 100, count, total, percent, process, ucd(pkg), wid1)
+        self._out_progress(
+            100, 100, count, total, percent, process, ucd(pkg), wid1)
 
 def progressbar(current, total, name=None):
     """Output the current status to the terminal using a simple

--- a/dnf/yum/rpmtrans.py
+++ b/dnf/yum/rpmtrans.py
@@ -89,9 +89,9 @@ class TransactionDisplay(object):
         """msgs is the messages that were output (if any)."""
         pass
 
-    def errorlog(self, msg):
-        """takes a simple error msg string"""
-        print(msg, file=sys.stderr)
+    def error(self, message):
+        """takes a simple error message string"""
+        print(message, file=sys.stderr)
 
     def filelog(self, package, action):
         # check package object type - if it is a string - just output it
@@ -127,9 +127,9 @@ class LoggingTransactionDisplay(TransactionDisplay):
                            self.PKG_VERIFY: 'Verified'}
         self.rpm_logger = logging.getLogger('dnf.rpm')
 
-    def errorlog(self, msg):
-        super(LoggingTransactionDisplay, self).errorlog(msg)
-        self.rpm_logger.error(msg)
+    def error(self, message):
+        super(LoggingTransactionDisplay, self).error(message)
+        self.rpm_logger.error(message)
 
     def filelog(self, package, action):
         # If the action is not in the fileaction list then dump it as a string
@@ -264,7 +264,7 @@ class RPMTransaction(object):
             self._ts_done = open(ts_done_fn, 'w')
         except (IOError, OSError) as e:
             for display in self.displays:
-                display.errorlog('could not open ts_done file: %s' % e)
+                display.error('could not open ts_done file: %s' % e)
             self._ts_done = None
             return False
         self._fdSetCloseOnExec(self._ts_done.fileno())
@@ -282,7 +282,7 @@ class RPMTransaction(object):
             #  Having incomplete transactions is probably worse than having
             # nothing.
             for display in self.displays:
-                display.errorlog('could not write to ts_done file: %s' % e)
+                display.error('could not write to ts_done file: %s' % e)
             self._ts_done = None
             misc.unlink_f(self.ts_done_fn)
 
@@ -369,7 +369,7 @@ class RPMTransaction(object):
             fo = open(tsfn, 'w')
         except (IOError, OSError) as e:
             for display in self.displays:
-                display.errorlog('could not open ts_all file: %s' % e)
+                display.error('could not open ts_all file: %s' % e)
             self._ts_done = None
             return
 
@@ -383,7 +383,7 @@ class RPMTransaction(object):
             #  Having incomplete transactions is probably worse than having
             # nothing.
             for display in self.displays:
-                display.errorlog('could not write to ts_all file: %s' % e)
+                display.error('could not write to ts_all file: %s' % e)
             misc.unlink_f(tsfn)
             self._ts_done = None
 
@@ -442,7 +442,7 @@ class RPMTransaction(object):
             self.fd = open(rpmloc)
         except IOError as e:
             for display in self.displays:
-                display.errorlog("Error: Cannot open file %s: %s" % (rpmloc, e))
+                display.error("Error: Cannot open file %s: %s" % (rpmloc, e))
         else:
             if self.trans_running:
                 self.total_installed += 1
@@ -530,13 +530,13 @@ class RPMTransaction(object):
         pkg, _, _ = self._extract_cbkey(h)
         msg = "Error in cpio payload of rpm package %s" % pkg
         for display in self.displays:
-            display.errorlog(msg)
+            display.error(msg)
 
     def _unpackError(self, bytes, total, h):
         pkg, _, _ = self._extract_cbkey(h)
         msg = "Error unpacking rpm package %s" % pkg
         for display in self.displays:
-            display.errorlog(msg)
+            display.error(msg)
 
     def _scriptError(self, bytes, total, h):
         # "bytes" carries the failed scriptlet tag,
@@ -553,7 +553,7 @@ class RPMTransaction(object):
             msg = ("Non-fatal %s scriptlet failure in rpm package %s" %
                    (scriptlet_name, name))
         for display in self.displays:
-            display.errorlog(msg)
+            display.error(msg)
 
     def _scriptStart(self, bytes, total, h):
         pass

--- a/dnf/yum/rpmtrans.py
+++ b/dnf/yum/rpmtrans.py
@@ -69,15 +69,15 @@ class TransactionDisplay(object):
     def __init__(self):
         pass
 
-    def event(self, package, action, te_current, te_total, ts_current, ts_total):
+    def progress(self, package, action, ti_done, ti_total, ts_done, ts_total):
         """
         @param package: A DNF package object or simple string of a package name
         @param action: A constant transaction set state
-        @param te_current: current number of bytes processed in the transaction
-                           element being processed
-        @param te_total: total number of bytes in the transaction element being
+        @param ti_done: current number of bytes processed in the transaction
+                        item being processed
+        @param ti_total: total number of bytes in the transaction item being
                          processed
-        @param ts_current: number of processes completed in whole transaction
+        @param ts_done: number of processes completed in whole transaction
         @param ts_total: total number of processes in the transaction.
         """
         # this is where a progress bar would be called
@@ -94,8 +94,8 @@ class TransactionDisplay(object):
 
     def filelog(self, package, action):
         # check package object type - if it is a string - just output it
-        """package is the same as in event() - a package object or simple string
-           action is also the same as in event()"""
+        """package is the same as in progress() - a package object or simple
+           string action is also the same as in progress()"""
         pass
 
     def verify_tsi_package(self, pkg, count, total):
@@ -468,13 +468,13 @@ class RPMTransaction(object):
             # RPM doesn't explicitly report when post-trans phase starts
             action = TransactionDisplay.TRANS_POST
             for display in self.displays:
-                display.event(None, action, None, None, None, None)
+                display.progress(None, action, None, None, None, None)
 
     def _instProgress(self, bytes, total, h):
         pkg, _, tsi = self._extract_tsi_cbkey(h)
         action = TransactionDisplay.ACTION_FROM_OP_TYPE[tsi.op_type]
         for display in self.displays:
-            display.event(
+            display.progress(
                 pkg, action, bytes, total, self.complete_actions,
                 self.total_actions)
 
@@ -496,8 +496,8 @@ class RPMTransaction(object):
             action = TransactionDisplay.PKG_ERASE
         for display in self.displays:
             display.filelog(pkg, action)
-            display.event(pkg, action, 100, 100, self.complete_actions,
-                          self.total_actions)
+            display.progress(pkg, action, 100, 100, self.complete_actions,
+                             self.total_actions)
 
         if self.test:
             return

--- a/dnf/yum/rpmtrans.py
+++ b/dnf/yum/rpmtrans.py
@@ -91,7 +91,7 @@ class TransactionDisplay(object):
 
     def error(self, message):
         """takes a simple error message string"""
-        print(message, file=sys.stderr)
+        pass
 
     def filelog(self, package, action):
         # check package object type - if it is a string - just output it
@@ -103,7 +103,16 @@ class TransactionDisplay(object):
         self.progress(pkg, self.PKG_VERIFY, 100, 100, count, total)
 
 
-class LoggingTransactionDisplay(TransactionDisplay):
+class ErrorTransactionDisplay(TransactionDisplay):
+
+    """An RPMTransaction display that prints errors to standard output."""
+
+    def error(self, message):
+        super(ErrorTransactionDisplay, self).error(message)
+        print(message, file=sys.stderr)
+
+
+class LoggingTransactionDisplay(ErrorTransactionDisplay):
     '''
     Base class for a RPMTransaction display callback class
     '''
@@ -143,7 +152,7 @@ class LoggingTransactionDisplay(TransactionDisplay):
 class RPMTransaction(object):
     def __init__(self, base, test=False, displays=()):
         if not displays:
-            displays = [TransactionDisplay()]
+            displays = [ErrorTransactionDisplay()]
         self.displays = displays
         self.base = base
         self.test = test  # are we a test?

--- a/dnf/yum/rpmtrans.py
+++ b/dnf/yum/rpmtrans.py
@@ -71,18 +71,20 @@ class TransactionDisplay(object):
         pass
 
     def progress(self, package, action, ti_done, ti_total, ts_done, ts_total):
-        """
-        @param package: A DNF package object or simple string of a package name
-        @param action: A constant transaction set state
-        @param ti_done: current number of bytes processed in the transaction
-                        item being processed
-        @param ti_total: total number of bytes in the transaction item being
-                         processed
-        @param ts_done: number of processes completed in whole transaction
-        @param ts_total: total number of processes in the transaction.
-        """
-        # this is where a progress bar would be called
+        """Report ongoing progress on a transaction item. :api
 
+        :param package: a package being processed
+        :param action: the action being performed
+        :param ti_done: number of processed bytes of the transaction
+           item being processed
+        :param ti_total: total number of bytes of the transaction item
+           being processed
+        :param ts_done: number of actions processed in the whole
+           transaction
+        :param ts_total: total number of actions in the whole
+           transaction
+
+        """
         pass
 
     def scriptout(self, msgs):
@@ -90,7 +92,7 @@ class TransactionDisplay(object):
         pass
 
     def error(self, message):
-        """takes a simple error message string"""
+        """Report an error that occurred during the transaction. :api"""
         pass
 
     def filelog(self, package, action):

--- a/dnf/yum/rpmtrans.py
+++ b/dnf/yum/rpmtrans.py
@@ -47,16 +47,17 @@ logger = logging.getLogger('dnf')
 
 class TransactionDisplay(object):
     # per-package events
-    PKG_CLEANUP   = 1
+    PKG_CLEANUP = 1
     PKG_DOWNGRADE = 2
-    PKG_ERASE     = 3
-    PKG_INSTALL   = 4
-    PKG_OBSOLETE  = 5
+    PKG_ERASE = 3
+    PKG_INSTALL = 4
+    PKG_OBSOLETE = 5
     PKG_REINSTALL = 6
-    PKG_UPGRADE   = 7
+    PKG_UPGRADE = 7
+    PKG_VERIFY = 8
 
     # transaction-wide events
-    TRANS_POST      = 10
+    TRANS_POST = 10
 
     ACTION_FROM_OP_TYPE = {
         dnf.transaction.DOWNGRADE : PKG_DOWNGRADE,
@@ -99,7 +100,7 @@ class TransactionDisplay(object):
         pass
 
     def verify_tsi_package(self, pkg, count, total):
-        pass
+        self.progress(pkg, self.PKG_VERIFY, 100, 100, count, total)
 
 
 class LoggingTransactionDisplay(TransactionDisplay):
@@ -108,20 +109,22 @@ class LoggingTransactionDisplay(TransactionDisplay):
     '''
     def __init__(self):
         super(LoggingTransactionDisplay, self).__init__()
-        self.action = {self.PKG_CLEANUP   : _('Cleanup'),
-                       self.PKG_DOWNGRADE : _('Downgrading'),
-                       self.PKG_ERASE     : _('Erasing'),
-                       self.PKG_INSTALL   : _('Installing'),
-                       self.PKG_OBSOLETE  : _('Obsoleting'),
-                       self.PKG_REINSTALL : _('Reinstalling'),
-                       self.PKG_UPGRADE   : _('Upgrading')}
-        self.fileaction = {self.PKG_CLEANUP   : 'Cleanup',
-                           self.PKG_DOWNGRADE : 'Downgraded',
-                           self.PKG_ERASE     : 'Erased',
-                           self.PKG_INSTALL   : 'Installed',
-                           self.PKG_OBSOLETE  : 'Obsoleted',
-                           self.PKG_REINSTALL : 'Reinstalled',
-                           self.PKG_UPGRADE   :  'Upgraded'}
+        self.action = {self.PKG_CLEANUP: _('Cleanup'),
+                       self.PKG_DOWNGRADE: _('Downgrading'),
+                       self.PKG_ERASE: _('Erasing'),
+                       self.PKG_INSTALL: _('Installing'),
+                       self.PKG_OBSOLETE: _('Obsoleting'),
+                       self.PKG_REINSTALL: _('Reinstalling'),
+                       self.PKG_UPGRADE: _('Upgrading'),
+                       self.PKG_VERIFY: _('Verifying')}
+        self.fileaction = {self.PKG_CLEANUP: 'Cleanup',
+                           self.PKG_DOWNGRADE: 'Downgraded',
+                           self.PKG_ERASE: 'Erased',
+                           self.PKG_INSTALL: 'Installed',
+                           self.PKG_OBSOLETE: 'Obsoleted',
+                           self.PKG_REINSTALL: 'Reinstalled',
+                           self.PKG_UPGRADE:  'Upgraded',
+                           self.PKG_VERIFY: 'Verified'}
         self.rpm_logger = logging.getLogger('dnf.rpm')
 
     def errorlog(self, msg):

--- a/doc/api_base.rst
+++ b/doc/api_base.rst
@@ -80,7 +80,7 @@
 
   .. method:: do_transaction([display])
 
-    Perform the resolved transaction. Use the optional `display` object(s) to report the progress.
+    Perform the resolved transaction. Use the optional `display` object(s) to report the progress. `display` can be either an instance of a subclass of :class:`dnf.callback.TransactionProgress` or a sequence of such instances.
 
   .. method:: download_packages(pkglist, progress=None)
 

--- a/doc/api_base.rst
+++ b/doc/api_base.rst
@@ -1,5 +1,5 @@
 ..
-  Copyright (C) 2014  Red Hat, Inc.
+  Copyright (C) 2014-2015  Red Hat, Inc.
 
   This copyrighted material is made available to anyone wishing to use,
   modify, copy, or redistribute it subject to the terms and conditions of
@@ -80,7 +80,7 @@
 
   .. method:: do_transaction([display])
 
-    Perform the resolved transaction. Use the optional `display` object to report the progress.
+    Perform the resolved transaction. Use the optional `display` object(s) to report the progress.
 
   .. method:: download_packages(pkglist, progress=None)
 

--- a/doc/api_callback.rst
+++ b/doc/api_callback.rst
@@ -1,5 +1,5 @@
 ..
-  Copyright (C) 2014  Red Hat, Inc.
+  Copyright (C) 2014-2015  Red Hat, Inc.
 
   This copyrighted material is made available to anyone wishing to use,
   modify, copy, or redistribute it subject to the terms and conditions of
@@ -61,3 +61,31 @@
   .. method:: start(total_files, total_size)
 
     Report start of a download batch. `total_files` is the total number of payloads in the batch. `total_size` is the total number of bytes to be downloaded.
+
+.. class:: TransactionProgress
+
+  Base class providing callbacks to receive information about an ongoing transaction.
+
+  .. method:: error(message)
+
+    Report an error that occurred during the transaction. `message` is a string which describes the error.
+
+  .. method:: progress(package, action, ti_done, ti_total, ts_done, ts_total)
+
+    Report ongoing progress on the given transaction item. `package` is the :class:`dnf.package.Package` being processed and `action` is a constant with the following meaning:
+
+    ============== =================================================================================
+    `action` value meaning
+    ============== =================================================================================
+    PKG_CLEANUP    `package` cleanup is being performed.
+    PKG_DOWNGRADE  `package` is being downgraded.
+    PKG_INSTALL    `package` is being installed.
+    PKG_OBSOLETE   `package` is being obsoleted.
+    PKG_REINSTALL  `package` is being reinstalled.
+    PKG_REMOVE     `package` is being removed.
+    PKG_UPGRADE    `package` is being upgraded.
+    PKG_VERIFY     `package` is being verified.
+    TRANS_POST     The post-trans phase started. In this case, all the other arguments are ``None``.
+    ============== =================================================================================
+
+  `ti_done` is the number of processed bytes of the transaction item, `ti_total` is the total number of bytes of the transaction item, `ts_done` is the number of actions processed in the whole transaction and `ts_total` is the total number of actions in the whole transaction.

--- a/doc/api_cli.rst
+++ b/doc/api_cli.rst
@@ -1,5 +1,5 @@
 ..
-  Copyright (C) 2014  Red Hat, Inc.
+  Copyright (C) 2014-2015  Red Hat, Inc.
 
   This copyrighted material is made available to anyone wishing to use,
   modify, copy, or redistribute it subject to the terms and conditions of
@@ -60,6 +60,10 @@ When packaging your custom command, we recommend you to define a virtual provide
     .. attribute:: success_exit_status
 
       The return status of the DNF command on success. Defaults to ``0``.
+
+    .. attribute:: transaction_display
+
+      An additional instance of a subclass of :class:`dnf.callback.TransactionProgress` used to report information about an ongoing transaction.
 .. class:: Command
 
   Base class of every DNF command.

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -21,6 +21,14 @@
 
 .. contents::
 
+======================
+Upcoming Release Notes
+======================
+
+API additions in X.X.0:
+
+:meth:`dnf.Base.do_transaction` now accepts multiple displays.
+
 ===================
 1.0.2 Release Notes
 ===================

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -31,7 +31,7 @@ API additions in X.X.0:
 
 API deprecations in X.X.0:
 
-* ``dnf.callback.LoggingTransactionDisplay`` is deprecated now. It was considered part of API despite the fact that it has never been documented.
+* ``dnf.callback.LoggingTransactionDisplay`` is deprecated now. It was considered part of API despite the fact that it has never been documented. Use :class:`dnf.callback.TransactionProgress` instead.
 
 ===================
 1.0.2 Release Notes

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -29,6 +29,10 @@ API additions in X.X.0:
 
 :meth:`dnf.Base.do_transaction` now accepts multiple displays.
 
+API deprecations in X.X.0:
+
+* ``dnf.callback.LoggingTransactionDisplay`` is deprecated now. It was considered part of API despite the fact that it has never been documented.
+
 ===================
 1.0.2 Release Notes
 ===================


### PR DESCRIPTION
based on #313

Still not sure about the names... I call it `Transaction`**Progress** because we have a "progress" in `dnf.callback` already. But it does not match `base.do_transaction(`**display**`)`. And the same goes for `DemandSheet.transaction_`**display**. It does not match `Transaction`**Progress** but matches `base.do_transaction(`**display**`)`.

Also note that I have renamed `errorlog` to just `error`.