### PR TITLE
format the email message with its as_string method

### DIFF
--- a/dnf/automatic/emitter.py
+++ b/dnf/automatic/emitter.py
@@ -97,7 +97,7 @@ class EmailEmitter(Emitter):
         # Send the email
         try:
             smtp = smtplib.SMTP(self._conf.email_host)
-            smtp.sendmail(email_from, email_to, str(message))
+            smtp.sendmail(email_from, email_to, message.as_string())
             smtp.close()
         except smtplib.SMTPException as exc:
             msg = _("Failed to send an email via '%s': %s") % (


### PR DESCRIPTION
otherwise `str()` includes the envelope header but this is already taken care of by `sendmail()`

fixes [RH bug #1269770](https://bugzilla.redhat.com/show_bug.cgi?id=1269770)