### PR TITLE
FIX: localPkg() return baseurl only if local repository

### DIFF
--- a/dnf/package.py
+++ b/dnf/package.py
@@ -164,7 +164,7 @@ class Package(hawkey.Package):
             path = os.path.join(self.baseurl, self.location)
             if path.startswith("file://"):
                 path = path[7:]
-            return path
+                return path
         loc = self.location
         if not self.repo.local:
             loc = os.path.basename(loc)


### PR DESCRIPTION
package.localPkg() was returning baseurl path for all repositories (stack trace below). After patching dnf installs packages without any problems.
-- cut --
Traceback (most recent call last):
  File "/bin/dnf", line 36, in <module>
    main.user_main(sys.argv[1:], exit_code=True)
  File "/usr/lib/python2.7/site-packages/dnf/cli/main.py", line 193, in user_main
    errcode = main(args)
  File "/usr/lib/python2.7/site-packages/dnf/cli/main.py", line 84, in main
    return _main(base, args)
  File "/usr/lib/python2.7/site-packages/dnf/cli/main.py", line 146, in _main
    ret = resolving(cli, base)
  File "/usr/lib/python2.7/site-packages/dnf/cli/main.py", line 168, in resolving
    base.do_transaction(display=displays)
  File "/usr/lib/python2.7/site-packages/dnf/cli/cli.py", line 218, in do_transaction
    self.gpgsigcheck(downloadpkgs)
  File "/usr/lib/python2.7/site-packages/dnf/cli/cli.py", line 238, in gpgsigcheck
    result, errmsg = self.sigCheckPkg(po)
  File "/usr/lib/python2.7/site-packages/dnf/base.py", line 942, in sigCheckPkg
    sigresult = dnf.rpm.miscutils.checkSig(ts, po.localPkg())
  File "/usr/lib/python2.7/site-packages/dnf/rpm/miscutils.py", line 62, in checkSig
    fdno = os.open(package, os.O_RDONLY)
OSError: [Errno 2] Nie ma takiego pliku ani katalogu: 'http://rpms.jdsieci.pl/jdsieci/fedora22/x86_64/bash-git-prompt-2.3.5-1.fc22.jds.noarch.rpm'
-- cut --