### PR TITLE
Fix handling with unicode directory (RhBug:1308994)

### DIFF
--- a/dnf/yum/rpmsack.py
+++ b/dnf/yum/rpmsack.py
@@ -31,6 +31,7 @@ flags = {"GT": rpm.RPMSENSE_GREATER,
          "EQ": rpm.RPMSENSE_EQUAL,
          None: 0 }
 
+
 def _open_no_umask(*args):
     """ Annoying people like to set umask's for root, which screws everything
         up for user readable stuff. """
@@ -45,6 +46,7 @@ def _open_no_umask(*args):
 
     return ret
 
+
 def _makedirs_no_umask(*args):
     """ Annoying people like to set umask's for root, which screws everything
         up for user readable stuff. """
@@ -55,6 +57,7 @@ def _makedirs_no_umask(*args):
         os.umask(oumask)
 
     return ret
+
 
 def _iopen(*args):
     """ IOError wrapper BS for open, stupid exceptions. """
@@ -67,8 +70,10 @@ def _iopen(*args):
         return None, e
     return ret, None
 
+
 def _sanitize(path):
     return path.replace('/', '').replace('~', '')
+
 
 class AdditionalPkgDB(object):
     """ Accesses additional package data rpmdb is unable to store.
@@ -124,6 +129,7 @@ class AdditionalPkgDB(object):
 
         return RPMDBAdditionalDataPackage(self.conf, thisdir,
                                           yumdb_cache=self.yumdb_cache)
+
 
 class RPMDBAdditionalDataPackage(object):
 

--- a/dnf/yum/rpmsack.py
+++ b/dnf/yum/rpmsack.py
@@ -15,7 +15,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from . import misc
-from sys import version_info
 import dnf.pycomp
 import glob
 import logging
@@ -23,8 +22,6 @@ import os
 import rpm
 
 logger = logging.getLogger('dnf')
-
-PY3 = version_info.major >= 3
 
 # For returnPackages(patterns=)
 flags = {"GT": rpm.RPMSENSE_GREATER,
@@ -39,7 +36,7 @@ def _open_no_umask(*args):
         up for user readable stuff. """
     oumask = os.umask(0o22)
     try:
-        if PY3:
+        if dnf.pycomp.PY3:
             ret = open(*args, encoding='utf-8')
         else:
             ret = open(*args)
@@ -62,7 +59,7 @@ def _makedirs_no_umask(*args):
 def _iopen(*args):
     """ IOError wrapper BS for open, stupid exceptions. """
     try:
-        if PY3:
+        if dnf.pycomp.PY3:
             ret = open(*args, encoding='utf-8')
         else:
             ret = open(*args)

--- a/dnf/yum/rpmsack.py
+++ b/dnf/yum/rpmsack.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from . import misc
+from sys import version_info
 import dnf.pycomp
 import glob
 import logging
@@ -22,6 +23,8 @@ import os
 import rpm
 
 logger = logging.getLogger('dnf')
+
+PY3 = version_info.major >= 3
 
 # For returnPackages(patterns=)
 flags = {"GT": rpm.RPMSENSE_GREATER,
@@ -36,7 +39,10 @@ def _open_no_umask(*args):
         up for user readable stuff. """
     oumask = os.umask(0o22)
     try:
-        ret = open(*args, encoding='utf-8')
+        if PY3:
+            ret = open(*args, encoding='utf-8')
+        else:
+            ret = open(*args)
     finally:
         os.umask(oumask)
 
@@ -56,7 +62,10 @@ def _makedirs_no_umask(*args):
 def _iopen(*args):
     """ IOError wrapper BS for open, stupid exceptions. """
     try:
-        ret = open(*args, encoding='utf-8')
+        if PY3:
+            ret = open(*args, encoding='utf-8')
+        else:
+            ret = open(*args)
     except IOError as e:
         return None, e
     return ret, None


### PR DESCRIPTION
It fixes handling of local rpm from unicode directory.

https://bugzilla.redhat.com/show_bug.cgi?id=1308994

Fix commit 63ab30c520d9fb7d83496f3616e454c363d4bacc