### PR TITLE
Raise error for group_install() if unknown group_id

### DIFF
--- a/dnf/comps.py
+++ b/dnf/comps.py
@@ -531,6 +531,8 @@ class Solver(object):
 
     def _group_install(self, group_id, pkg_types, exclude, strict=True):
         group = self.comps._group_by_id(group_id)
+        if not group:
+            raise ValueError(_("Group_id '%s' does not exist.") % ucd(group_id))
         p_grp = self.persistor.group(group_id)
         if p_grp.installed:
             raise CompsError(_("Group '%s' is already installed.") %


### PR DESCRIPTION
It fixes traceback if group_id doesn't exist. It is only important for API
users.

File "/usr/lib/python3.5/site-packages/dnf/comps.py", line 540, in _group_install
  p_grp.name = group.name
AttributeError: 'NoneType' object has no attribute 'name'