### PR TITLE
Add description of localpkg_gpgcheck conf option (RhBug:1297087)

### DIFF
--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -331,6 +331,11 @@ configuration.
 
     Determines how DNF resolves host names. Set this to '4'/'IPv4' or '6'/'IPv6' to resolve to IPv4 or IPv6 addresses only. By default, DNF resolves to either addresses.
 
+``localpkg_gpgcheck``
+    :ref:`boolean <boolean-label>`
+
+    Whether to perform a GPG signature check on local packages (packages in a file, not in a repositoy). The default is False.
+
 ``max_parallel_downloads``
     :ref:`integer <integer-label>`
 


### PR DESCRIPTION
The option was supported by yum and dnf, but in dnf was not mentioned in
documentation.

https://bugzilla.redhat.com/show_bug.cgi?id=1297087