### PR TITLE
cli: don't crash if y/n and sys.stdin is None

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -248,7 +248,7 @@ class BaseCli(dnf.Base):
 
             elif result == 1:
                 ay = self.conf.assumeyes and not self.conf.assumeno
-                if not sys.stdin.isatty() and not ay:
+                if (not sys.stdin or not sys.stdin.isatty()) and not ay:
                     raise dnf.exceptions.Error(_('Refusing to automatically import keys when running ' \
                             'unattended.\nUse "-y" to override.'))
 


### PR DESCRIPTION
Per https://bugzilla.redhat.com/show_bug.cgi?id=1278382 , if
sys.stdin is somehow None (which currently seems to be the case
when a dnf command is run in virt-builder) and a dnf command
leads to a y/n question, dnf will crash. This should fix it.