### PR TITLE
Fix problem with obsolete dnf in epel version 0.6.4.2

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -108,7 +108,6 @@ Requires:       python-librepo >= %{librepo_version}
 Requires:       pygpgme
 Requires:       rpm-plugin-systemd-inhibit
 Requires:       rpm-python >= %{rpm_version}
-Obsoletes:      %{name} <= 0.6.4
 
 %description -n python2-%{name}
 Python 2 interface to DNF.
@@ -135,7 +134,6 @@ Requires:       python3-librepo >= %{librepo_version}
 Requires:       python3-pygpgme
 Requires:       rpm-plugin-systemd-inhibit
 Requires:       rpm-python3 >= %{rpm_version}
-Obsoletes:      %{name} <= 0.6.4
 
 %description -n python3-%{name}
 Python 3 interface to DNF.


### PR DESCRIPTION
If dnf in EPEL (0.6.4.2) is upgraded into higher version, the python2-dnf
incorrectly obsolete not only python-dnf but also dnf. The patch should solve
it.