### PR TITLE
Some dnf-automatic documentation improvements

### DIFF
--- a/doc/automatic.rst
+++ b/doc/automatic.rst
@@ -80,7 +80,7 @@ Choosing how the results should be reported.
 ``emit_via``
     list, default: ``email, stdio, motd``
 
-    List of emitters to report the results through. Available emitters are ``stdio`` to print the result to standard output, ``email`` to send the report via email and ``motd`` sends the result to */etc/motd* file. If emit_via is ``None``, no messages will be sent.
+    List of emitters to report the results through. Available emitters are ``stdio`` to print the result to standard output, ``email`` to send the report via email and ``motd`` sends the result to */etc/motd* file.
 
 ``system_name``
     string, default: hostname of the given system

--- a/doc/automatic.rst
+++ b/doc/automatic.rst
@@ -80,12 +80,17 @@ Choosing how the results should be reported.
 ``emit_via``
     list, default: ``email, stdio, motd``
 
-    List of emitters to report the results through. Available emitters are ``stdio`` to print the result to standard output, ``email`` to send the report via email and ``motd`` sends the result to */etc/motd* file.
+    List of emitters to report the results through. Available emitters are ``stdio`` to print the result to standard output, ``email`` to send the report via email and ``motd`` sends the result to */etc/motd* file. If emit_via is ``None``, no messages will be sent.
 
 ``system_name``
     string, default: hostname of the given system
 
     How the system is called in the reports.
+
+``output_width``
+    number, default: 80
+
+    The width, in characters, that messages that are emitted should be formatted to.
 
 -------------------
 ``[email]`` section
@@ -112,7 +117,7 @@ The email emitter configuration.
 ``[base]`` section
 ------------------
 
-Can be used to override settings from DNF's main configuration file. See :doc:`command_ref`.
+Can be used to override settings from DNF's main configuration file. See :doc:`conf_ref`.
 
 ===================
  Run dnf-automatic

--- a/etc/dnf/automatic.conf
+++ b/etc/dnf/automatic.conf
@@ -24,7 +24,6 @@ apply_updates = no
 # to have cron send the messages.  If emit_via includes email, this
 # program will send email itself according to the configured options.
 # If emit_via includes motd, /etc/motd file will have the messages.
-# If emit_via is None or left blank, no messages will be sent.
 # Default is email,stdio.
 emit_via = stdio
 


### PR DESCRIPTION
* mentioned that None is a possible value of emit_via if one wants to suppress output
* documented option output_width
* link to overridable base settings should point to configuration reference, not to command reference