### PR TITLE
repo: repos with no valid mirrors/urls shall not be revived

### DIFF
--- a/dnf/repo.py
+++ b/dnf/repo.py
@@ -707,7 +707,7 @@ class Repo(dnf.yum.config.RepoConf):
             handle = self._handle_new_remote(tmpdir)
             handle.fetchmirrors = True
             handle.perform()
-            if handle.metalink is None:
+            if handle.metalink is None or not handle.mirrorlisturl:
                 logger.debug("reviving: repo '%s' skipped, no metalink.", self.id)
                 return False
             hashes = handle.metalink['hashes']


### PR DESCRIPTION
It turns out that sometimes `metalink` does not have all the information needed to work properly (urls/mirrors) and if that is the case, we may not "revive" the repository from it's slumber and should rather fetch new metadata.
