### PR TITLE
Fix the reposdir in installroot

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -953,8 +953,9 @@ class Cli(object):
         # with cachedir in place we can configure stuff depending on it:
         self.base._activate_persistor()
 
-        self.optparser.configure_from_options(opts, self.base.conf, self.demands,
-                                              self.base.output, ('reposdir' not in getattr(opts, 'main_setopts', {})))
+        self.optparser.configure_from_options(
+            opts, self.base.conf,self.demands, self.base.output,
+            ('reposdir' not in getattr(opts, 'main_setopts', {})))
 
         self._configure_repos(opts)
 

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -952,14 +952,15 @@ class Cli(object):
         self._configure_cachedir()
         # with cachedir in place we can configure stuff depending on it:
         self.base._activate_persistor()
+
+        self.optparser.configure_from_options(opts, self.base.conf, self.demands,
+                                              self.base.output, ('reposdir' not in getattr(opts, 'main_setopts', {})))
+
         self._configure_repos(opts)
 
         self.base.configure_plugins()
 
         self.command.configure()
-
-        self.optparser.configure_from_options(opts, self.base.conf, self.demands,
-                        self.base.output, ('reposdir' in getattr(opts, 'main_setopts', {})))
 
         if opts.debugsolver:
             self.base.conf.debug_solver = True


### PR DESCRIPTION
The patch allows use reposdir from inside of installroot. The problem was
discovered by ci-dnf-stack.