### PR TITLE
Change example of 'dnf-command(repoquery)'

### DIFF
--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -33,7 +33,13 @@ Description
 
 .. _command_provides-label:
 
-`DNF`_ is the next upcoming major version of `Yum`_, a package manager for RPM-based Linux distributions. It roughly maintains CLI compatibility with Yum and defines strict API for extensions and plugins. Plugins can modify or extend features of DNF or provide additional CLI commands on top of those mentioned below. If you know the name of such a command (including commands mentioned below), you may find/install the package which provides it using the appropriate virtual provide in the form of ``dnf-command(<alias>)`` where ``<alias>`` is the name of the command; e.g. ``dnf-command(repoquery)`` for a ``repoquery`` command (the same applies to specifying dependencies of packages that require a particular command).
+`DNF`_ is the next upcoming major version of `Yum`_, a package manager for RPM-based Linux distributions. It roughly
+maintains CLI compatibility with Yum and defines strict API for extensions and plugins. Plugins can modify or extend
+features of DNF or provide additional CLI commands on top of those mentioned below. If you know the name of such a
+command (including commands mentioned below), you may find/install the package which provides it using the appropriate
+virtual provide in the form of ``dnf-command(<alias>)`` where ``<alias>`` is the name of the command; e.g.
+``dnf install 'dnf-command(repoquery)'`` to install a ``repoquery`` plugin (the same applies to specifying
+dependencies of packages that require a particular DNF command).
 
 Available commands:
 


### PR DESCRIPTION
It add reproducible example of dnf-command -
"dnf install 'dnf-command(repoquery)'"