### PR TITLE
move autoglob feature directly to filter()

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -154,11 +154,11 @@ class Base(object):
                 continue
             for excl in r.exclude:
                 pkgs = self.sack.query().filter(reponame=r.id).\
-                    filter_autoglob(name=excl)
+                    filter(name__glob=excl)
                 self.sack.add_excludes(pkgs)
             for incl in r.include:
                 pkgs = self.sack.query().filter(reponame=r.id).\
-                    filter_autoglob(name=incl)
+                    filter(name__glob=incl)
                 self.sack.add_includes(pkgs)
 
     def _store_persistent_data(self):
@@ -1700,9 +1700,7 @@ class Base(object):
         providers = dnf.query.by_provides(self.sack, provides_spec)
         if providers:
             return providers
-        if any(map(dnf.util.is_glob_pattern, provides_spec)):
-            return self.sack.query().filter(file__glob=provides_spec)
-        return self.sack.query().filter(file=provides_spec)
+        return self.sack.query().filter(file__glob=provides_spec)
 
     def history_undo_operations(self, operations):
         """Undo the operations on packages by their NEVRAs.

--- a/dnf/subject.py
+++ b/dnf/subject.py
@@ -35,20 +35,17 @@ class Subject(object):
         self.icase = ignore_case
 
     def _nevra_to_filters(self, query, nevra):
-        nevra_attrs = [("name", True, True), ("epoch", False, False),
-                       ("version", True, False), ("release", False, False),
-                       ("arch", True, False)]
+        nevra_attrs = [("name", True), ("epoch", False),
+                       ("version", False), ("release", False),
+                       ("arch", False)]
 
-        for (name, check_glob, add_flags) in nevra_attrs:
+        for (name, add_flags) in nevra_attrs:
             attr = getattr(nevra, name)
             flags = []
             if attr:
                 if add_flags:
                     flags = self._query_flags
-                if check_glob:
-                    query = query.filter_autoglob(*flags, **{name: attr})
-                else:
-                    query.filterm(*flags, **{name: attr})
+                query.filterm(*flags, **{name + '__glob': attr})
 
         return query
 
@@ -113,7 +110,7 @@ class Subject(object):
                     return q
 
         if self.filename_pattern:
-            return sack.query().filter_autoglob(file=pat)
+            return sack.query().filter(file__glob=pat)
 
         return sack.query().filter(empty=True)
 

--- a/dnf/util.py
+++ b/dnf/util.py
@@ -117,7 +117,9 @@ def is_exhausted(iterator):
         return False
 
 def is_glob_pattern(pattern):
-    return set(pattern) & set("*[?")
+    if is_string_type(pattern):
+        pattern = [pattern]
+    return (isinstance(pattern, list) and any(set(p) & set("*[?") for p in pattern))
 
 def is_string_type(obj):
     return isinstance(obj, basestring)


### PR DESCRIPTION
~~it's pretty safe change
if there's no glob among arguments it will use noglob filter as it does now
and you can still force glob variant with xxx__glob parameter if you want to~~
filterm(xxx=) still works the same way
filterm(xxx__glob=) now works as former filter_autoglob()