### PR TITLE
dnf-automatic crashed when option 'emitter' was set to 'None' (RhBug:1314961)

### DIFF
--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -60,7 +60,7 @@ def build_emitters(conf):
                 emitter = dnf.automatic.emitter.MotdEmitter(system_name)
                 emitters.append(emitter)
             else:
-                assert False
+                raise dnf.exceptions.ConfigError("Unknowr emitter option: %s" % name)
     return emitters
 
 

--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -58,7 +58,8 @@ def build_emitters(conf):
             emitter = dnf.automatic.emitter.MotdEmitter(system_name)
             emitters.append(emitter)
         else:
-            assert False
+            if name != 'None':
+                assert False
     return emitters
 
 

--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -47,18 +47,20 @@ logger = logging.getLogger('dnf')
 def build_emitters(conf):
     emitters = dnf.util.MultiCallList([])
     system_name = conf.emitters.system_name
-    for name in conf.emitters.emit_via:
-        if name == 'email':
-            emitter = dnf.automatic.emitter.EmailEmitter(system_name, conf.email)
-            emitters.append(emitter)
-        elif name == 'stdio':
-            emitter = dnf.automatic.emitter.StdIoEmitter(system_name)
-            emitters.append(emitter)
-        elif name == 'motd':
-            emitter = dnf.automatic.emitter.MotdEmitter(system_name)
-            emitters.append(emitter)
-        else:
-            assert False
+    emit_via = conf.emitters.emit_via
+    if emit_via:
+        for name in emit_via:
+            if name == 'email':
+                emitter = dnf.automatic.emitter.EmailEmitter(system_name, conf.email)
+                emitters.append(emitter)
+            elif name == 'stdio':
+                emitter = dnf.automatic.emitter.StdIoEmitter(system_name)
+                emitters.append(emitter)
+            elif name == 'motd':
+                emitter = dnf.automatic.emitter.MotdEmitter(system_name)
+                emitters.append(emitter)
+            else:
+                assert False
     return emitters
 
 

--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -57,9 +57,8 @@ def build_emitters(conf):
         elif name == 'motd':
             emitter = dnf.automatic.emitter.MotdEmitter(system_name)
             emitters.append(emitter)
-        else:
-            if name != 'None':
-                assert False
+        else: 
+            assert False
     return emitters
 
 

--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -57,7 +57,7 @@ def build_emitters(conf):
         elif name == 'motd':
             emitter = dnf.automatic.emitter.MotdEmitter(system_name)
             emitters.append(emitter)
-        else: 
+        else:
             assert False
     return emitters
 

--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -519,6 +519,8 @@ class BaseConfig(object):
         if parser.has_section(section):
             for name in parser.options(section):
                 value = parser.get(section, name)
+                if value == 'None':
+                    value = ''
                 opt = self._get_option(name)
                 if opt and not opt._is_runtimeonly():
                     try:

--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -520,7 +520,7 @@ class BaseConfig(object):
             for name in parser.options(section):
                 value = parser.get(section, name)
                 if value == 'None':
-                    value = ''
+                    value = None 
                 opt = self._get_option(name)
                 if opt and not opt._is_runtimeonly():
                     try:

--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -520,7 +520,7 @@ class BaseConfig(object):
             for name in parser.options(section):
                 value = parser.get(section, name)
                 if value == 'None':
-                    value = None 
+                    value = None
                 opt = self._get_option(name)
                 if opt and not opt._is_runtimeonly():
                     try:

--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -519,7 +519,7 @@ class BaseConfig(object):
         if parser.has_section(section):
             for name in parser.options(section):
                 value = parser.get(section, name)
-                if value == 'None':
+                if not value or value == 'None':
                     value = None
                 opt = self._get_option(name)
                 if opt and not opt._is_runtimeonly():

--- a/etc/dnf/automatic.conf
+++ b/etc/dnf/automatic.conf
@@ -25,6 +25,7 @@ apply_updates = no
 # program will send email itself according to the configured options.
 # If emit_via includes motd, /etc/motd file will have the messages.
 # Default is email,stdio.
+# If emit_via is None or left blank, no messages will be sent.
 emit_via = stdio
 
 


### PR DESCRIPTION
Option 'emitter' can now be set to 'motd', 'stdio', 'email' or 'None'.

References: https://bugzilla.redhat.com/show_bug.cgi?id=1314961