### PR TITLE
tests: cleanup of nogpgcheck leftovers

### DIFF
--- a/tests/support.py
+++ b/tests/support.py
@@ -252,7 +252,7 @@ class _BaseStubMixin(object):
         logger.setLevel(logging.DEBUG)
         logger.addHandler(logging.StreamHandler(stream))
         return mock.Mock(base=self, log_stream=stream, logger=logger,
-                         nogpgcheck=True, demands=dnf.cli.demand.DemandSheet())
+                         demands=dnf.cli.demand.DemandSheet())
 
     def read_mock_comps(self, seed_persistor=True):
         self._comps, self._group_persistor = mock_comps(seed_persistor)
@@ -277,7 +277,6 @@ class BaseCliStub(_BaseStubMixin, dnf.cli.cli.BaseCli):
 
 class CliStub(object):
     """A class mocking `dnf.cli.Cli`."""
-    nogpgcheck = True
 
     def __init__(self, base):
         """Initialize the CLI."""


### PR DESCRIPTION
This is no longer needed after 1679f9f6.