### PR TITLE
Filter out .src packages when multilib_proto=all

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1413,7 +1413,7 @@ class Base(object):
         subj = dnf.subject.Subject(pkg_spec)
         if self.conf.multilib_policy == "all" or \
            subj.is_arch_specified(self.sack):
-            q = subj.get_best_query(self.sack)
+            q = subj.get_best_query(self.sack).filter(arch__neq="src")
             if reponame is not None:
                 q = q.filter(reponame=reponame)
             if not q:


### PR DESCRIPTION
In the case where multilib_proto is 'all' and source repos have been
enabled, source packages may be marked for install and subsequently fail
with an error.  So we need to filter out source packages in this case.