### PR TITLE
spec: correctly set up requirements for python subpkg

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -36,8 +36,11 @@ BuildRequires:  python-bugzilla
 BuildRequires:  python-sphinx
 BuildRequires:  systemd
 BuildRequires:  bash-completion
-# We don't need to have python with specific version as we use %%python_provide
-Requires:       python-%{name} = %{version}-%{release}
+%if %{with python3}
+Requires:       python3-%{name} = %{version}-%{release}
+%else
+Requires:       python2-%{name} = %{version}-%{release}
+%endif
 Requires(post):     systemd
 Requires(preun):    systemd
 Requires(postun):   systemd


### PR DESCRIPTION
Unfortunately %python_provide is still providing py2 package by default
even on f24, f25 (rawhide). So let's require explicitly.

Reported-by: Jaroslav Mracek <jmracek@redhat.com>
Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>