### PR TITLE
Adds a new sendmail-like emitter for dnf-automatic.

### DIFF
--- a/dnf/automatic/emitter.py
+++ b/dnf/automatic/emitter.py
@@ -105,10 +105,13 @@ class EmailEmitter(Emitter):
                 self._conf.email_host, exc)
             logger.error(msg)
 
+
 class CommandEmailEmitter(EmailEmitter):
     def commit(self):
         command_fmt = self._conf.command
         subj, body = self._prepare_msg()
+        if dnf.pycomp.PY3:
+            body = body.encode('utf-8')
         cmd_subject = dnf.pycomp.shlex_quote(subj)
         cmd_email_from = dnf.pycomp.shlex_quote(self._conf.email_from)
         cmd_email_to = dnf.pycomp.shlex_quote(' '.join(self._conf.email_to))

--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -57,6 +57,9 @@ def build_emitters(conf):
         elif name == 'motd':
             emitter = dnf.automatic.emitter.MotdEmitter(system_name)
             emitters.append(emitter)
+        elif name == 'command_email':
+            emitter = dnf.automatic.emitter.CommandEmailEmitter(system_name, conf.command_email)
+            emitters.append(emitter)
         else:
             assert False
     return emitters
@@ -75,6 +78,7 @@ class AutomaticConfig(object):
         self.commands = CommandsConfig()
         self.email = EmailConfig()
         self.emitters = EmittersConfig()
+        self.command_email = CommandEmailConfig()
         self._parser = None
         self._load(filename)
         self.commands.imply()
@@ -118,6 +122,15 @@ class EmailConfig(dnf.conf.BaseConfig):
         self._add_option('email_from',  dnf.conf.Option("root"))
         self._add_option('email_host',  dnf.conf.Option("localhost"))
         self._add_option('email_port',  dnf.conf.IntOption(25))
+
+
+class CommandEmailConfig(dnf.conf.BaseConfig):
+    def __init__(self, section='command_email', parser=None):
+        super(CommandEmailConfig, self).__init__(section, parser)
+        self._add_option('command',  dnf.conf.Option("mail -s {subject} -r {email_from} {email_to}"))
+        self._add_option('email_to', dnf.conf.ListOption(["root"]))
+        self._add_option('email_from', dnf.conf.Option("root"))
+
 
 class EmittersConfig(dnf.conf.BaseConfig):
     def __init__(self, section='emiter', parser=None):

--- a/dnf/pycomp.py
+++ b/dnf/pycomp.py
@@ -33,6 +33,7 @@ if PY3:
     from io import StringIO
     import queue
     import urllib.parse
+    import shlex
 
     # functions renamed in py3
     Queue = queue.Queue
@@ -46,6 +47,7 @@ if PY3:
     base64_decodebytes = base64.decodebytes
     urlparse = urllib.parse
     urllib_quote = urlparse.quote
+    shlex_quote = shlex.quote
 
     def gettext_setup(t):
         _ = t.gettext
@@ -67,7 +69,6 @@ if PY3:
         f.write(content)
     def email_mime(body):
         return email.mime.text.MIMEText(body)
-
 else:
     # functions renamed in py3
     from __builtin__ import unicode, basestring, long, xrange, raw_input
@@ -75,11 +76,13 @@ else:
     import Queue
     import urllib
     import urlparse
+    import pipes
 
     Queue = Queue.Queue
     filterfalse = itertools.ifilterfalse
     base64_decodebytes = base64.decodestring
     urllib_quote = urllib.quote
+    shlex_quote = pipes.quote
 
     def gettext_setup(t):
         _ = t.ugettext

--- a/etc/dnf/automatic.conf
+++ b/etc/dnf/automatic.conf
@@ -23,7 +23,9 @@ apply_updates = no
 # emit_via includes stdio, messages will be sent to stdout; this is useful
 # to have cron send the messages.  If emit_via includes email, this
 # program will send email itself according to the configured options.
-# If emit_via includes motd, /etc/motd file will have the messages.
+# If emit_via includes motd, /etc/motd file will have the messages. if
+# emit_via includes command_email, then messages will be send via a shell
+# command compatible with sendmail.
 # Default is email,stdio.
 emit_via = stdio
 
@@ -37,6 +39,19 @@ email_to = root
 
 # Name of the host to connect to to send email messages.
 email_host = localhost
+
+
+[email_command]
+# The shell command to use to send email. This is a Python format string,
+# as used in str.format(). The format function will pass arguments called
+# subject, email_from, email_to.
+# command = "mail -s {subject} -r {email_from} {email_to}"
+
+# The address to send email messages from.
+email_from = root@example.com
+
+# List of addresses to send messages to.
+email_to = root
 
 
 [base]


### PR DESCRIPTION
The existing EmailEmitter does not support authentication, making it difficult to send emails when the source host is not whitelisted for SMTP access. As an example, sending local mail is impossible if the MTA is configured to always require authentication.

This change solves the problem by letting the user specify a command to send email in their preferred way.