### PR TITLE
dnf-makecache.service: start service after akmods.service (RhBug:1187111)

### DIFF
--- a/etc/systemd/dnf-makecache.service
+++ b/etc/systemd/dnf-makecache.service
@@ -1,4 +1,5 @@
 [Unit]
+After=akmods.service
 Description=dnf makecache
 
 [Service]


### PR DESCRIPTION
The problem is dnf-makecache and akmods starts at the same time,
makecache blocks rpmdb for some time. In this time akmods builds
RPM package with kernel modules. When it's built rpmdb probably
still blocked so akmods will fail to install package.

Adding After=akmods.service will just delay starting while akmods
still building modules.

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1187111
Signed-off-by: Ivan Shapovalov <intelfx100@gmail.com>
Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>