### PR TITLE
Add new option mandatory-only for group install plus doc changes

### DIFF
--- a/dnf/cli/commands/group.py
+++ b/dnf/cli/commands/group.py
@@ -74,7 +74,11 @@ class GroupCommand(commands.Command):
         if extcmds[0] == 'with-optional':
             types = tuple(dnf.const.GROUP_PACKAGE_TYPES + ('optional',))
             return types, extcmds[1:]
-        return dnf.const.GROUP_PACKAGE_TYPES, extcmds
+        elif extcmds[0] == 'mandatory-only':
+            types = ('mandatory',)
+            return types, extcmds[1:]
+        else:
+            return dnf.const.GROUP_PACKAGE_TYPES, extcmds
 
     @classmethod
     def canonical(cls, command_list):

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -307,8 +307,8 @@ Groups are virtual collections of packages. DNF keeps track of groups that the u
     Display package lists of a group. Shows which packages are installed or
     available from a repo when ``-v`` is used.
 
-``dnf [options] group install [with-optional] <group-spec>...``
-    Mark the specified group installed and install packages it contains. Also include optional packages of the group if ``with-optional`` is specified.
+``dnf [options] group install [install-option] <group-spec>...``
+    Mark the specified group installed and install packages it contains (mandatory and defaults). If [install-option] is specified with ``mandatory-only``, it installs only mandatory packages. If [install-option] is specified with ``with-optional``, it also includes optional packages of the group.
 
 .. _grouplist_command-label:
 


### PR DESCRIPTION
The new option allowed to install only mandatory packages for group install.
The documentation was also changed to describe new option