### PR TITLE
Added fix for correct error message for group info (RhBug:1209649)

### DIFF
--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -1026,10 +1026,10 @@ class HelpCommand(Command):
         command_names = command.aliases
         if len(command_names) > 1:
             if len(command_names) > 2:
-                help_output += _("aliases: ")
+                help_output += _("\naliases: ")
             else:
-                help_output += _("alias: ")
-            help_output = '\n\n' + help_output + ', '.join(command.aliases[1:])
+                help_output += _("\nalias: ")
+            help_output += ', '.join(command.aliases[1:])
 
         return help_output
 

--- a/dnf/cli/commands/group.py
+++ b/dnf/cli/commands/group.py
@@ -43,7 +43,7 @@ def _ensure_grp_arg(cli, basecmd, extcmds):
     """
     if len(extcmds) == 0:
         logger.critical(_('Error: Need a group or list of groups'))
-        commands.err_mini_usage(cli, basecmd)
+        commands.err_mini_usage(cli, 'group')
         raise dnf.cli.CliError
 
 


### PR DESCRIPTION
Fix added for presenting user a correct error message for command
group info

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1209649

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>