### PR TITLE
Remove unused function 'timed' from dnf.util

### DIFF
--- a/dnf/util.py
+++ b/dnf/util.py
@@ -215,19 +215,6 @@ def strip_prefix(s, prefix):
         return s[len(prefix):]
     return None
 
-def timed(fn):
-    """Decorator, prints out the ms a function took to complete.
-
-    Used for debugging.
-
-    """
-    def decorated(*args, **kwargs):
-        start = time.time()
-        retval = fn(*args, **kwargs)
-        length = time.time() - start
-        print("%s took %.02f ms" % (fn.__name__, length * 1000))
-        return retval
-    return decorated
 
 def touch(path, no_create=False):
     """Create an empty file if it doesn't exist or bump it's timestamps.


### PR DESCRIPTION
The def timed is not used in any component of dnf, therefore it is a candidate
to remove it.