### PR TITLE
Replacement for  package-cleanup --cleandupes and --oldkernels

### DIFF
--- a/dnf/cli/commands/remove.py
+++ b/dnf/cli/commands/remove.py
@@ -72,7 +72,8 @@ class RemoveCommand(commands.Command):
                 for pkg in dups:
                     self.base.package_remove(pkg)
             else:
-                raise dnf.exceptions.Error(_('No duplicated packages for removal.'))
+                raise dnf.exceptions.Error(
+                    _('No duplicated packages found for removal.'))
             return
         if self.opts.oldinstallonly:
             q = self.base.sack.query()
@@ -83,7 +84,8 @@ class RemoveCommand(commands.Command):
                 for pkg in instonly:
                     self.base.package_remove(pkg)
             else:
-                raise dnf.exceptions.Error(_('No old installonly packages for removal.'))
+                raise dnf.exceptions.Error(
+                    _('No old installonly packages found for removal.'))
             return
 
         # Remove groups.

--- a/doc/cli_vs_yum.rst
+++ b/doc/cli_vs_yum.rst
@@ -381,8 +381,8 @@ Detailed table for ``package-cleanup`` replacement:
 ``package-cleanup --orphans``           ``dnf repoquery --extras``
 ``package-cleanup --oldkernels``        ``dnf repoquery --installonly``
 ``package-cleanup --problems``          ``dnf repoquery --unsatisfied``
-``package-cleanup --cleandupes``        ``dnf remove $(dnf repoquery --duplicated --latest-limit -1 -q)``
-``package-cleanup --oldkernels``        ``dnf remove $(dnf repoquery --installonly --latest-limit -3 -q)``
+``package-cleanup --cleandupes``        ``dnf remove --duplicated``
+``package-cleanup --oldkernels``        ``dnf remove --oldinstallonly``
 ================================        =============================
 
 Utilities that have not been ported yet:

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -634,6 +634,12 @@ Remove Command
 ``dnf [options] remove <package-specs>...``
     Removes the specified packages from the system along with any packages depending on the packages being removed. Each ``<spec>`` can be either a ``<package-spec>``, which specifies a package directly, or a ``@<group-spec>``, which specifies an (environment) group which contains it. If ``clean_requirements_on_remove`` is enabled (the default) also removes any dependencies that are no longer needed.
 
+``dnf [options] remove --duplicated``
+    Removes older version of duplicated packages.
+
+``dnf [options] remove --oldinstallonly``
+    Removes old installonly packages keeping only ``installonly_limit`` latest versions.
+
 .. _repolist_command-label:
 
 ----------------


### PR DESCRIPTION
This is a simplified replacement for yum's
package-cleanup --cleandupes
package-cleanup --oldkernels

Currently our doc says
```
package-cleanup --cleandupes 	= dnf remove $(dnf repoquery --duplicated --latest-limit -1 -q)
package-cleanup --oldkernels 	= dnf remove $(dnf repoquery --installonly --latest-limit -3 -q)
```
this change simplifies it to 
```
dnf remove --duplicated
dnf remove --oldinstallonly
```
