### PR TITLE
Change order of search and add new default repodirs (RhBug:1286477)

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -174,6 +174,9 @@ mv $RPM_BUILD_ROOT%{_bindir}/dnf-automatic-2 $RPM_BUILD_ROOT%{_bindir}/dnf-autom
 rm $RPM_BUILD_ROOT%{_bindir}/dnf-automatic-3
 %endif
 
+# This will eventually be the new default location for repo files
+mkdir $RPM_BUILD_ROOT%{_sysconfdir}/distro.repos.d
+
 %check
 make ARGS="-V" test
 pushd py3
@@ -190,6 +193,7 @@ popd
 %{_unitdir}/dnf-makecache.service
 %{_unitdir}/dnf-makecache.timer
 %{_var}/cache/dnf
+%ghost %{_sysconfdir}/distro.repos.d
 
 %files conf
 %license COPYING PACKAGE-LICENSING

--- a/dnf/yum/config.py
+++ b/dnf/yum/config.py
@@ -738,7 +738,7 @@ class YumConf(BaseConfig):
 
     keepcache = BoolOption(False)
     logdir = Option('/var/log') # :api
-    reposdir = ListOption(['/etc/yum/repos.d', '/etc/yum.repos.d']) # :api
+    reposdir = ListOption(['/etc/yum.repos.d', '/etc/yum/repos.d', '/etc/distro.repos.d']) # :api
 
     debug_solver = BoolOption(False)
 


### PR DESCRIPTION
This PR is based on the fix from #406

Currently, DNF checks `/etc/yum/repos.d` and then `/etc/yum/repos.d` for repo configuration data. However, neither of these directories are owned by DNF and in the event neither exist, it winds up creating `/etc/yum/repos.d`, which could create issues depending on how a distribution is packaging the repo data.

To correct this issue, the search paths is altered to include new locations: ~~`/etc/dnf/repos.d` and~~ ~~`/etc/dnf.repos.d`~~ `/etc/distro.repos.d`.

The search order has been altered to include those two in that particular order, with then `/etc/yum.repos.d` and `/etc/yum/repos.d` directories listed ~~after~~ before them.

~~This ensures that in the event that none of the directories exist, DNF will opt to create `/etc/dnf/repos.d`, a directory that would exist within a directory the DNF package already owns.~~

Note, this PR replaces #406  