### PR TITLE
Add version to Obsoletes for dnf-langpacks package (RhBug:1366793)

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -72,7 +72,7 @@ Conflicts:      python3-dnf-plugins-core < %{min_plugins_core}
 
 # dnf-langpacks package is retired in F25
 # to have clean upgrade path for dnf-langpacks
-Obsoletes:      dnf-langpacks
+Obsoletes:      dnf-langpacks  <= 0.15.1-6
 
 %description
 Package manager forked from Yum, using libsolv as a dependency resolver.


### PR DESCRIPTION
In the last FESCo meeting it was decided that obsoletes for dnf-langpacks be versioned obsoletes. Hence, proposing this change.