### PR TITLE
Remove -OO from #!/usr/bin/python

### DIFF
--- a/bin/dnf-2
+++ b/bin/dnf-2
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/python
 # The dnf executable script.
 #
 # Copyright (C) 2012-2014 Red Hat, Inc.

--- a/bin/dnf-3
+++ b/bin/dnf-3
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -OO
+#!/usr/bin/python3
 # The dnf executable script.
 #
 # Copyright (C) 2014 Red Hat, Inc.

--- a/bin/dnf-automatic-2
+++ b/bin/dnf-automatic-2
@@ -1,4 +1,4 @@
-#!/usr/bin/python -OO
+#!/usr/bin/python
 # dnf-automatic executable.
 #
 # Copyright (C) 2014 Red Hat, Inc.

--- a/bin/dnf-automatic-3
+++ b/bin/dnf-automatic-3
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -OO
+#!/usr/bin/python3
 # dnf-automatic executable.
 #
 # Copyright (C) 2014 Red Hat, Inc.


### PR DESCRIPTION
To prevent an incidents with .pyo files -OO options was removed.