### PR TITLE
remove formating from translation strings

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -586,7 +586,7 @@ class Base(object):
             del testcb
 
             if len(tserrors) > 0:
-                errstring = _('Transaction check error:\n')
+                errstring = _('Transaction check error:') + '\n'
                 for descr in tserrors:
                     errstring += '  %s\n' % ucd(descr)
 
@@ -635,7 +635,7 @@ class Base(object):
                     'At least %dMB more space needed on the %s filesystem.',
                     disk[k]) % (disk[k], k) + '\n'
 
-        summary = _('Error Summary\n-------------\n') + summary
+        summary = _('Error Summary') + '\n-------------\n' + summary
 
         return summary
 
@@ -1824,9 +1824,9 @@ class Base(object):
         key_installed = False
 
         def _prov_key_data(msg):
-            msg += _('Failing package is: %s\n'
-                     ' GPG Keys are configured as: %s\n'
-                     ) % (po, ", ".join(repo.gpgkey))
+            msg += _('Failing package is: %s') % (po) + '\n '
+            msg += _('GPG Keys are configured as: %s') % \
+                    (', '.join(repo.gpgkey) + '\n')
             return '\n\n\n' + msg
 
         user_cb_fail = False

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -212,7 +212,7 @@ class BaseCli(dnf.Base):
                                        total_cb)
             except dnf.exceptions.DownloadError as e:
                 specific = dnf.cli.format.indent_block(ucd(e))
-                errstring = _('Error downloading packages:\n%s') % specific
+                errstring = _('Error downloading packages:') + '\n%s' % specific
                 # setting the new line to prevent next chars being eaten up by carriage returns
                 print()
                 raise dnf.exceptions.Error(errstring)

--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -65,7 +65,7 @@ def err_mini_usage(cli, basecmd):
         return
     cmd = cli.cli_commands[basecmd]
     txt = cli.cli_commands["help"]._makeOutput(cmd)
-    logger.critical(_(' Mini usage:\n'))
+    logger.critical(_(' Mini usage:') + '\n')
     logger.critical(txt)
 
 def checkGPGKey(base, cli):

--- a/dnf/cli/commands/group.py
+++ b/dnf/cli/commands/group.py
@@ -177,7 +177,7 @@ class GroupCommand(commands.Command):
                 in_group = len(self.base.comps.groups_by_pattern(group)) > 0
                 in_environment = len(self.base.comps.environments_by_pattern(group)) > 0
                 if not in_group and not in_environment:
-                    logger.error(_('Warning: No groups match:\n   %s'), group)
+                    logger.error(_('Warning: No groups match:') + '\n   %s', group)
                     errs = True
             if errs:
                 return 0, []

--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -704,7 +704,7 @@ class Output(object):
         """
         def names(packages):
             return sorted(pkg.name for pkg in packages)
-        print(_('\nGroup: %s') % group.ui_name)
+        print('\n' + _('Group: %s') % group.ui_name)
 
         verbose = self.conf.verbose
         if verbose:
@@ -1061,7 +1061,7 @@ class Output(object):
                 msg = self.fmtColumns(columns, u" ", u"\n")
                 hibeg, hiend = self._highlight(self.conf.color_update_installed)
                 for obspo in sorted(obsoletes):
-                    appended = _('     replacing  %s%s%s.%s %s\n')
+                    appended = '     ' + _('replacing') + '  %s%s%s.%s %s\n'
                     appended %= (hibeg, obspo.name, hiend, obspo.arch, obspo.evr)
                     msg += appended
                 totalmsg = totalmsg + msg


### PR DESCRIPTION
This should achieve less error prone translations. 