### PR TITLE
Change default email address in automatic.conf (RhBug:1278592)

### DIFF
--- a/etc/dnf/automatic.conf
+++ b/etc/dnf/automatic.conf
@@ -35,7 +35,7 @@ output_width = 80
 
 [email]
 # The address to send email messages from.
-email_from = root@localhost.com
+email_from = root@example.com
 
 # List of addresses to send messages to.
 email_to = root


### PR DESCRIPTION
The default email address was changed to more common example email.