### PR TITLE
Mention the --help-cmd used for plugins

### DIFF
--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -262,7 +262,7 @@ class OptionParser(argparse.ArgumentParser):
     def get_usage(self):
         """ get the usage information to show the user. """
         desc = {'main': _('List of Main Commands'),
-                'plugin': _('List of Plugin Commands')}
+                'plugin': _('List of Plugin Commands\n\nuse dnf PLUGIN --help-cmd for more info')}
         name = dnf.const.PROGRAM_NAME
         usage = '%s [options] COMMAND\n' % name
         for grp in ['main', 'plugin']:


### PR DESCRIPTION
Otherwise it is not immediately clear how to get help for the plugins and doing `dnf PLUGIN --help` shows the main help screen.