### PR TITLE
Change default reposdir to /etc/sys.repos.d

### DIFF
--- a/dnf/yum/config.py
+++ b/dnf/yum/config.py
@@ -740,7 +740,7 @@ class YumConf(BaseConfig):
 
     keepcache = BoolOption(False)
     logdir = Option('/var/log') # :api
-    reposdir = ListOption(['/etc/yum.repos.d', '/etc/yum/repos.d', '/etc/distro.repos.d']) # :api
+    reposdir = ListOption(['/etc/sys.repos.d', '/etc/yum.repos.d', '/etc/yum/repos.d']) # :api
 
     debug_solver = BoolOption(False)
 

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -885,7 +885,7 @@ Files
     /etc/dnf/dnf.conf
 
 ``Repository``
-    /etc/yum.repos.d/
+    /etc/sys.repos.d/
 
 .. _see_also-label:
 

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -26,7 +26,7 @@
 =============
 
 `DNF`_ by default uses the global configuration file at ``/etc/dnf/dnf.conf`` and
-all \*.repo files found under ``/etc/yum.repos.d``. The latter is typically used
+all \*.repo files found under ``/etc/sys.repos.d``. The latter is typically used
 for repository configuration and takes precedence over global configuration.
 
 The configuration file has INI format consisting of section declaration and
@@ -444,7 +444,7 @@ Files
     /etc/dnf/dnf.conf
 
 ``Repository``
-    /etc/yum.repos.d/
+    /etc/sys.repos.d/
 
 ==========
  See Also

--- a/doc/use_cases.rst
+++ b/doc/use_cases.rst
@@ -68,7 +68,7 @@ A feature may be for example a concrete version of a package
 (``/var/lib/mock/fedora-21-i386/result/hawkey-0.5.3-2.20150116gitd002c90.fc21.i686.rpm``),
 an URL of a binary RPM file
 (``http://jenkins.cloud.fedoraproject.org/job/DNF/lastSuccessfulBuild/artifact/fedora-21-i386-build/hawkey-0.5.3-99.649.20150116gitd002c90233fc96893806836a258f14a50ee0cf47.fc21.i686.rpm``),
-a configuration file (``/etc/yum.repos.d/fedora-rawhide.repo``), a language
+a configuration file (``/etc/sys.repos.d/fedora-rawhide.repo``), a language
 interpreter (``ruby(runtime_executable)``), an extension (``python3-dnf``), a
 support for building modules for the current running kernel
 (``kernel-devel-uname-r = $(uname -r)``), an executable (``*/binaryname``) or a


### PR DESCRIPTION
For DNF 2.0, we are switching the default reposdir to `/etc/sys.repos.d`. This PR changes the code and documentation to reflect that.

In addition, `/etc/yum/repos.d` was never commonly used (RH/Fedora used `/etc/yum.repos.d`), so it has been dropped.