### PR TITLE
cli: fix warning from re.split() about non-empty pattern

### DIFF
--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -128,7 +128,7 @@ class OptionParser(argparse.ArgumentParser):
         Returns a new list. """
         def __call__(self, parser, namespace, values, opt_str):
             res = getattr(namespace, self.dest)
-            res.extend(re.split("\s*,?\s*", values))
+            res.extend(re.split("\s*[,\s]\s*", values))
 
     class _SplitExtendDictCallback(argparse.Action):
         """ Split string at "," or whitespace to (key, value).


### PR DESCRIPTION
```python
/usr/lib64/python3.5/re.py:203: FutureWarning: split() requires a non-empty pattern match.
  return _compile(pattern, flags).split(string, maxsplit)
```

Reported-by: Peter Lemenkov <plemenko@redhat.com>
Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>