### PR TITLE
Enable information about "Last metadata check"

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -818,8 +818,9 @@ class Cli(object):
         if demands.sack_activation:
             lar = self.demands.available_repos
             if lar:
-                repos = list(repo for repo in self.base.repos.iter_enabled()
-                                           if repo.metadata)
+                for repo in self.base.repos.iter_enabled():
+                    repo.load()
+                repos = list(self.base.repos.iter_enabled())
                 if repos:
                     mts = max(repo.metadata.timestamp for repo in repos)
                     # do not bother users with fractions of seconds


### PR DESCRIPTION
It corrects the commit 95aca139ff8128f0684c7c1d12e57e7a6a745123

The information about Last metadata check should again appear in output.