### PR TITLE
Argparser

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -10,8 +10,8 @@
 %global py3pluginpath %{python3_sitelib}/dnf-plugins
 
 Name:		dnf
-Version:	1.1.2
-Release:	4%{?snapshot}%{?dist}
+Version:	1.2.0
+Release:	1%{?snapshot}%{?dist}
 Summary:	Package manager forked from Yum, using libsolv as a dependency resolver
 # For a breakdown of the licensing, see PACKAGE-LICENSING
 License:	GPLv2+ and GPLv2 and GPL

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -745,6 +745,10 @@ class Cli(object):
                 self.base.repos.add(repofp)
                 logger.info(_("Added %s repo from %s") % (label, path))
 
+        if opts.repo:
+            opts.repos_ed.insert(0, ("*", "disable"))
+            opts.repos_ed.extend([(r, "enable") for r in opts.repo])
+
         # Process repo enables and disables in order
         try:
             for (repo, operation) in opts.repos_ed:

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -1003,7 +1003,19 @@ class Cli(object):
                            self.base.output)
             sys.exit(0)
 
-        # show help if the user requests it
+        # subparsers needs to be added before printing the command help
+        self.optparser.init_subparser_commands(set(self.cli_commands.values()))
+
+        # temporary backwards compatible help-cmd help for commands
+        if (opts.help or opts.help_cmd) and len(cmds):
+            command_cls = self.cli_commands.get(cmds[0])
+            if not command_cls:
+                self.optparser.argparser.usage = self.optparser.get_usage()
+                self.optparser.argparser.print_help()
+                raise CliError
+            print(command_cls.parser.format_help())
+            sys.exit(0)
+        # show the global dnf help if the user requests it
         # this is done here, because we first have the full
         # usage info after the plugins are loaded.
         if opts.help:
@@ -1012,8 +1024,6 @@ class Cli(object):
             self.optparser.argparser.usage = self.optparser.get_usage()
             self.optparser.argparser.print_help()
             sys.exit(0)
-
-        self.optparser.init_subparser_commands(set(self.cli_commands.values()))
 
         # parse again with all command subparsers set
         opts, cmds = self.optparser.argparser.parse_known_args(args)

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -988,6 +988,14 @@ class Cli(object):
             opts.debuglevel = opts.errorlevel = dnf.const.VERBOSE_LEVEL
         self.nogpgcheck = opts.nogpgcheck
 
+        # store the main commands & summaries, before plugins are loaded
+        self.optparser.add_commands(self.cli_commands, 'main')
+        if self.base.conf.plugins:
+            self.base.plugins.load(self.base.conf.pluginpath, opts.disableplugins)
+        self.base.plugins.run_init(self.base, self)
+        # store the plugin commands & summaries
+        self.optparser.add_commands(self.cli_commands,'plugin')
+
         # the configuration reading phase is now concluded, finish the init
         self._configure_cachedir()
         # with cachedir in place we can configure stuff depending on it:
@@ -999,13 +1007,6 @@ class Cli(object):
                            self.base.output)
             sys.exit(0)
 
-        # store the main commands & summaries, before plugins are loaded
-        self.optparser.add_commands(self.cli_commands, 'main')
-        if self.base.conf.plugins:
-            self.base.plugins.load(self.base.conf.pluginpath, opts.disableplugins)
-        self.base.plugins.run_init(self.base, self)
-        # store the plugin commands & summaries
-        self.optparser.add_commands(self.cli_commands,'plugin')
 
         # build the usage info and put it into the optparser.
         self.optparser.usage = self.optparser.get_usage()

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -745,6 +745,9 @@ class Cli(object):
                 self.base.repos.add(repofp)
                 logger.info(_("Added %s repo from %s") % (label, path))
 
+                # do not let this repo to be disabled
+                opts.repos_ed.append((label, "enable"))
+
         if opts.repo:
             opts.repos_ed.insert(0, ("*", "disable"))
             opts.repos_ed.extend([(r, "enable") for r in opts.repo])

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -847,23 +847,18 @@ class Cli(object):
             conffile = dnf.const.CONF_FILENAME
         return installroot, conffile
 
-    def _parse_commands(self):
+    def _parse_commands(self, cmds, opts):
         """Check that the requested CLI command exists."""
-
-        if len(self.base.cmds) < 1:
-            logger.critical(_('You need to give some command'))
-            self.print_usage()
-            raise CliError
-
-        basecmd = self.base.cmds[0] # our base command
+        basecmd = opts.cmd
         command_cls = self.cli_commands.get(basecmd)
-        if command_cls is None:
-            logger.critical(_('No such command: %s. Please use %s --help'),
-                            basecmd, sys.argv[0])
-            logger.info(_("It could be a DNF plugin command, "
-                          "try: \"dnf install 'dnf-command(%s)'\""), basecmd)
+        # invalid options in commands without subparser
+        if cmds and getattr(command_cls, "set_argparse_subparser", None):
+            logger.critical(_('Unrecognized arguments given: %s. '
+                              'Please use %s --help'),
+                            cmds, sys.argv[0])
             raise CliError
         self.command = command_cls(self)
+        self.command.opts = opts
 
         (base, ext) = self.command.canonical(self.base.cmds)
         self.base.basecmd, self.base.extcmds = (base, ext)
@@ -921,7 +916,7 @@ class Cli(object):
         :param args: a list of command line arguments
         """
         self.optparser = dnf.cli.option_parser.OptionParser()
-        opts, cmds = self.optparser.parse_known_args(args)
+        opts, cmds = self.optparser.argparser.parse_known_args(args)
 
         # Just print out the version if that's what the user wanted
         if opts.version:
@@ -991,10 +986,11 @@ class Cli(object):
         # store the main commands & summaries, before plugins are loaded
         self.optparser.add_commands(self.cli_commands, 'main')
         if self.base.conf.plugins:
-            self.base.plugins.load(self.base.conf.pluginpath, opts.disableplugins)
+            self.base.plugins.load(self.base.conf.pluginpath,
+                                   opts.disableplugins)
         self.base.plugins.run_init(self.base, self)
         # store the plugin commands & summaries
-        self.optparser.add_commands(self.cli_commands,'plugin')
+        self.optparser.add_commands(self.cli_commands, 'plugin')
 
         # the configuration reading phase is now concluded, finish the init
         self._configure_cachedir()
@@ -1007,16 +1003,20 @@ class Cli(object):
                            self.base.output)
             sys.exit(0)
 
-
-        # build the usage info and put it into the optparser.
-        self.optparser.usage = self.optparser.get_usage()
-
         # show help if the user requests it
         # this is done here, because we first have the full
         # usage info after the plugins are loaded.
         if opts.help:
-            self.optparser.print_help()
+            # build the usage info and put it into the optparser.
+            # will be erased once we use default --help
+            self.optparser.argparser.usage = self.optparser.get_usage()
+            self.optparser.argparser.print_help()
             sys.exit(0)
+
+        self.optparser.init_subparser_commands(set(self.cli_commands.values()))
+
+        # parse again with all command subparsers set
+        opts, cmds = self.optparser.argparser.parse_known_args(args)
 
         # save our original args out
         self.base.args = args
@@ -1027,8 +1027,9 @@ class Cli(object):
 
         self._log_essentials()
         try:
-            self._parse_commands() # before we return check over the base command
-                                  # + args make sure they match/make sense
+            # before we return check over the base command
+            # args make sure they match/make sense
+            self._parse_commands(cmds, opts)
         except CliError:
             sys.exit(1)
         self.command.configure(self.base.extcmds)
@@ -1092,7 +1093,7 @@ class Cli(object):
         return self.command.run(self.base.extcmds)
 
     def print_usage(self):
-        return self.optparser.print_usage()
+        return self.optparser.argparser.print_usage()
 
 
 class CmdConf(object):

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -1012,12 +1012,12 @@ class Cli(object):
 
         # subparsers needs to be added before printing the command help
         self.optparser.init_subparser_commands(set(self.cli_commands.values()))
+        self.optparser.argparser.usage = self.optparser.get_usage()
 
         # temporary backwards compatible help-cmd help for commands
         if (opts.help or opts.help_cmd) and len(cmds):
             command_cls = self.cli_commands.get(cmds[0])
             if not command_cls:
-                self.optparser.argparser.usage = self.optparser.get_usage()
                 self.optparser.argparser.print_help()
                 raise CliError
             print(command_cls.parser.format_help())
@@ -1028,7 +1028,6 @@ class Cli(object):
         if opts.help:
             # build the usage info and put it into the optparser.
             # will be erased once we use default --help
-            self.optparser.argparser.usage = self.optparser.get_usage()
             self.optparser.argparser.print_help()
             sys.exit(0)
 

--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -179,6 +179,12 @@ class Command(object):
         extra = command_list[1:]
         return (base, extra)
 
+    # @staticmethod
+    # def set_argparse_subparser(parsers):
+    #     # commented out to identify commands using new API
+    #     # :api
+    #     pass
+
     def configure(self, args):
         """Do any command-specific configuration. #:api"""
 

--- a/dnf/cli/commands/install.py
+++ b/dnf/cli/commands/install.py
@@ -21,6 +21,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from .. import commands
+from dnf.cli.option_parser import OptionParser
 from dnf.i18n import _
 
 import dnf.exceptions
@@ -37,44 +38,44 @@ class InstallCommand(commands.Command):
     """
 
     aliases = ('install',)
-    activate_sack = True
-    resolve = True
     summary = _("Install a package or packages on your system")
     usage = "%s..." % _('PACKAGE')
-    writes_rpmdb = True
 
-    def doCheck(self, basecmd, extcmds):
+    @staticmethod
+    def set_argparse_subparser(parser):
+        parser.add_argument('package', nargs='+',
+                            action=OptionParser.ParseSpecGroupFileCallback)
+
+    def configure(self, args):
         """Verify that conditions are met so that this command can run.
-        These include that the program is being run by the root user,
-        that there are enabled repositories with gpg keys, and that
+        That there are enabled repositories with gpg keys, and that
         this command is called with appropriate arguments.
-
-        :param basecmd: the name of the command
-        :param extcmds: the command line arguments passed to *basecmd*
         """
+        demands = self.cli.demands
+        demands.sack_activation = True
+        demands.available_repos = True
+        demands.resolving = True
+        demands.root_user = True
         commands.checkGPGKey(self.base, self.cli)
-        commands.checkPackageArg(self.cli, basecmd, extcmds)
-        commands.checkEnabledRepo(self.base, extcmds)
+        commands.checkEnabledRepo(self.base, self.opts.filenames)
 
     def run(self, extcmds):
-        pkg_specs, grp_specs, filenames = commands.parse_spec_group_file(
-            extcmds)
         strict = self.base.conf.strict
         package_install_fnc = functools.partial(self.base.package_install,
                                                 strict=strict)
 
         # Install files.
-        local_pkgs = map(self.base.add_remote_rpm, filenames)
+        local_pkgs = map(self.base.add_remote_rpm, self.opts.filenames)
         # try to install packages with higher version first
         local_pkgs = sorted(local_pkgs, reverse=True)
         results = map(package_install_fnc, local_pkgs)
         done = functools.reduce(operator.or_, results, False)
 
         # Install groups.
-        if grp_specs:
+        if self.opts.grp_specs:
             self.base.read_comps()
             try:
-                self.base.env_group_install(grp_specs,
+                self.base.env_group_install(self.opts.grp_specs,
                                             dnf.const.GROUP_PACKAGE_TYPES,
                                             strict=strict)
             except dnf.exceptions.Error:
@@ -84,7 +85,7 @@ class InstallCommand(commands.Command):
 
         # Install packages.
         errs = []
-        for pkg_spec in pkg_specs:
+        for pkg_spec in self.opts.pkg_specs:
             try:
                 self.base.install(pkg_spec, strict=strict)
             except dnf.exceptions.MarkingError:

--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -178,14 +178,15 @@ class OptionParser:
         # has set something or whether we are getting a default.
 
         opt_parser = argparse.ArgumentParser(add_help=False)
-        opt_parser.add_argument('--allowerasing', action='store_true',
-                                default=None,
-                                help=_('allow erasing of installed packages to '
-                                'resolve dependencies'))
-        opt_parser.add_argument("-b", "--best", action="store_true",
-                                default=None,
-                                help=_("try the best available package versions
-                                       " in transactions."))
+        opt_parser.add_argument(
+            '--allowerasing', action='store_true',
+            default=None,
+            help=_('allow erasing of installed packages to '
+                   'resolve dependencies'))
+        opt_parser.add_argument(
+            "-b", "--best", action="store_true",
+            default=None,
+            help=_("try the best available package versions in transactions."))
         opt_parser.add_argument("-C", "--cacheonly", dest="cacheonly",
                                 action="store_true", default=None,
                                 help=_("run entirely from system cache, "
@@ -280,6 +281,8 @@ class OptionParser:
         # but first after plugins are loaded.
         opt_parser.add_argument('-h', '--help', action="store_true",
                                 help="show help")
+        opt_parser.add_argument('--help-cmd', action="store_true",
+                                help="show command help")
         self.argparser = argparse.ArgumentParser(
             self, add_help=False,
             usage="dnf [options] COMMAND", parents=[opt_parser])
@@ -320,6 +323,7 @@ class OptionParser:
                                                **kwargs)
                 if getattr(cmd, "set_argparse_subparser", None):
                     cmd.set_argparse_subparser(parser)
+                cmd.parser = parser
 
     def get_usage(self):
         """ get the usage information to show the user. """

--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -224,11 +224,19 @@ class OptionParser:
         opt_parser.add_argument("--installroot", help=_("set install root"),
                                 metavar='[path]')
         opt_parser.add_argument("--enablerepo", action=self._RepoCallback,
-                                 dest='repos_ed', default=[],
-                                 metavar='[repo]')
-        opt_parser.add_argument("--disablerepo", action=self._RepoCallback,
-                                 dest='repos_ed', default=[],
-                                 metavar='[repo]')
+                                dest='repos_ed', default=[],
+                                metavar='[repo]')
+        repo_group = opt_parser.add_mutually_exclusive_group()
+        repo_group.add_argument("--disablerepo", action=self._RepoCallback,
+                                dest='repos_ed', default=[],
+                                metavar='[repo]')
+        repo_group.add_argument(
+            '--repo', metavar='[repo]', action='append',
+            help=_('enable just specific repositories by an id or a glob, '
+                   'can be specified multiple times'))
+        # compat: erase in 2.0.0 --repoid hidden compatibility alias for --repo
+        repo_group.add_argument('--repoid', dest='repo', action='append',
+                                help=argparse.SUPPRESS)
         opt_parser.add_argument("-x", "--exclude", default=[],
                                 action=self._SplitCallback, dest='excludepkgs',
                                 help=_("exclude packages by name or glob"),

--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -223,13 +223,17 @@ class OptionParser:
                                 help=_("show DNF version and exit"))
         opt_parser.add_argument("--installroot", help=_("set install root"),
                                 metavar='[path]')
-        opt_parser.add_argument("--enablerepo", action=self._RepoCallback,
-                                dest='repos_ed', default=[],
-                                metavar='[repo]')
+        opt_parser.add_argument(
+            "--enablerepo", action=self._RepoCallback,
+            dest='repos_ed', default=[], metavar='[repo]',
+            help=_('enable specific repositories by an id or a glob, '
+                   'can be specified multiple times'))
         repo_group = opt_parser.add_mutually_exclusive_group()
-        repo_group.add_argument("--disablerepo", action=self._RepoCallback,
-                                dest='repos_ed', default=[],
-                                metavar='[repo]')
+        repo_group.add_argument(
+            "--disablerepo", action=self._RepoCallback,
+            dest='repos_ed', default=[], metavar='[repo]',
+            help=_('disable specific repositories by an id or a glob, '
+                   'can be specified multiple times'))
         repo_group.add_argument(
             '--repo', metavar='[repo]', action='append',
             help=_('enable just specific repositories by an id or a glob, '

--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -22,6 +22,7 @@ from __future__ import unicode_literals
 from dnf.i18n import _
 
 import argparse
+import dnf
 import dnf.exceptions
 import dnf.yum.misc
 import logging
@@ -30,26 +31,41 @@ import sys
 
 logger = logging.getLogger("dnf")
 
-class OptionParser(argparse.ArgumentParser):
+
+def error(self, msg):
+    """Output an error message, and exit the program.  This method
+    is overridden so that error output goes to the logger.
+
+    :param msg: the error message to output
+    """
+    self.print_help()
+    g = re.match(r"argument COMMAND: invalid choice: u'([^']*)'", msg)
+    if g:
+        cmd = g.groups(1)[0]
+        logger.critical(_("\nNo such command: %s"), cmd)
+        logger.info(_("It could be a DNF plugin command, "
+                      "try: \"dnf install 'dnf-command(%s)'\""),
+                    cmd)
+    else:
+        logger.critical(msg)
+    raise dnf.cli.CliError
+
+
+class OptionParser:
     """Subclass that makes some minor tweaks to make ArgumentParser do things the
     "yum way".
     """
 
     def __init__(self, **kwargs):
-        argparse.ArgumentParser.__init__(self, add_help=False, **kwargs)
         self._cmd_usage = {} # names, summary for dnf commands, to build usage
         self._cmd_groups = set() # cmd groups added (main, plugin)
-        self._addYumBasicOptions()
-
-    def error(self, msg):
-        """Output an error message, and exit the program.  This method
-        is overridden so that error output goes to the logger.
-
-        :param msg: the error message to output
-        """
-        self.print_usage()
-        logger.critical(_("Command line error: %s"), msg)
-        sys.exit(1)
+        # parent instance of Argument parser with dnf global switches
+        self.opt_parser = None
+        # main instance of Argument parser to which are subparsers applied
+        self.argparser = None
+        self._add_global_options()
+        # bind the function to the object
+        self.argparser.error = error.__get__(self.argparser)
 
     @staticmethod
     def _non_nones2dict(in_dct):
@@ -103,7 +119,7 @@ class OptionParser(argparse.ArgumentParser):
 
         except ValueError as e:
             logger.critical(_('Options Error: %s'), e)
-            self.print_help()
+            self.argparser.print_help()
             sys.exit(1)
 
     @staticmethod
@@ -122,6 +138,19 @@ class OptionParser(argparse.ArgumentParser):
             operation = 'disable' if opt_str == '--disablerepo' else 'enable'
             l = getattr(namespace, self.dest)
             l.append((values, operation))
+
+    class ParseSpecGroupFileCallback(argparse.Action):
+        def __call__(self, parser, namespace, values, opt_str):
+            setattr(namespace, "filenames", [])
+            setattr(namespace, "grp_specs", [])
+            setattr(namespace, "pkg_specs", [])
+            for value in values:
+                if value.endswith('.rpm'):
+                    namespace.filenames.append(value)
+                elif value.startswith('@'):
+                    namespace.grp_specs.append(value[1:])
+                else:
+                    namespace.pkg_specs.append(value)
 
     class _SplitCallback(argparse.Action):
         """ Split all strings in seq, at "," and whitespace.
@@ -144,103 +173,117 @@ class OptionParser(argparse.ArgumentParser):
             dct = getattr(namespace, self.dest)
             dct[key] = val
 
-    def _addYumBasicOptions(self):
+    def _add_global_options(self):
         # All defaults need to be a None, so we can always tell whether the user
         # has set something or whether we are getting a default.
-        self.conflict_handler = "resolve"
-        self.conflict_handler = "error"
 
-        self.add_argument('--allowerasing', action='store_true', default=None,
-                           help=_('allow erasing of installed packages to '
-                                  'resolve dependencies'))
-        self.add_argument("-b", "--best", action="store_true", default=None,
-                           help=_("try the best available package versions in "
-                                  "transactions."))
-        self.add_argument("-C", "--cacheonly", dest="cacheonly",
-                           action="store_true", default=None,
-                           help=_("run entirely from system cache, "
-                                  "don't update cache"))
-        self.add_argument("-c", "--config", dest="conffile",
-                           default=None, metavar='[config file]',
-                           help=_("config file location"))
-        self.add_argument("-d", "--debuglevel", dest="debuglevel",
-                           metavar='[debug level]', default=None,
-                           help=_("debugging output level"), type=int)
-        self.add_argument("--debugsolver",
-                           action="store_true", default=None,
-                           help=_("dumps detailed solving results into files"))
-        self.add_argument("--showduplicates", dest="showdupesfromrepos",
-                           action="store_true", default=None,
-                           help=_("show duplicates, in repos, "
-                                  "in list/search commands"))
-        self.add_argument("-e", "--errorlevel", default=None, type=int,
-                           help=_("error output level"))
-        self.add_argument("--rpmverbosity", default=None,
-                           help=_("debugging output level for rpm"),
-                           metavar='[debug level name]')
-        self.add_argument("-q", "--quiet", dest="quiet", action="store_true",
-                           default=None, help=_("quiet operation"))
-        self.add_argument("-v", "--verbose", action="store_true",
-                           default=None, help=_("verbose operation"))
-        self.add_argument("-y", "--assumeyes", action="store_true",
-                           default=None, help=_("answer yes for all questions"))
-        self.add_argument("--assumeno", action="store_true",
-                           default=None, help=_("answer no for all questions"))
-        self.add_argument("--version", action="store_true", default=None,
-                           help=_("show DNF version and exit"))
-        self.add_argument("--installroot", help=_("set install root"),
-                           metavar='[path]')
-        self.add_argument("--enablerepo", action=self._RepoCallback,
-                           dest='repos_ed', default=[],
-                           metavar='[repo]')
-        self.add_argument("--disablerepo", action=self._RepoCallback,
-                           dest='repos_ed', default=[],
-                           metavar='[repo]')
-        self.add_argument("-x", "--exclude", default=[], dest='excludepkgs',
-                          action=self._SplitCallback,
-                          help=_("exclude packages by name or glob"),
-                          metavar='[package]')
-        self.add_argument("--disableexcludes", default=[],
-                          dest="disable_excludes",
-                          action=self._SplitCallback,
-                          help=_("disable excludes"),
-                          metavar='[repo]')
-        self.add_argument("--repofrompath", default={},
-                          action=self._SplitExtendDictCallback,
-                          metavar='[repo,path]',
-                          help=_("label and path to additional repository," \
-                                 " can be specified multiple times."))
-        self.add_argument("--noplugins", action="store_false", default=None,
-                          dest='plugins', help=_("disable all plugins"))
-        self.add_argument("--nogpgcheck", action="store_true", default=None,
-                          help=_("disable gpg signature checking"))
-        self.add_argument("--disableplugin", dest="disableplugins", default=[],
-                          action=self._SplitCallback,
-                          help=_("disable plugins by name"),
-                          metavar='[plugin]')
-        self.add_argument("--color", dest="color", default=None,
-                          help=_("control whether color is used"))
-        self.add_argument("--releasever", default=None,
-                           help=_("override the value of $releasever in config"
-                                  " and repo files"))
-        self.add_argument("--setopt", dest="setopts", default=[],
-                           action="append",
-                           help=_("set arbitrary config and repo options"))
-        self.add_argument("--refresh", dest="freshest_metadata",
-                          action="store_true",
-                          help=_("set metadata as expired before running the command"))
-        self.add_argument("-4", dest="ip_resolve", default=None,
-                          help=_("resolve to IPv4 addresses only"),
-                          action="store_const", const='ipv4')
-        self.add_argument("-6", dest="ip_resolve", default=None,
-                          help=_("resolve to IPv6 addresses only"),
-                          action="store_const", const='ipv6')
-        self.add_argument("--downloadonly", dest="downloadonly", action="store_true",
-                          help=_("only download packages"), default=False)
+        opt_parser = argparse.ArgumentParser(add_help=False)
+        opt_parser.add_argument('--allowerasing', action='store_true',
+                                default=None,
+                                help=_('allow erasing of installed packages to '
+                                'resolve dependencies'))
+        opt_parser.add_argument("-b", "--best", action="store_true",
+                                default=None,
+                                help=_("try the best available package versions
+                                       " in transactions."))
+        opt_parser.add_argument("-C", "--cacheonly", dest="cacheonly",
+                                action="store_true", default=None,
+                                help=_("run entirely from system cache, "
+                                       "don't update cache"))
+        opt_parser.add_argument("-c", "--config", dest="conffile",
+                                default=None, metavar='[config file]',
+                                help=_("config file location"))
+        opt_parser.add_argument("-d", "--debuglevel", dest="debuglevel",
+                                metavar='[debug level]', default=None,
+                                help=_("debugging output level"), type=int)
+        opt_parser.add_argument(
+            "--debugsolver", action="store_true", default=None,
+            help=_("dumps detailed solving results into files"))
+        opt_parser.add_argument("--showduplicates", dest="showdupesfromrepos",
+                                action="store_true", default=None,
+                                help=_("show duplicates, in repos, "
+                                       "in list/search commands"))
+        opt_parser.add_argument("-e", "--errorlevel", default=None, type=int,
+                                help=_("error output level"))
+        opt_parser.add_argument("--rpmverbosity", default=None,
+                                help=_("debugging output level for rpm"),
+                                metavar='[debug level name]')
+        opt_parser.add_argument("-q", "--quiet", dest="quiet", default=None,
+                                action="store_true", help=_("quiet operation"))
+        opt_parser.add_argument("-v", "--verbose", action="store_true",
+                                default=None, help=_("verbose operation"))
+        opt_parser.add_argument("-y", "--assumeyes", action="store_true",
+                                help=_("answer yes for all questions"),
+                                default=None)
+        opt_parser.add_argument("--assumeno", action="store_true",
+                                help=_("answer no for all questions"),
+                                default=None)
+        opt_parser.add_argument("--version", action="store_true", default=None,
+                                help=_("show DNF version and exit"))
+        opt_parser.add_argument("--installroot", help=_("set install root"),
+                                metavar='[path]')
+        opt_parser.add_argument("--enablerepo", action=self._RepoCallback,
+                                 dest='repos_ed', default=[],
+                                 metavar='[repo]')
+        opt_parser.add_argument("--disablerepo", action=self._RepoCallback,
+                                 dest='repos_ed', default=[],
+                                 metavar='[repo]')
+        opt_parser.add_argument("-x", "--exclude", default=[],
+                                action=self._SplitCallback, dest='excludepkgs',
+                                help=_("exclude packages by name or glob"),
+                                metavar='[package]')
+        opt_parser.add_argument("--disableexcludes", default=[],
+                                dest="disable_excludes",
+                                action=self._SplitCallback,
+                                help=_("disable excludes"),
+                                metavar='[repo]')
+        opt_parser.add_argument("--repofrompath", default={},
+                                action=self._SplitExtendDictCallback,
+                                metavar='[repo,path]',
+                                help=_("label and path to additional "
+                                       "repository, can be specified multiple"
+                                       "times."))
+        opt_parser.add_argument("--noplugins", action="store_false",
+                                default=None,
+                                dest='plugins', help=_("disable all plugins"))
+        opt_parser.add_argument("--nogpgcheck", action="store_true",
+                                default=None,
+                                help=_("disable gpg signature checking"))
+        opt_parser.add_argument("--disableplugin", dest="disableplugins",
+                                action=self._SplitCallback, default=[],
+                                help=_("disable plugins by name"),
+                                metavar='[plugin]')
+        opt_parser.add_argument("--color", dest="color", default=None,
+                                help=_("control whether color is used"))
+        opt_parser.add_argument("--releasever", default=None,
+                                help=_("override the value of $releasever in "
+                                       "config and repo files"))
+        opt_parser.add_argument(
+            "--setopt", dest="setopts", default=[],
+            action="append",
+            help=_("set arbitrary config and repo options"))
+        opt_parser.add_argument(
+            "--refresh", dest="freshest_metadata",
+            action="store_true",
+            help=_("set metadata as expired before running the command"))
+        opt_parser.add_argument("-4", dest="ip_resolve", default=None,
+                                help=_("resolve to IPv4 addresses only"),
+                                action="store_const", const='ipv4')
+        opt_parser.add_argument("-6", dest="ip_resolve", default=None,
+                                help=_("resolve to IPv6 addresses only"),
+                                action="store_const", const='ipv6')
+        opt_parser.add_argument("--downloadonly", dest="downloadonly",
+                                action="store_true", default=False,
+                                help=_("only download packages"))
         # we add our own help option, so we can control that help is not shown
         # automatic when we do the .parse_known_args(args)
         # but first after plugins are loaded.
-        self.add_argument('-h', '--help', action="store_true", help="show help")
+        opt_parser.add_argument('-h', '--help', action="store_true",
+                                help="show help")
+        self.argparser = argparse.ArgumentParser(
+            self, add_help=False,
+            usage="dnf [options] COMMAND", parents=[opt_parser])
+        self.opt_parser = opt_parser
 
     def _add_cmd_usage(self, cmd, group):
         """ store usage info about a single dnf command."""
@@ -258,6 +301,25 @@ class OptionParser(argparse.ArgumentParser):
         """
         for cmd in set(cli_cmds.values()):
             self._add_cmd_usage(cmd, group)
+
+    def init_subparser_commands(self, commands):
+        subparsers = self.argparser.add_subparsers(dest="cmd",
+                                                   metavar="COMMAND",
+                                                   help=argparse.SUPPRESS)
+        for cmd in commands:
+            kwargs = {}
+            if cmd.usage:
+                kwargs["usage"] = cmd.usage
+            if cmd.summary:
+                kwargs["description"] = cmd.summary
+            # in python2 aliases are not supported
+            # TODO when python2 is gone: add aliases=cmd.aliases[1:]
+            for alias in cmd.aliases:
+                parser = subparsers.add_parser(alias, add_help=False,
+                                               parents=[self.opt_parser],
+                                               **kwargs)
+                if getattr(cmd, "set_argparse_subparser", None):
+                    cmd.set_argparse_subparser(parser)
 
     def get_usage(self):
         """ get the usage information to show the user. """

--- a/doc/api_cli.rst
+++ b/doc/api_cli.rst
@@ -88,6 +88,10 @@ When packaging your custom command, we recommend you to define a virtual provide
 
     Usage string for the command used as displayed by the CLI help.
 
+  .. staticmethod:: set_argparse_subparser(parser)
+
+    Static method used for argparser subparser setup of command options. Usage and description are added automatically from attributes of the class. When this method is implemented, ``opts`` and ``parser`` will be added as attributes of the object maintaining :class:`argparse.Namespace` of parsed options and subparser of the command respectively.
+
   .. method:: configure(args)
 
     Perform any configuration on the command itself and on the CLI. `args` is a list of additional arguments to the command. Typically, the command implements this call to set up any :class:`demands <.DemandSheet>` it has on the way the :class:`.Sack` will be initialized. Default no-op implementation is provided.

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -139,7 +139,7 @@ Options
     Specify a path or url to a repository (same path as in a baseurl) to add to
     the repositories for this query. This option can be used multiple times.
     If you want to view only the packages from this repository combine this
-    with ``--disablerepo``/``--enablerepo``. The repo label for the repository
+    with ``--repo=<repo>`` or ``--disablerepo="*"`` switches. The repo label for the repository
     is specified by <repo>.
 
 ``--nogpgcheck``

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -107,7 +107,7 @@ Options
     Disable the listed plugins specified by names or globs.
 
 ``--disablerepo=<repoid>``
-    Disable specific repositories by an id or a glob.
+    Disable specific repositories by an id or a glob. This option is mutually exclusive with ``--repo``.
 
 .. _downloadonly-label:
 
@@ -119,7 +119,7 @@ Options
     10 (shows all error messages), default is 2. Deprecated, use ``-v`` instead.
 
 ``--enablerepo=<repoid>``
-    Enable specific repositories by an id or a glob.
+    Enable additional repositories by an id or a glob.
 
 ``-x <package-spec>, --exclude=<package-spec>``
     Exclude packages specified by ``<package-spec>`` from the operation.
@@ -159,6 +159,9 @@ Options
     affect cache paths, values in configuration files and mirrorlist URLs. Using
     '/' for this value makes DNF detect the release number from the running
     system.
+
+``--repo=<repoid>``
+    Enable just specific repositories by an id or a glob. Can be used multiple times with accumulative effect. It is basically shortcut for ``--disablerepo="*" --enablerepo=<repoid>`` and is mutually exclusive with ``--disablerepo`` option.
 
 ``--rpmverbosity=<debug level name>``
     debugging output level for rpm

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -21,6 +21,16 @@
 
 .. contents::
 
+======================
+Upcoming Release Notes
+======================
+
+API additions in 1.2.0:
+
+Implemented ``--repo`` :doc:`configuration <conf_ref>` option.
+
+Added set_argparse_subparser static method for defining command subparser into :doc:`Command class <api_cli>`. This is the preferred way for plugins to deal with command line arguments.
+
 ===================
 1.1.2 Release Notes
 ===================

--- a/tests/cli/test_option_parser.py
+++ b/tests/cli/test_option_parser.py
@@ -28,29 +28,31 @@ import dnf.util
 
 
 class OptionParserTest(support.TestCase):
+
+    def setUp(self):
+        self.parser = OptionParser()
+        self.ap = self.parser.argparser
+
     def test_parse(self):
-        parser = OptionParser()
-        opts, cmds = parser.parse_known_args(['update', '--nogpgcheck'])
+        opts, cmds = self.ap.parse_known_args(['update', '--nogpgcheck'])
         self.assertEqual(cmds, ['update'])
         self.assertTrue(opts.nogpgcheck)
         self.assertIsNone(opts.color)
 
     def test_configure_from_options(self):
-        parser = OptionParser()
-        opts, _ = parser.parse_known_args(['update', '-y', '--allowerasing'])
+        opts, _ = self.ap.parse_known_args(['update', '-y', '--allowerasing'])
         conf = dnf.util.Bunch()
         conf.color = 'auto'
         conf.exclude = []
         demands = dnf.util.Bunch()
-        parser.configure_from_options(opts, conf, demands, None)
+        self.parser.configure_from_options(opts, conf, demands, None)
         self.assertTrue(demands.allow_erasing)
         self.assertTrue(conf.assumeyes)
 
     def test_non_nones2dict(self):
-        parser = OptionParser()
-        values = parser.parse_args(args=['-y'])
+        values = self.ap.parse_args(args=['-y'])
         self.assertIsInstance(values, argparse.Namespace)
-        dct = parser._non_nones2dict(values.__dict__)
+        dct = self.parser._non_nones2dict(values.__dict__)
         self.assertTrue(dct['assumeyes'])
 
 
@@ -119,11 +121,11 @@ class OptionParserAddCmdTest(support.TestCase):
         self.assertEqual(self.parser._cmd_groups, set(['main', 'plugin']))
 
     def test_help_option_set(self):
-        opts, cmds = self.parser.parse_known_args(['-h'])
+        opts, cmds = self.parser.argparser.parse_known_args(['-h'])
         self.assertTrue(opts.help)
 
     def test_help_option_notset(self):
-        opts, cmds = self.parser.parse_known_args(['foo', 'bar'])
+        opts, cmds = self.parser.argparser.parse_known_args(['foo', 'bar'])
         self.assertFalse(opts.help)
 
     def test_get_usage(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -148,6 +148,7 @@ class CliTest(TestCase):
 
     def test_configure_repos(self, _):
         opts = Namespace()
+        opts.repo = []
         opts.repos_ed = [('*', 'disable'), ('comb', 'enable')]
         opts.cacheonly = True
         opts.repofrompath = {}
@@ -168,6 +169,7 @@ class CliTest(TestCase):
     def test_configure_repos_expired(self, _):
         """Ensure that --cacheonly beats the expired status."""
         opts = Namespace()
+        opts.repo = []
         opts.repos_ed = []
         opts.cacheonly = True
         opts.repofrompath = {}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -132,11 +132,19 @@ class CliTest(TestCase):
         self.cli.configure(['update', '-y'])
         self.assertTrue(self.base.conf.assumeyes)
 
-    def test_opt_between_cmds(self, _):
-        self.cli.configure(args=['install', 'pkg1', '-y', 'pkg2'])
-        self.assertTrue(self.base.conf.assumeyes)
-        self.assertEqual(self.base.basecmd, "install")
-        self.assertEqual(self.base.extcmds, ["pkg1", "pkg2"])
+    def test_glob_options_cmds(self, _):
+        params = [
+            ['install', '-y', 'pkg1', 'pkg2'],
+            ['install', 'pkg1', 'pkg2', '-y'],
+            ['-y', 'install', 'pkg1', 'pkg2']
+        ]
+        # argparser doesn't allow glob option between cmd parameters
+
+        for param in params:
+            self.cli.configure(args=param)
+            self.assertTrue(self.base.conf.assumeyes)
+            self.assertEqual(self.base.basecmd, "install")
+            self.assertEqual(self.base.extcmds, ["pkg1", "pkg2"])
 
     def test_configure_repos(self, _):
         opts = Namespace()


### PR DESCRIPTION
This is the command line parsing refactoring. I tried to make it compatible with current plugin Commands so there is still a lot of ugly compatible code remaining. 

How Commands should be using subparser can be seen in f6cf6cd or https://github.com/jsilhan/dnf-plugins-core/commit/dbac6856d53b915daff5e3673936fd154f95c05a

~~(312129e could be probably wrong for case `--enablerepo=* --disablerepo=X` but I don't like relying on order of switches either.)~~

what needs to be done:
- [ ] all commands from DNF should use subparser
- [ ] all plugins from dnf-plugins-core should use subparser
- [ ] all plugins from dnf-plugins-extras should use subparser
- [ ] system-upgrade, langpack, ...
- [ ] once finished we can use default --help and delete all other --help related stuff
- [ ] get rid of ArgumentParser in dnfpluginscore/__init__.py

next command refactoring (optional):
- [ ] get rid of demands set as Command attributes -> use `self.cli.demands`
     (there's a catch that `available_repos` are by default set to True in Command and to False in demans) 
- [ ] get rid of doCheck calls -> use config
- [ ] use ActionCallbacks for argparser whenever possible and delete additional checking
- [ ] move dnf/cli/commands.__init__.py to separate files
- [ ] once all commands are using subparser we can use nargs in --setopt, --repo, --enablerepo, --disablerepo, --exclude, --disableexcludes, --disableplugin, ...
- [ ] use argcomplete for bash completion

there's a minimal testing script of DNF parsing example https://gist.github.com/jsilhan/bebea8e389378f34dbcd (extends https://github.com/rpm-software-management/dnf/pull/185)

Opinions, @MichaelMraka , @rholy , @mluscon , @ignatenkobrain , @timlau ?