### PR TITLE
Always read default fs vars

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -73,6 +73,7 @@ DNF CONTRIBUTORS
     Neal Gompa <ngompa13@gmail.com>
     Olivier Andrieu <olivier.andrieu@esterel-technologies.com>
     Padraig Brady <P@draigBrady.com>
+    Pat Riehecky <riehecky@fnal.gov>
     Peter Hjalmarsson <kanelxake@gmail.com>
     Peter Simonyi <pts@petersimonyi.ca>
     Petr Spacek <pspacek@redhat.com>

--- a/dnf/conf/substitutions.py
+++ b/dnf/conf/substitutions.py
@@ -31,6 +31,7 @@ class Substitutions(dict):
         arch = hawkey.detect_arch()
         self['arch'] = arch
         self['basearch'] = dnf.arch.basearch(arch)
+        self.update_from_etc('/')
         self._update_from_env()
 
     def _update_from_env(self):


### PR DESCRIPTION
This patch sets dnf to read /etc/dnf/vars even if installroot is some other path.  This easily allows special vars set in /etc/dnf/vars to be used for setting up an alternate install root.

RhBug:1304036