### PR TITLE
save:guardar -> save:ahorrar

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -1861,7 +1861,7 @@ msgstr "¡se suponía que %s estuviera eliminado, pero no lo está! "
 #, python-format
 msgid "Delta RPMs reduced %.1f MB of updates to %.1f MB (%d.1%% saved)"
 msgstr ""
-"Delta RPMs redujo %.1f MB de actualizaciones a %.1f MB (%d.1%% guardados)"
+"Delta RPMs redujo %.1f MB de actualizaciones a %.1f MB (%d.1%% de ahorro)"
 
 #: ../dnf/base.py:929
 #, python-format


### PR DESCRIPTION
*Guardar* is *save* when the meaning is that of *to keep*: *save a copy*, *save changes*.  In this sentence the meaning is *to avoid waste*, thus *ahorrar*.  If we want past participles, then change *de ahorro* into *ahorrado*.