### PR TITLE
Fix GPG signature check (RhBug:1297087)

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -943,7 +943,7 @@ class Base(object):
               2 = Fatal GPG verification error, give up.
         """
         if po.from_cmdline:
-            check = self.conf.localpkg_gpgcheck
+            check = self.conf.gpgcheck
             hasgpgkey = 0
         else:
             repo = self.repos[po.repoid]

--- a/dnf/yum/config.py
+++ b/dnf/yum/config.py
@@ -765,7 +765,6 @@ class YumConf(BaseConfig):
     diskspacecheck = BoolOption(True)
     gpgcheck = BoolOption(False)
     repo_gpgcheck = BoolOption(False)
-    localpkg_gpgcheck = BoolOption(False)
     obsoletes = BoolOption(True)
     showdupesfromrepos = BoolOption(False)
     enabled = BoolOption(True)


### PR DESCRIPTION
This doesn't completely fix [bug 1277087](https://bugzilla.redhat.com/show_bug.cgi?id=1297087). It appears there are actually two separate issues described by the two sets of reproducibility steps. This pull request fixes the first, where the signature check is skipped because the wrong variable is used to determine whether or not to check signatures. Variable *localpkg_gpgcheck* from the *YumConf* class is used instead of *gpgcheck*. The former defaults to False and doesn't get updated again while the latter is what gets updated when reading the */etc/dnf/dnf.conf* file.

The second issue is a possible error when checking the actual signature and, from what I could tell, it's somewhere in RPM. The call to *hdrFromFdno()* in [DNF](https://github.com/rpm-software-management/dnf/blob/2803fe91df417b7dcd3fdfaf06f55f2938775f0f/dnf/rpm/miscutils.py#L64) gets passed to [RPM](https://github.com/rpm-software-management/rpm/blob/73ea59e0d53503bb45d5eac9d9792127a6d04c23/python/rpm/transaction.py#L167), which is where the signature is verified.