### PR TITLE
Fix incorrect value of reponame

### DIFF
--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -747,7 +747,7 @@ class RepoPkgsCommand(Command):
         def run_on_repo(self):
             """Execute the command with respect to given arguments *cli_args*."""
             _checkGPGKey(self.base, self.cli)
-            self.base.upgrade_userlist_to(self.opts.pkg_specs, self.opts.reponame)
+            self.base.upgrade_userlist_to(self.opts.pkg_specs, self.reponame)
 
     SUBCMDS = {CheckUpdateSubCommand, InfoSubCommand, InstallSubCommand,
                ListSubCommand, MoveToSubCommand, ReinstallOldSubCommand,


### PR DESCRIPTION
File "/usr/lib64/python3.5/site-packages/hawkey/__init__.py", line 359, in set
  super(Selector, self).set(*arg_tuple)
TypeError: must be str, not list