### PR TITLE
spec: require python2-pygpgme explicitly

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -97,7 +97,11 @@ BuildRequires:  python-iniparse
 BuildRequires:  python-libcomps >= %{libcomps_version}
 BuildRequires:  python-librepo >= %{librepo_version}
 BuildRequires:  python-nose
+%if 0%{?rhel} && 0%{?rhel} <= 7
 BuildRequires:  pygpgme
+%else
+BuildRequires:  python2-pygpgme
+%endif
 BuildRequires:  pyliblzma
 BuildRequires:  rpm-python >= %{rpm_version}
 Recommends:     bash-completion
@@ -108,7 +112,11 @@ Requires:       python-hawkey >= %{hawkey_version}
 Requires:       python-iniparse
 Requires:       python-libcomps >= %{libcomps_version}
 Requires:       python-librepo >= %{librepo_version}
+%if 0%{?rhel} && 0%{?rhel} <= 7
 Requires:       pygpgme
+%else
+Requires:       python2-pygpgme
+%endif
 Requires:       rpm-plugin-systemd-inhibit
 Requires:       rpm-python >= %{rpm_version}
 


### PR DESCRIPTION
So far we didn't fix bug in builddep which installs dependencies by
provides explicitly require python2-pygpgme. Anyway it's good thing
to do.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1332830
References: https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/message/5DAXFPMJEIISHLKNCYTGYMDLBW2F5GKK/
Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>