### PR TITLE
doc: Fixed syntax of `assumeyes` and `defaultyes` ref lables in `conf_ref.rst`

### DIFF
--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -47,6 +47,7 @@ or :ref:`mirrorlist <mirrorlist-label>` option definition.
 ================
 
 .. _assumeyes-label:
+
 ``assumeyes``
     :ref:`boolean <boolean-label>`
 
@@ -79,6 +80,7 @@ or :ref:`mirrorlist <mirrorlist-label>` option definition.
     more debug output is put to stdout. Default is 2.
 
 .. _defaultyes-label:
+
 ``defaultyes``
     :ref:`boolean <boolean-label>`
 


### PR DESCRIPTION
Another little syntax error since I'm not familiar with Python stuff like rst

I feel like I'm bombarding you guys with lots of tiny, unimportant, patches, so many apologies!