### PR TITLE
history: YumHistoryPackage is not hashable with python-3 (RhBug:1245121)

### DIFF
--- a/dnf/yum/history.py
+++ b/dnf/yum/history.py
@@ -184,6 +184,9 @@ class YumHistoryPackage(object):
 
         return self_repoid < other_repoid  # less or grater
 
+    def __hash__(self):
+        return hash(self.pkgtup)
+
     def __eq__(self, other):
         """ Compare packages for yes/no equality, includes everything in the
             UI package comparison. """


### PR DESCRIPTION
python-3 implicitly sets __hash__ to None if __eq__ method is defined,
so TypeError is raised when YumHistoryPackage objects are added to set()

#473 already mentions this bug, but simply removes set() as uniqueness test