### PR TITLE
Make private function from 'is_arch_specified' in dnf.selector

### DIFF
--- a/dnf/selector.py
+++ b/dnf/selector.py
@@ -26,7 +26,7 @@ import dnf.util
 
 class Selector(hawkey.Selector):
     # :api
-    def set_autoglob(self, **kwargs):
+    def _set_autoglob(self, **kwargs):
         nargs = {}
         for (key, value) in kwargs.items():
             if dnf.util.is_glob_pattern(value):

--- a/dnf/subject.py
+++ b/dnf/subject.py
@@ -52,7 +52,7 @@ class Subject(object):
     @staticmethod
     def _nevra_to_selector(sltr, nevra):
         if nevra.name is not None:
-            sltr.set_autoglob(name=nevra.name)
+            sltr._set_autoglob(name=nevra.name)
         if nevra.version is not None:
             evr = nevra.version
             if nevra.epoch is not None and nevra.epoch > 0:

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -30,5 +30,5 @@ class SelectorTest(TestCase):
     def test_set_autoglob(self):
         sltr = dnf.selector.Selector(self.sack)
         with mock.patch.object(sltr, 'set') as mock_set:
-            sltr.set_autoglob(learn="how", to="play*")
+            sltr._set_autoglob(learn="how", to="play*")
             mock_set.assert_called_with(learn="how", to__glob="play*")


### PR DESCRIPTION
To make more distinguishable API and private functions the def set_autoglob
was renamed to _set_autoglob.