### PR TITLE
Correct and add detail to the build instructions in the README

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -68,6 +68,7 @@ DNF CONTRIBUTORS
     Haïkel Guémar <haikel.guemar@gmail.com>
     Kevin Kofler <kevin.kofler@chello.at>
     Kushal Das <kushaldas@gmail.com>
+    Matt Sturgeon <matt@sturgeon.me.uk
     Matthew Miller <mattdm@mattdm.org>
     Michael Scherer <misc@redhat.com>
     Neal Gompa <ngompa13@gmail.com>

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,13 @@ sources.
  Building from source
 ======================
 
-From the DNF git checkout directory::
+All commands should be run from the DNF git checkout directory.
+
+To install the build dependancies::
+
+    sudo dnf builddep dnf.spec
+
+To build DNF::
 
     mkdir build;
     pushd build;
@@ -41,6 +47,12 @@ To run DNF when compiled for Python2::
 To run DNF when compiled for Python3::
 
     PYTHONPATH=`readlink -f .` bin/dnf-3 <arguments>
+
+If you want to build the manpages, use the option ``-DWITH_MAN=0`` with cmake.
+
+Man pages will be located in ``build/doc`` and can be read with ``man -l``, e.g::
+
+    man -l build/doc/dnf.8
 
 =============================
  Building and installing rpm


### PR DESCRIPTION
The previous build instructions in the `README` instructed the user to run `bin/dnf` when actually `bin/dnf-2` or `bin/dnf-3` is the correct command.

I've also added a few other changes, including instructions on using `dnf.spec` to install the build dependencies and how to build the manpages.