### PR TITLE
output: don't show recommended packages as packages with conflicts (R…

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -1,4 +1,4 @@
-%global hawkey_version 0.6.1
+%global hawkey_version 0.7.0
 %global librepo_version 1.7.16
 %global libcomps_version 0.1.6
 %global rpm_version 4.12.0

--- a/dnf/goal.py
+++ b/dnf/goal.py
@@ -83,7 +83,8 @@ class Goal(hawkey.Goal):
         return res
 
     def available_updates_diff(self, query):
-        available_updates = set(query.upgrades().latest().run())
+        available_updates = set(query.upgrades().filter(arch__neq="src")
+                                .latest().run())
         installable_updates = set(self.list_upgrades())
         installs = set(self.list_installs())
         return (available_updates - installable_updates) - installs

--- a/dnf/goal.py
+++ b/dnf/goal.py
@@ -67,7 +67,10 @@ class Goal(hawkey.Goal):
 
         pkgs_run1 = set(self.list_upgrades()).union(set(self.list_installs()))
         ng = deepcopy(self)
-        if not ng.run(allow_uninstall=True, force_best=True):
+        params = {"allow_uninstall": True, "force_best": True}
+        if hawkey.IGNORE_WEAK_DEPS in self.actions:
+            params["ignore_weak_deps"] = True
+        if not ng.run(**params):
             return map(lambda p: (p, None), pkgs_run1)
         pkgs_run2 = set(ng.list_upgrades()).union(set(ng.list_installs()))
         pkgs_diff_run1 = pkgs_run1 - pkgs_run2


### PR DESCRIPTION
…hBug:1303991)

Packages with weak dependencies not pulled into transaction when install_weak_deps is set to False were shown in "Skipping packages with conflicts section". Not they are excluded from this section.

there needs to be a change in libhif too.