### PR TITLE
DNF reinstall deletes yumdb entry (RhBug:1343764)

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -877,7 +877,6 @@ class Base(object):
             else:
                 self._yumdb.get_package(rpo).clean()
             count = display_banner(rpo, count)
-            
         if self._record_history():
             rpmdbv = rpmdb_sack.rpmdb_version(self._yumdb)
             self.history.end(rpmdbv, 0)

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -874,10 +874,10 @@ class Base(object):
                     logger.critical(msg, rpo)
                     count = display_banner(rpo, count)
                     continue
+            else:
+                self._yumdb.get_package(rpo).clean()
             count = display_banner(rpo, count)
-            yumdb_item = self._yumdb.get_package(rpo)
-            yumdb_item.clean()
-
+            
         if self._record_history():
             rpmdbv = rpmdb_sack.rpmdb_version(self._yumdb)
             self.history.end(rpmdbv, 0)


### PR DESCRIPTION
Fixed bug where DNF removed yumdb entry after reinstall of package that was installed as a dependency.

References: https://bugzilla.redhat.com/show_bug.cgi?id=1343764