### PR TITLE
Change order of searched default repo directory (RhBug:1286477)

### DIFF
--- a/dnf/yum/config.py
+++ b/dnf/yum/config.py
@@ -738,7 +738,7 @@ class YumConf(BaseConfig):
 
     keepcache = BoolOption(False)
     logdir = Option('/var/log') # :api
-    reposdir = ListOption(['/etc/yum/repos.d', '/etc/yum.repos.d']) # :api
+    reposdir = ListOption(['/etc/yum.repos.d', '/etc/yum/repos.d'])  # :api
 
     debug_solver = BoolOption(False)
 


### PR DESCRIPTION
When dnf looks for repo directory, it first check /etc/yum.repo.d/ for presence.

When /etc/yum.repo.d/ and /etc/yum/repo.d/ not present it will created
/etc/yum.repo.d/ directory if new repo with dnf config-manager is created.