### PR TITLE
Add `defaultyes` to the docs and implement cli options (RhBug:1289164)

### DIFF
--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -61,7 +61,7 @@ class OptionParser(argparse.ArgumentParser):
     def configure_from_options(self, opts, conf, demands, output):
         """Configure parts of CLI from the opts. """
 
-        options_to_move = ('best', 'assumeyes', 'assumeno',
+        options_to_move = ('best', 'assumeyes', 'assumeno', 'defaultyes', 'defaultno',
                            'showdupesfromrepos', 'plugins', 'ip_resolve',
                            'rpmverbosity', 'disable_excludes')
 
@@ -183,9 +183,13 @@ class OptionParser(argparse.ArgumentParser):
         self.add_argument("-v", "--verbose", action="store_true",
                            default=None, help=_("verbose operation"))
         self.add_argument("-y", "--assumeyes", action="store_true",
-                           default=None, help=_("answer yes for all questions"))
+                           default=None, help=_("automatically answer yes for all questions"))
         self.add_argument("--assumeno", action="store_true",
-                           default=None, help=_("answer no for all questions"))
+                           default=None, help=_("automatically answer no for all questions"))
+        self.add_argument("--defaultyes", action="store_true",
+                           default=None, help=_("set the default answer to yes for all questions"))
+        self.add_argument("--defaultno", action="store_true",
+                           default=None, help=_("set the default answer to no for all questions"))
         self.add_argument("--version", action="store_true", default=None,
                            help=_("show DNF version and exit"))
         self.add_argument("--installroot", help=_("set install root"),

--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -622,10 +622,11 @@ class Output(object):
         yui = (ucd(_('y')), ucd(_('yes')))
         nui = (ucd(_('n')), ucd(_('no')))
         aui = yui + nui
+        defaultyes = not self.conf.defaultno and self.conf.defaultyes
         while True:
             msg = _('Is this ok [y/N]: ')
             choice = ''
-            if self.conf.defaultyes:
+            if defaultyes:
                 msg = _('Is this ok [Y/n]: ')
             try:
                 choice = dnf.i18n.ucd_input(msg)
@@ -635,7 +636,7 @@ class Output(object):
                 choice = nui[0]
             choice = ucd(choice).lower()
             if len(choice) == 0:
-                choice = yui[0] if self.conf.defaultyes else nui[0]
+                choice = yui[0] if defaultyes else nui[0]
             if choice in aui:
                 break
 

--- a/dnf/yum/config.py
+++ b/dnf/yum/config.py
@@ -761,6 +761,7 @@ class YumConf(BaseConfig):
     assumeyes = BoolOption(False)  # :api
     assumeno = BoolOption(False)
     defaultyes = BoolOption(False)
+    defaultno = BoolOption(False)
     alwaysprompt = BoolOption(True)
     diskspacecheck = BoolOption(True)
     gpgcheck = BoolOption(False)

--- a/doc/api_conf.rst
+++ b/doc/api_conf.rst
@@ -27,6 +27,11 @@ Configurable settings of the :class:`dnf.Base` object are stored into a :class:`
 
     Boolean option, if set to ``True`` on any user input asking for confirmation
     (e.g. after transaction summary) the answer is implicitly ``yes``. Default is ``False``.
+
+  .. attribute:: assumeno
+
+    Boolean option, if set to ``True`` on any user input asking for confirmation
+    (e.g. after transaction summary) the answer is implicitly ``no``. This option will override ``assumeyes`` and should be used with caution. Default is ``False``.
   
   .. attribute:: best
 
@@ -43,6 +48,18 @@ Configurable settings of the :class:`dnf.Base` object are stored into a :class:`
   .. attribute:: debuglevel
 
     Debug messages output level, in the range 0 to 10. Default is 2.
+
+
+  .. attribute::defaultyes
+
+    Boolean option, if set to ``True`` on any user input asking for confirmation
+    (e.g. after transaction summary) the default answer is ``yes``. The default is ``False``.
+
+  .. attribute:: defaultno
+
+    Boolean option, if set to ``True`` on any user input asking for confirmation
+    (e.g. after transaction summary) the default answer is ``no``. This option will override ``defaultyes`` and should be used with caution. Default is ``False``.
+  
 
   .. attribute:: installonly_limit
 

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -89,7 +89,7 @@ Options
     Allow erasing of installed packages to resolve dependencies. This option could be used as an alternative to ``yum swap`` command where packages to remove are not explicitly defined.
 
 ``--assumeno``
-    answer no for all questions
+    Automatically answer no for all questions
 
 ``-b, --best``
     Try the best available package versions in transactions. Specifically during ``dnf upgrade``, which by default skips over updates that can not be installed for dependency reasons, the switch forces DNF to only consider the latest packages and possibly fail giving a reason why the latest version can not be installed.
@@ -107,6 +107,12 @@ Options
 
 ``--debugsolver``
     Dump data aiding in dependency solver debugging into ``./debugdata``.
+
+``--defaultno``
+    Set the default answer to no for all questions. Will override ``--defaultyes``.
+
+``--defaultyes``
+    Set the default answer to yes for all questions.
 
 ``--disableexcludes=[all|main|<repoid>]``
 
@@ -189,7 +195,7 @@ Options
     show DNF version and exit
 
 ``-y, --assumeyes``
-    answer yes for all questions
+    Automatically answer yes for all questions
 
 List options are comma separated. Command-line options override respective settings from configuration files.
 

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -49,7 +49,8 @@ or :ref:`mirrorlist <mirrorlist-label>` option definition.
 ``assumeyes``
     :ref:`boolean <boolean-label>`
 
-    If enabled then on any user input asking for confirmation (e.g. after transaction summary) the answer is implicitly ``yes``. The default is False.
+    If enabled ``dnf`` will assume ``Yes`` where it would normally prompt for
+    confirmation from user input (see also ``defaultyes``). Default is False.
 
 ``best``
     :ref:`boolean <boolean-label>`
@@ -75,6 +76,13 @@ or :ref:`mirrorlist <mirrorlist-label>` option definition.
 
     Debug messages output level, in the range 0 to 10. The higher the number the
     more debug output is put to stdout. Default is 2.
+
+
+``defaultyes``
+    :ref:`boolean <boolean-label>`
+
+    If enabled the default answer to user confirmation prompts will be ``Yes``. Not
+    to be confused with ``assumeyes`` which will not prompt at all. Default is False.
 
 ``errorlevel``
     :ref:`integer <integer-label>`


### PR DESCRIPTION
_See also #447 and my commit message here d7e5d448c89eba54577dcbf136cc160b73e0a784_

I've added `--defaultyes` and `--defaultno` cli options to complement `defaultyes` added in f79fd1eced64ffdec7865f5128217ee6d46d15af

I have also added documentation for the cli options, the `dnf.conf` options (excluding `assumeno` and `defaultno`) and the API properties these options actually affect.

Apologies for opening a new PR. I felt it was a cleaner option since the original was intended only to update the docs.