### PR TITLE
Swap /etc/distro.repos.d for /etc/sys.repos.d

### DIFF
--- a/dnf/yum/config.py
+++ b/dnf/yum/config.py
@@ -740,7 +740,7 @@ class YumConf(BaseConfig):
 
     keepcache = BoolOption(False)
     logdir = Option('/var/log') # :api
-    reposdir = ListOption(['/etc/yum.repos.d', '/etc/yum/repos.d', '/etc/distro.repos.d']) # :api
+    reposdir = ListOption(['/etc/yum.repos.d', '/etc/yum/repos.d', '/etc/sys.repos.d']) # :api
 
     debug_solver = BoolOption(False)
 


### PR DESCRIPTION
As discussed with @jsilhan, dnf-2.0 will default to `/etc/sys.repos.d` (see #481), and Mageia will be switching to this path after this is accepted into DNF.

The name makes more sense anyway.