### PR TITLE
Remove settings from automatic.conf and change documentation

### DIFF
--- a/doc/automatic.rst
+++ b/doc/automatic.rst
@@ -112,7 +112,7 @@ The email emitter configuration.
 ``[base]`` section
 ------------------
 
-Can be used to override settings from DNF's main configuration file. See :doc:`command_ref`.
+Can be used to override settings from DNF's main configuration file. See :doc:`conf_ref`.
 
 ===================
  Run dnf-automatic

--- a/etc/dnf/automatic.conf
+++ b/etc/dnf/automatic.conf
@@ -24,13 +24,8 @@ apply_updates = no
 # to have cron send the messages.  If emit_via includes email, this
 # program will send email itself according to the configured options.
 # If emit_via includes motd, /etc/motd file will have the messages.
-# If emit_via is None or left blank, no messages will be sent.
 # Default is email,stdio.
 emit_via = stdio
-
-# The width, in characters, that messages that are emitted should be
-# formatted to.
-output_width = 80
 
 
 [email]


### PR DESCRIPTION
Unused setting None for email emitter was remove. Also output_with for emails
formatting was removed for same reason.

 Minor change represented by exchange of reference in Base section in
 documentation for automatic.