### PR TITLE
Replace assert_called() with assert_called_with() for Py35 support

### DIFF
--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -353,7 +353,7 @@ class LocalRepoTest(support.TestCase):
             self.assertTrue(self.repo.load())
         self.assertTrue(remote_handle_m.fetchmirrors)
         self.assertFalse(self.repo._expired)
-        reset_age_m.assert_called()
+        reset_age_m.assert_called_with()
 
     @mock.patch.object(dnf.repo.Metadata, 'reset_age')
     @mock.patch('dnf.repo.Repo._handle_new_remote')


### PR DESCRIPTION
mock in Python 3.5 doesn't support assert_called(), which causes this test to fail. Changing it to assert_called_with() fixes this and appears to still work with Python 2 and earlier versions in Python 3.3 and Python 3.4.