### PR TITLE
completion_helper: don't crash if exception was occured (RhBug:1225225)

### DIFF
--- a/dnf/cli/completion_helper.py
+++ b/dnf/cli/completion_helper.py
@@ -19,6 +19,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301  USA
 
+import dnf.exceptions
 import dnf.cli
 import re
 import sys
@@ -184,7 +185,10 @@ def main(args):
     cli.register_command(CleanCompletionCommand)
     cli.register_command(HistoryCompletionCommand)
     cli.configure(args)
-    cli.run()
+    try:
+        cli.run()
+    except dnf.exceptions.Exception:
+        sys.exit(0)
 
 if __name__ == "__main__":
     try:


### PR DESCRIPTION
For example, if cache not found for repo.

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1225225
Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>