### PR TITLE
Allow file arg for --whatprovides in repoquery (RhBug:1356926)

### DIFF
--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -300,7 +300,11 @@ class RepoQueryCommand(commands.Command):
         if self.opts.file:
             q = q.filter(file__glob=self.opts.file)
         if self.opts.whatprovides:
-            q = q.filter(provides__glob=[self.opts.whatprovides])
+            a = q.filter(provides__glob=[self.opts.whatprovides])
+            if a:
+                q = a
+            else:
+                q = q.filter(file__glob=self.opts.whatprovides)
         if self.opts.alldeps or self.opts.exactdeps:
             if not self.opts.whatrequires:
                 raise dnf.exceptions.Error(


### PR DESCRIPTION
It makes it compatible with yum repoquery

https://bugzilla.redhat.com/show_bug.cgi?id=1356926