### PR TITLE
base: check if package is installed only by name in upgrade()

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1512,7 +1512,7 @@ class Base(object):
             msg = 'downgrade_package() for an installed package.'
             raise NotImplementedError(msg)
 
-        q = self.sack.query().installed().filter(name=pkg.name, arch=pkg.arch)
+        q = self.sack.query().installed().filter(name=pkg.name, arch=[pkg.arch, "noarch"])
         if not q:
             msg = _("Package %s not installed, cannot downgrade it.")
             logger.warning(msg, pkg.name)
@@ -1554,7 +1554,7 @@ class Base(object):
             msg = 'upgrade_package() for an installed package.'
             raise NotImplementedError(msg)
 
-        q = self.sack.query().installed().filter(name=pkg.name, arch=pkg.arch)
+        q = self.sack.query().installed().filter(name=pkg.name, arch=[pkg.arch, "noarch"])
         if not q:
             msg = _("Package %s not installed, cannot update it.")
             logger.warning(msg, pkg.name)


### PR DESCRIPTION
Package rubygem-bson for long time was noarch and was shipping
arch-dependent subpkg rubygem-bson_ext. Things were changed and
now rubygem-bson is arch-dependent and rubygem-bson_ext is
replaced by main package.

But dnf update /path/to/new/rpm fails with:
Package rubygem-bson not installed, cannot update it.

Because it checks architecture. Let's not check it anymore.

Reported-by: Vít Ondruch <vondruch@redhat.com>
Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1230183
Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>