### PR TITLE
Add `defaultyes` to the docs (RhBug:1289164)

### DIFF
--- a/doc/api_conf.rst
+++ b/doc/api_conf.rst
@@ -44,6 +44,11 @@ Configurable settings of the :class:`dnf.Base` object are stored into a :class:`
 
     Debug messages output level, in the range 0 to 10. Default is 2.
 
+
+  .. attribute::defaultyes
+
+    Like ``assumeyes`` but will still prompt for confirmation. The default is ``False``.
+
   .. attribute:: installonly_limit
 
     An integer to limit the number of installed installonly packages (packages that do not upgrade, instead few versions are installed in parallel). Defaults to ``0``, that is the limiting is disabled.

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -76,6 +76,12 @@ or :ref:`mirrorlist <mirrorlist-label>` option definition.
     Debug messages output level, in the range 0 to 10. The higher the number the
     more debug output is put to stdout. Default is 2.
 
+
+``defaultyes``
+    :ref:`boolean <boolean-label>`
+
+    Like ``assumeyes`` but will still prompt for confirmation. The default is False.
+
 ``errorlevel``
     :ref:`integer <integer-label>`
 


### PR DESCRIPTION
`defaultyes` (introduced in f79fd1eced64ffdec7865f5128217ee6d46d15af) switches the confirmation prompt from `[y/N]` to `[Y/n]` and was previously undocumented.

This should help towards (RhBug:1289164)