### PR TITLE
dnf-makecache.service: some fixes for akmods

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -61,6 +61,8 @@ DNF CONTRIBUTORS
     Frank Dana
     George Machitidze <giomac@gmail.com>
     Haïkel Guémar <haikel.guemar@gmail.com>
+    Igor Gnatenko <i.gnatenko.brain@gmail.com>
+    Ivan Shapovalov <intelfx100@gmail.com>
     Kevin Kofler <kevin.kofler@chello.at>
     Kushal Das <kushaldas@gmail.com>
     Matthew Miller

--- a/etc/systemd/dnf-makecache.service
+++ b/etc/systemd/dnf-makecache.service
@@ -1,5 +1,5 @@
 [Unit]
-After=akmods.service
+After=akmods.service akmods-shutdown.service
 Description=dnf makecache
 
 [Service]

--- a/etc/systemd/dnf-makecache.service
+++ b/etc/systemd/dnf-makecache.service
@@ -1,4 +1,5 @@
 [Unit]
+After=akmods.service
 Description=dnf makecache
 
 [Service]


### PR DESCRIPTION
```
commit 78e6d7058a99bc762e0145096b89e14bf734040b
Author: Ivan Shapovalov <intelfx100@gmail.com>
Date:   Thu Aug 6 23:09:45 2015 +0300

    dnf-makecache.service: start service after akmods-shutdown.service (RhBug:1187111)
    
    Another situation to consider is shutting down the system at the
    moment dnf-makecache.service is running. There is a unit
    akmods-shutdown.service which builds new modules at shutdown time;
    it is implemented as an oneshot service with a no-op start and actual
    work on stop.
    
    So, when a system starts to shut down in such circumstances, a stop
    job will be enqueued for akmods-shutdown.service and the existing
    start job for dnf-makecache.service will be reversed into a stop job.
    
    Thus, because in systemd ordering at stop time is inverse to that which
    is specified, order dnf-makecache.service after akmods-shutdown.service.
    
    Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1187111
    Signed-off-by: Ivan Shapovalov <intelfx100@gmail.com>
    Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>

commit 02bdb9158d0bb6c6b95031533b0b7532420f73d7
Author: Igor Gnatenko <i.gnatenko.brain@gmail.com>
Date:   Thu Aug 6 22:34:39 2015 +0300

    dnf-makecache.service: start service after akmods.service (RhBug:1187111)
    
    The problem is dnf-makecache and akmods starts at the same time,
    makecache blocks rpmdb for some time. In this time akmods builds
    RPM package with kernel modules. When it's built rpmdb probably
    still blocked so akmods will fail to install package.
    
    Adding After=akmods.service will just delay starting while akmods
    still building modules.
    
    Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1187111
    Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>
    Signed-off-by: Ivan Shapovalov <intelfx100@gmail.com>
```

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1187111