### PR TITLE
Changed handling of --disablerepo and --enablerepo (RhBug:1345976)

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -727,11 +727,6 @@ class Cli(object):
         for repo in notmatch:
             logger.warning(_("No repository matching: %s"), repo)
 
-        if self.nogpgcheck:
-            for repo in self.base.repos.values():
-                repo.gpgcheck = False
-                repo.repo_gpgcheck = False
-
         for rid in self.base._repo_persistor.get_expired_repos():
             repo = self.base.repos.get(rid)
             if repo:

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -725,7 +725,7 @@ class Cli(object):
             sys.exit(1)
 
         for repo in notmatch:
-            logger.warning(_("No repository match: %s"), repo)
+            logger.warning(_("No repository matching: %s"), repo)
 
         if self.nogpgcheck:
             for repo in self.base.repos.values():


### PR DESCRIPTION
When option "--disablerepo=" or "--enablerepo=" is set and it does not match any repository it just prints warning. If there is set "--setopt=strict=true" and "--enablerepo=" it raise exception and stops.

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1345976
