### PR TITLE
Support for braces in substitution

### DIFF
--- a/dnf/conf/parser.py
+++ b/dnf/conf/parser.py
@@ -25,7 +25,7 @@ import dnf.util
 import os.path
 import re
 
-_KEYCRE = re.compile(r"\$(\w+)")
+_KEYCRE = re.compile(r"\$(\w+)|\${(\w+)}")
 
 
 def substitute(raw, substs):
@@ -47,7 +47,7 @@ def substitute(raw, substs):
 
         # Determine replacement value (if unknown variable then preserve
         # original)
-        varname = m.group(1).lower()
+        varname = m.group(2).lower() if m.group(2) else m.group(1)
         replacement = substs.get(varname, m.group())
 
         start, end = m.span()

--- a/tests/conf/test_parser.py
+++ b/tests/conf/test_parser.py
@@ -23,6 +23,15 @@ import dnf.conf.parser
 class SubstituteTest(tests.support.TestCase):
     def test_read(self):
         substs = {'lies' : 'fact'}
+        # Test a single word without braces
         rawstr = '$Substitute some $lies.'
-        self.assertEqual(dnf.conf.parser.substitute(rawstr, substs),
-                         '$Substitute some fact.')
+        result = '$Substitute some fact.'
+        self.assertEqual(substitute(rawstr, substs), result)
+        # And with braces
+        rawstr = '$Substitute some ${lies}.'
+        self.assertEqual(substitute(rawstr, substs), result)
+
+        # Test a word with braces without space
+        rawstr = '$Substitute some ${lies}withoutspace.'
+        result = '$Substitute some factwithoutspace.'
+        self.assertEqual(substitute(rawstr, substs), result)

--- a/tests/conf/test_parser.py
+++ b/tests/conf/test_parser.py
@@ -35,3 +35,13 @@ class SubstituteTest(tests.support.TestCase):
         rawstr = '$Substitute some ${lies}withoutspace.'
         result = '$Substitute some factwithoutspace.'
         self.assertEqual(substitute(rawstr, substs), result)
+
+        # Tests a single brace before (no substitution)
+        rawstr = '$Substitute some ${lieswithoutspace.'
+        result = '$Substitute some ${lieswithoutspace.'
+        self.assertEqual(substitute(rawstr, substs), result)
+
+        # Tests a single brace after (substitution and leave the brace)
+        rawstr = '$Substitute some $lies}withoutspace.'
+        result = '$Substitute some fact}withoutspace.'
+        self.assertEqual(substitute(rawstr, substs), result)


### PR DESCRIPTION
The existing substitution didn't support barces which prevented use
in some cases. This change adds a second match in the regex to
handle braces and adds additional tests to verify that it is
working as expected.
See https://lists.fedoraproject.org/pipermail/devel/2015-October/215924.html