### PR TITLE
Add description of --skip-brokem replacement for install command

### DIFF
--- a/doc/cli_vs_yum.rst
+++ b/doc/cli_vs_yum.rst
@@ -20,16 +20,27 @@
 ####################################
 
 .. only :: html
-    
+
     .. contents::
 
 ======================
  No ``--skip-broken``
 ======================
 
-The ``--skip-broken`` command line switch is not recognized by DNF. The
-semantics this was supposed to trigger in Yum is now the default for plain ``dnf
-update``. There is no equivalent for ``yum --skip-broken update foo``, as
+The ``--skip-broken`` command line switch is not recognized by DNF.
+
+For install command:
+
+Instead of ``--skip-broken``, the new option ``--setopt=strict=0`` could be used
+with DNF to skip all unavailable packages or packages with broken dependencies
+given to DNF command without raising the error causing the whole operation to
+fail. This behavior can be set as default in dnf.conf file. See :ref:`strict
+conf option <strict-label>`.
+
+For upgrade command:
+
+The semantics this was supposed to trigger in Yum is now the default for plain
+``dnf update``. There is no equivalent for ``yum --skip-broken update foo``, as
 silently skipping ``foo`` in this case only amounts to masking an error
 contradicting the user request. To try using the latest versions of packages in
 transactions there is the ``--best`` command line switch.

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -189,7 +189,7 @@ or :ref:`mirrorlist <mirrorlist-label>` option definition.
 ``name``
     :ref:`string <string-label>`
 
-    A human-readable name of the repository. Defaults to the ID of the repository. 
+    A human-readable name of the repository. Defaults to the ID of the repository.
 
 .. _repo_priority-label:
 
@@ -204,6 +204,8 @@ or :ref:`mirrorlist <mirrorlist-label>` option definition.
     :ref:`boolean <boolean-label>`
 
     If enabled, DNF will continue running and disable the repository that couldn't be contacted for any reason when downloading metadata. This option doesn't affect skipping of unavailable packages after dependency resolution. To check inaccessibility of repository use it in combination with :ref:`refresh command line option <refresh_command-label>`. The default is True.
+
+.. _strict-label:
 
 ``strict``
     :ref:`boolean <boolean-label>`


### PR DESCRIPTION
It describe replacement of yum --skip-brokem install command in DNF including
reference to strict option in conf file.