### PR TITLE
Misleading error message when trying to "upgrade" src.rpm (RhBug:1365…

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1529,8 +1529,8 @@ class Base(object):
             raise NotImplementedError(msg)
 
         if pkg.arch == 'src':
-            msg = _("Package %s is a source package and cannot be updated, ignoring.")
-            logger.info(msg, pkg.name)
+            msg = _("File %s is a source package and cannot be updated, ignoring.")
+            logger.info(msg, pkg.location)
             return 0
 
         q = self.sack.query().installed().filter(name=pkg.name, arch=[pkg.arch, "noarch"])

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1528,6 +1528,11 @@ class Base(object):
             msg = 'upgrade_package() for an installed package.'
             raise NotImplementedError(msg)
 
+        if pkg.arch == 'src':
+            msg = _("Package %s is a source package and cannot be updated, ignoring.")
+            logger.info(msg, pkg.name)
+            return 0
+
         q = self.sack.query().installed().filter(name=pkg.name, arch=[pkg.arch, "noarch"])
         if not q:
             msg = _("Package %s not installed, cannot update it.")


### PR DESCRIPTION
…593)

When trying to update source package should be print info that it is source package and not print misleading error that package is not installed so cannot be upgraded

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1365593