### PR TITLE
install: don't crash when terminal window is too small (RhBug:1256531)

### DIFF
--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -2120,7 +2120,7 @@ class CliTransactionDisplay(LoggingTransactionDisplay):
         self.output = True
 
         # for a progress bar
-        self.mark = "#"
+        self.mark = "="
         self.marks = 22
 
     def progress(self, package, action, ti_done, ti_total, ts_done, ts_total):

--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -2227,14 +2227,20 @@ class CliTransactionDisplay(LoggingTransactionDisplay):
             fmt = "\r  %s: %s   " + done
             wid2 = full_pnl
         elif progress:
-            bar = fmt_bar % (self.mark * int(marks * (percent / 100.0)), )
+            if marks > 5:
+                bar = fmt_bar % (self.mark * int(marks * (percent / 100.0)), )
+            else:
+                bar = ""
             fmt = "\r  %s: %s " + bar + " " + done
             wid2 = pnl
         elif percent == 100:
             fmt = "  %s: %s   " + done
             wid2 = full_pnl
         else:
-            bar = fmt_bar % (self.mark * marks, )
+            if marks > 5:
+                bar = fmt_bar % (self.mark * marks, )
+            else:
+                bar = ""
             fmt = "  %s: %s " + bar + " " + done
             wid2 = pnl
         return fmt, wid1, wid2


### PR DESCRIPTION
It was caused by the progress bar. Also mark of the progress bar was unified with downloading progress bar.