### PR TITLE
Allow dnf to use a socks5 proxy, since curl support it

### DIFF
--- a/dnf/yum/config.py
+++ b/dnf/yum/config.py
@@ -745,7 +745,7 @@ class YumConf(BaseConfig):
     exclude = ListOption()
     include = ListOption()
     fastestmirror = BoolOption(False)
-    proxy = UrlOption(schemes=('http', 'ftp', 'https'), allow_none=True) #:api
+    proxy = UrlOption(schemes=('http', 'ftp', 'https', 'socks5', 'socks5h', 'socks4', 'socks4a'), allow_none=True) #:api
     proxy_username = Option() #:api
     proxy_password = Option() #:api
     username = Option() #:api


### PR DESCRIPTION
While they are not used often, socks proxy still exist in the wild.
Another big user of the socks proxotol is tor, so this modification
permit to use dnf over tor, with the intent of protecting people from
inference against what kind of packages they do use, as seen on
http://people.skolelinux.org/pere/blog/Always_download_Debian_packages_using_Tor___the_simple_recipe.html