### PR TITLE
cli: cosmetic: print less intrusive dnf redirection message

### DIFF
--- a/bin/yum
+++ b/bin/yum
@@ -20,10 +20,7 @@
 #
 
 executable="/usr/bin/dnf"
-msg="Yum command has been deprecated, redirecting to '$executable $@'.\n"\
-"See 'man dnf' and 'man yum2dnf' for more information.\n"\
-"To transfer transaction metadata from yum to DNF, run:\n"\
-"'dnf install python-dnf-plugins-extras-migrate && dnf-2 migrate'\n"
+msg="Redirecting to '$executable $@' (see 'man yum2dnf')\n"
 
 echo -e $msg >&2
 exec $executable "$@"

--- a/doc/cli_vs_yum.rst
+++ b/doc/cli_vs_yum.rst
@@ -400,7 +400,7 @@ Utilities that have not been ported yet:
 ``verifytree``,
 ``yum-groups-manager``
 
-Feel free to file a RFE_ for missing functionality if you need it.
+Take a look at FAQ_ about yum to DNF migration. Feel free to file a RFE_ for missing functionality if you need it.
 
 .. _dnf debuginfo-install: http://dnf-plugins-core.readthedocs.org/en/latest/debuginfo-install.html
 .. _dnf list installed: http://dnf.readthedocs.org/en/latest/command_ref.html
@@ -418,3 +418,4 @@ Feel free to file a RFE_ for missing functionality if you need it.
 .. _dnf copr: http://rpm-software-management.github.io/dnf-plugins-core/copr.html
 .. _dnf.conf: http://dnf.readthedocs.org/en/latest/conf_ref.html
 .. _RFE: https://github.com/rpm-software-management/dnf/wiki/Bug-Reporting#new-feature-request
+.. _FAQ: http://dnf.readthedocs.io/en/latest/user_faq.html

--- a/doc/user_faq.rst
+++ b/doc/user_faq.rst
@@ -37,6 +37,10 @@ Yes, you can. And this setup is tested by many.
 
 There is one restriction: DNF and Yum keep additional data about each installed package and every performed transaction. This data is currently not shared between the two managers so if the admin installs half of the packages with DNF and the other half with Yum then each program can not benefit from the information held by the other one. The practical bottom line is that commands like ``autoremove`` can not take a completely informed decision and thus have to "play it safe" and remove only a subset of dependencies they would be able to otherwise. Similar situation exists with groups.
 
+To transfer transaction additional data from yum to DNF, run::
+
+    dnf install python-dnf-plugins-extras-migrate && dnf-2 migrate
+
 .. _dnf_yum_package-label:
 
 Is there a compatibility layer for Yum?

--- a/doc/yum-dnf.rst
+++ b/doc/yum-dnf.rst
@@ -27,8 +27,9 @@ See Also
 ========
 
 * :manpage:`dnf.conf(8)`, :ref:`DNF Configuration Reference <conf_ref-label>`
-* :manpage:`yum2dnf(8)`,
+* :manpage:`yum2dnf(8)`, Description of differences between yum and DNF
 * `DNF`_ project homepage (https://github.com/rpm-software-management/dnf/)
 * `Fedora wiki`_ page (http://fedoraproject.org/wiki/Changes/ReplaceYumWithDNF)
+* yum to DNF migration FAQ (http://dnf.readthedocs.io/en/latest/user_faq.html)
 
 .. _Fedora wiki: http://fedoraproject.org/wiki/Changes/ReplaceYumWithDNF


### PR DESCRIPTION
As DNF have to be more compatible with yum and /usr/bin/yum binary will
be supported longer than was originally planned, we will reduce the
annoying redirecting output