### PR TITLE
Have rpm2cpio use rpm libraries for decompression

### DIFF
--- a/dnf/rpm/miscutils.py
+++ b/dnf/rpm/miscutils.py
@@ -17,7 +17,6 @@ from __future__ import print_function, absolute_import
 from __future__ import unicode_literals
 import dnf.pycomp
 import rpm
-import gzip
 import os
 import sys
 import locale
@@ -148,13 +147,7 @@ def rpm2cpio(fdno, out=sys.stdout, bufsize=2048):
     del ts
 
     compr = hdr[rpm.RPMTAG_PAYLOADCOMPRESSOR] or 'gzip'
-    #XXX FIXME
-    #if compr == 'bzip2':
-        # TODO: someone implement me!
-    #el
-    if compr != 'gzip':
-        raise RpmUtilsError('Unsupported payload compressor: "%s"' % compr)
-    f = gzip.GzipFile(None, 'rb', None, os.fdopen(fdno, 'rb', bufsize))
+    f = rpm.fd.open(fdno, 'r', compr)
     while 1:
         tmp = f.read(bufsize)
         if tmp == "": break


### PR DESCRIPTION
Use the same method RPM uses to access package files.