### PR TITLE
Use short package name for bash completion

### DIFF
--- a/etc/bash_completion.d/dnf
+++ b/etc/bash_completion.d/dnf
@@ -103,7 +103,7 @@ _dnf()
             install|update|upgrade|reinstall|info)
                 if ! _is_path "$cur"; then
                     if [ -r $cache_file ] && ! _modified_sack words[@]; then
-                        COMPREPLY=( $( compgen -W '$( $sqlite3 $cache_file "select pkg from available WHERE pkg LIKE \"$cur%\"" 2>/dev/null )' ) )
+                        COMPREPLY=( $( compgen -W '$( $sqlite3 $cache_file "select pkg from available WHERE pkg LIKE \"$cur%\"" | awk "BEGIN { FS=\"-\";OFS=\"-\"} {print} {NF-=2;$1=$1;print}" 2>/dev/null )' ) )
                     else
                         _dnf_helper $command "$cur"
                     fi


### PR DESCRIPTION
Right now to complete the name of a package you only get the full name (version/architecture), the completion engine should give you the option to use the short name as well:

[510][aruiz@raynor ~/src/dnf]$ dnf install foo
foo2hbpl
foo2hbpl-0.20151111-3.fc23.x86_64
foo2hbpl2
foo2hbpl2-0.20130618-2.fc22.i686
foo2hbpl2-0.20130618-2.fc22.x86_64
foo2hiperc
foo2hiperc-0.20130618-2.fc22.i686
foo2hiperc-0.20130618-2.fc22.x86_64
foo2hiperc-0.20151111-3.fc23.x86_64
...

I've tested this for speed and the awk script doesn't add a problematic amount of overhead in my system, these queries still run at <500ms speed.