### PR TITLE
history: Fix TypeError dnf.yum.packages.parsePackages (RhBug:1245121)

### DIFF
--- a/dnf/yum/packages.py
+++ b/dnf/yum/packages.py
@@ -73,7 +73,7 @@ def parsePackages(pkgs, usercommands, casematch=0):
         if not casematch:
             command = command.lower()
         if command in pkgdict:
-            exactmatch.update(pkgdict[command])
+            exactmatch = pkgdict[command]
             del pkgdict[command]
         else:
             # anything we couldn't find a match for
@@ -87,7 +87,7 @@ def parsePackages(pkgs, usercommands, casematch=0):
                 foundit = 0
                 for item in trylist:
                     if regex.match(item):
-                        matched.update(pkgdict[item])
+                        matched = pkgdict[item]
                         del pkgdict[item]
                         foundit = 1
 


### PR DESCRIPTION
`dnf history info <command>` fails without this, and the error is
in trying to set.update an unhashable type. Instead of using set.update
I just assigned the value of the list to the set()