### PR TITLE
Correct translations for "Is this ok [Y/n]: " (defaultyes)

### DIFF
--- a/po/cs.po
+++ b/po/cs.po
@@ -601,7 +601,7 @@ msgstr "V pořádku [a/N]: "
 
 #: ../dnf/cli/output.py:629
 msgid "Is this ok [Y/n]: "
-msgstr "V pořádku [a/N]: "
+msgstr "V pořádku [A/n]: "
 
 #: ../dnf/cli/output.py:707
 #, python-format

--- a/po/de.po
+++ b/po/de.po
@@ -620,7 +620,7 @@ msgstr "Ist dies in Ordnung? [j/N] : "
 
 #: ../dnf/cli/output.py:629
 msgid "Is this ok [Y/n]: "
-msgstr "Ist dies in Ordnung? [j/N] : "
+msgstr "Ist dies in Ordnung? [J/n] : "
 
 #: ../dnf/cli/output.py:707
 #, python-format

--- a/po/fi.po
+++ b/po/fi.po
@@ -588,7 +588,7 @@ msgstr "Onko tämä ok [k/E]: "
 
 #: ../dnf/cli/output.py:629
 msgid "Is this ok [Y/n]: "
-msgstr ""
+msgstr "Onko tämä ok [K/e]: "
 
 #: ../dnf/cli/output.py:707
 #, python-format

--- a/po/gu.po
+++ b/po/gu.po
@@ -579,7 +579,7 @@ msgstr "શું આ બરાબર છે [y/N]: "
 
 #: ../dnf/cli/output.py:629
 msgid "Is this ok [Y/n]: "
-msgstr ""
+msgstr "શું આ બરાબર છે [Y/n]: "
 
 #: ../dnf/cli/output.py:707
 #, python-format

--- a/po/it.po
+++ b/po/it.po
@@ -590,7 +590,7 @@ msgstr "Procedere [s/N]: "
 
 #: ../dnf/cli/output.py:629
 msgid "Is this ok [Y/n]: "
-msgstr "Procedere [s/N]: "
+msgstr "Procedere [S/n]: "
 
 #: ../dnf/cli/output.py:707
 #, python-format

--- a/po/ms.po
+++ b/po/ms.po
@@ -575,7 +575,7 @@ msgstr "Adakah ini ok [y/T]: "
 
 #: ../dnf/cli/output.py:629
 msgid "Is this ok [Y/n]: "
-msgstr ""
+msgstr "Adakah ini ok [Y/t]: "
 
 #: ../dnf/cli/output.py:707
 #, python-format

--- a/po/nb.po
+++ b/po/nb.po
@@ -586,7 +586,7 @@ msgstr "Er dette ok [j/N]: "
 
 #: ../dnf/cli/output.py:629
 msgid "Is this ok [Y/n]: "
-msgstr ""
+msgstr "Er dette ok [J/n]: "
 
 #: ../dnf/cli/output.py:707
 #, python-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -587,7 +587,7 @@ msgstr "Correto? [s/N]: "
 
 #: ../dnf/cli/output.py:629
 msgid "Is this ok [Y/n]: "
-msgstr ""
+msgstr "Correto? [S/n]: "
 
 #: ../dnf/cli/output.py:707
 #, python-format

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -955,7 +955,7 @@ msgstr "Pogrešan tsflag u datoteci podešavanja: %s"
 
 #: ../dnf/cli/output.py:626
 msgid "Is this ok [Y/n]: "
-msgstr ""
+msgstr "Da li je ovo u redu [D/n]: "
 
 #: ../dnf/cli/output.py:623
 msgid "Is this ok [y/N]: "


### PR DESCRIPTION
Issue reported by [florian] on [ask fedora]: Several translations did not adjust text when `defaultyes` is true.

Please note that I do not speak any of the languages in this commit, however a German speaker reported the issue with the `de` translation.

[florian]: https://ask.fedoraproject.org/en/users/8814/florian/
[ask fedora]: https://ask.fedoraproject.org/en/question/83212/can-you-set-dnfs-prompt-yn-instead-of-yn/?comment=83656#comment-83656