### PR TITLE
Allow setting options on temporary repos from the command line

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -745,6 +745,13 @@ class Cli(object):
                 self.base.repos.add(repofp)
                 logger.info(_("Added %s repo from %s") % (label, path))
 
+                if label in self.repo_setopts:
+                    for opt in self.repo_setopts[label].items:
+                        if not hasattr(repofp, opt):
+                            msg = "Repo %s did not have a %s attr. before setopt"
+                            logger.warning(msg, label, opt)
+                        setattr(repofp, opt, getattr(self.repo_setopts[label], opt))
+
         # Process repo enables and disables in order
         try:
             for (repo, operation) in opts.repos_ed:


### PR DESCRIPTION
The --setopt=repoid.option=... options are handled before the --repofrompath=repoid,... options, so the temporary repositories don't pick up any of those additional settings.  Here is an example patch that allows configuring temporary repos with --setopt.  Could this (or equivalent functionality) be included in a future release?