### PR TITLE
cli: don't show backtrace when supplied wrong path in repofromurl (RhBug:1325869)

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -737,9 +737,7 @@ class Cli(object):
         self.base.read_all_repos(repo_setopts)
         if opts.repofrompath:
             for label, path in opts.repofrompath.items():
-                if os.path.isabs(path):
-                    path = 'file://{}'.format(path)
-                elif os.path.isdir(path):
+                if '://' not in path:
                     path = 'file://{}'.format(os.path.abspath(path))
                 repofp = dnf.repo.Repo(label, self.base.conf.cachedir)
                 try:

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -737,10 +737,15 @@ class Cli(object):
         self.base.read_all_repos(repo_setopts)
         if opts.repofrompath:
             for label, path in opts.repofrompath.items():
-                if path[0] == '/':
-                    path = 'file://' + path
+                if os.path.isabs(path):
+                    path = 'file://{}'.format(path)
+                elif os.path.isdir(path):
+                    path = 'file://{}'.format(os.path.abspath(path))
                 repofp = dnf.repo.Repo(label, self.base.conf.cachedir)
-                repofp.baseurl = path
+                try:
+                    repofp.baseurl = path
+                except ValueError as e:
+                    raise dnf.exceptions.RepoError(e)
                 self.base.repos.add(repofp)
                 logger.info(_("Added %s repo from %s"), label, path)
 


### PR DESCRIPTION
* Check more nicely if path is absolute by os.path.isabs, not by checking first
  character
* If path is not absolute, check if directory exists and then use it
* Finally if path is wrong, do not throw ValueError and raise dnf.exceptions.RepoError
  with better error message

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1325869
Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>