### PR TITLE
Create new api method setup_logging_from_conf()

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -230,6 +230,11 @@ class Base(object):
         """Run plugins configure() method."""
         self._plugins._run_config()
 
+    def setup_logging_from_conf(self):
+        # :api
+        """Setup debuglevel, errorlevel and logdir from base.conf object"""
+        return self._logging._setup_from_dnf_conf(self._conf)
+
     def fill_sack(self, load_system_repo=True, load_available_repos=True):
         # :api
         """Prepare the Sack and the Goal objects. """

--- a/doc/api_base.rst
+++ b/doc/api_base.rst
@@ -66,6 +66,10 @@
 
      Configure plugins by runing their configure() method.
 
+  .. method:: setup_logging_from_conf(self, conf)
+
+     Setup :ref:`debuglevel <debuglevel-label>` , :ref:`errorlevel <errorlevel-label>` and :ref:`logdir <logdir-label>` for logging from base.conf object.
+
   .. method:: fill_sack([load_system_repo=True, load_available_repos=True])
 
     Setup the package sack. If `load_system_repo` is ``True``, load information about packages in the local RPMDB into the sack. Else no package is considered installed during dependency solving. If `load_available_repos` is ``True``, load information about packages from the available repositories into the sack.

--- a/doc/api_conf.rst
+++ b/doc/api_conf.rst
@@ -40,9 +40,18 @@ Configurable settings of the :class:`dnf.Base` object are stored into a :class:`
 
     Path to the default main configuration file. Default is ``"/etc/dnf/dnf.conf"``.
 
+.. _debuglevel-label:
+
   .. attribute:: debuglevel
 
     Debug messages output level, in the range 0 to 10. Default is 2.
+
+.. _errorlevel-label:
+
+  .. attribute:: errorlevel
+
+    Error messages output level, in the range 0 to 10. The higher the number the
+    more error output is put to stderr. Default is 2.
 
   .. attribute:: get_reposdir
 
@@ -61,6 +70,8 @@ Configurable settings of the :class:`dnf.Base` object are stored into a :class:`
   .. attribute:: installroot
 
     The root of the filesystem for all packaging operations.
+
+.. _logdir-label:
 
   .. attribute:: logdir
 

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -91,7 +91,7 @@ or :ref:`mirrorlist <mirrorlist-label>` option definition.
     :ref:`integer <integer-label>`
 
     Error messages output level, in the range 0 to 10. The higher the number the
-    more error output is put to stderr. Default is 2. This is deprecated in DNF.
+    more error output is put to stderr. Default is 2.
 
 ``install_weak_deps``
     :ref:`boolean <boolean-label>`
@@ -130,6 +130,11 @@ or :ref:`mirrorlist <mirrorlist-label>` option definition.
     Keeps downloaded packages in the cache when set to True. Even if it is set to False and packages have not been
     installed they will still persist until next successful transaction. The default
     is False.
+
+``logdir``
+    :ref:`string <string-label>`
+
+    Directory where the log files will be stored. Default is ``/var/log``.
 
 .. _metadata_timer_sync-label:
 


### PR DESCRIPTION
It allows users of API to setup debuglevel, errorlevel and logdir for logging.
It is used by lorax.