### PR TITLE
 '--exclude' option empties whole transaction

### DIFF
--- a/dnf/conf/parser.py
+++ b/dnf/conf/parser.py
@@ -235,7 +235,7 @@ class ConfigPreProcessor(object):
         fo = self._incstack.pop()
         fo.close()
         if len(self._incstack) > 0:
-            self.name = self._incstack[-1].geturl()
+            self.name = self._incstack[-1].name
         else:
             self.name = None
 


### PR DESCRIPTION
_incstack contains file objects (opened) (RhBug:1227053)

fixing
Traceback (most recent call last):
...
  File "/usr/lib/python3.4/site-packages/dnf/conf/parser.py", line 167, in readline
    self._popfile()
  File "/usr/lib/python3.4/site-packages/dnf/conf/parser.py", line 236, in _popfile
    self.name = self._incstack[-1].geturl()
  File "/usr/lib64/python3.4/tempfile.py", line 394, in __getattr__
    a = getattr(file, name)
AttributeError: '_io.TextIOWrapper' object has no attribute 'geturl'