### PR TITLE
cli: fix storing arguments in history (RhBug:1239274)

### DIFF
--- a/dnf/cli/main.py
+++ b/dnf/cli/main.py
@@ -90,7 +90,7 @@ def _main(base, args):
     # do our cli parsing and config file setup
     # also sanity check the things being passed on the cli
     try:
-        cli.configure(map(ucd, args))
+        cli.configure(list(map(ucd, args)))
         cli.check()
     except dnf.exceptions.LockError:
         raise


### PR DESCRIPTION
argument for dnf.cli.configure() should be list, not map.
In python 2 map() returns list, but in python3 it is not the same, so
let's use list().

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1239274
Reported-by: Vít Ondruch <vondruch@redhat.com>
Tested-by: Daniele Viganò <dennyvatwork@gmail.com>
Tested-by: Vinicius Reis <angiolucci@gmail.com>
Tested-by: Martin Mézl <mezlm@seznam.cz>
Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>