### PR TITLE
repo: don't get current timeout for librepo

### DIFF
--- a/dnf/repo.py
+++ b/dnf/repo.py
@@ -646,8 +646,10 @@ class Repo(dnf.yum.config.RepoConf):
         h.proxy = self.proxy
         h.lowspeedlimit = self.minrate
         h.lowspeedtime = self.timeout
-        current_timeout = h.getinfo(librepo.LRO_CONNECTTIMEOUT)
-        h.connecttimeout = max(self.timeout, current_timeout)
+        if self.timeout > 0:
+            h.connecttimeout = self.timeout
+        else:
+            h.connecttimeout = None
         h.proxyuserpwd = _user_pass_str(self.proxy_username, self.proxy_password)
         h.sslverifypeer = h.sslverifyhost = self.sslverify
 


### PR DESCRIPTION
1st of all, getting max of current limit and user-specified limit is
bad idea, because if user specified limit less than current then his
option is ignored.

2nd point is that librepo doesn't support return current connection
timeout. LRO_CONNECTTIMEOUT is just constant (18). I guess in C code
it's just enum.

We need to check if value is more than 0. In case of zero curl_easy_setopt()
will use internal default timeout - 300 seconds. If it's less than zero
it's undocumented what will happen, so let's just set None to move handling
completely to librepo.

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1272977#c6
Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>