### PR TITLE
Defaultyes docs

### DIFF
--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -183,9 +183,9 @@ class OptionParser(argparse.ArgumentParser):
         self.add_argument("-v", "--verbose", action="store_true",
                            default=None, help=_("verbose operation"))
         self.add_argument("-y", "--assumeyes", action="store_true",
-                           default=None, help=_("answer yes for all questions"))
+                           default=None, help=_("Automatically answer yes for all questions"))
         self.add_argument("--assumeno", action="store_true",
-                           default=None, help=_("answer no for all questions"))
+                           default=None, help=_("Automatically answer no for all questions"))
         self.add_argument("--version", action="store_true", default=None,
                            help=_("show DNF version and exit"))
         self.add_argument("--installroot", help=_("set install root"),

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -89,7 +89,7 @@ Options
     Allow erasing of installed packages to resolve dependencies. This option could be used as an alternative to ``yum swap`` command where packages to remove are not explicitly defined.
 
 ``--assumeno``
-    answer no for all questions
+    Automatically answer no for all questions
 
 ``-b, --best``
     Try the best available package versions in transactions. Specifically during ``dnf upgrade``, which by default skips over updates that can not be installed for dependency reasons, the switch forces DNF to only consider the latest packages and possibly fail giving a reason why the latest version can not be installed.
@@ -191,7 +191,7 @@ Options
     show DNF version and exit
 
 ``-y, --assumeyes``
-    answer yes for all questions
+    Automatically answer yes for all questions
 
 List options are comma separated. Command-line options override respective settings from configuration files.
 

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -46,10 +46,12 @@ or :ref:`mirrorlist <mirrorlist-label>` option definition.
  [main] Options
 ================
 
+.. _assumeyes-label:
 ``assumeyes``
     :ref:`boolean <boolean-label>`
 
-    If enabled then on any user input asking for confirmation (e.g. after transaction summary) the answer is implicitly ``yes``. The default is False.
+    If enabled dnf will assume ``Yes`` where it would normally prompt for
+    confirmation from user input (see also :ref:`defaultyes <defaultyes-label>`). Default is False.
 
 ``best``
     :ref:`boolean <boolean-label>`
@@ -75,6 +77,13 @@ or :ref:`mirrorlist <mirrorlist-label>` option definition.
 
     Debug messages output level, in the range 0 to 10. The higher the number the
     more debug output is put to stdout. Default is 2.
+
+.. _defaultyes-label:
+``defaultyes``
+    :ref:`boolean <boolean-label>`
+
+    If enabled the default answer to user confirmation prompts will be ``Yes``. Not
+    to be confused with :ref:`assumeyes <assumeyes-label>` which will not prompt at all. Default is False.
 
 ``errorlevel``
     :ref:`integer <integer-label>`


### PR DESCRIPTION
Version 3 of #447 

Included the requested changes from [#450](/rpm-software-management/dnf/pull/450#issuecomment-188775786)

* Added `defaultyes` to `conf_ref`
* Tweaked docs for `--assumeyes` and `--assumeno`