### PR TITLE
dnf-2.0:Renamed option 'last' to '--last'

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -558,7 +558,7 @@ class BaseCli(dnf.Base):
     def transaction_id_or_offset(extcmd):
         """Convert user input to a transaction ID or an offset from the end."""
         try:
-            offset_str, = re.match('^--last(-\d+)?$', extcmd).groups()
+            offset_str, = re.match('^last(-\d+)?$', extcmd).groups()
         except AttributeError:  # extcmd does not match the regex.
             id_ = int(extcmd)
             if id_ < 0:
@@ -566,7 +566,7 @@ class BaseCli(dnf.Base):
                 raise ValueError('bad transaction ID given: %s' % extcmd)
             return id_
         else:
-            # Was extcmd '--last-N' or just '--last'?
+            # Was extcmd 'last-N' or just 'last'?
             offset = int(offset_str) if offset_str else 0
             # Return offsets as negative numbers, where -1 means the last
             # transaction as when indexing sequences.

--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -1339,10 +1339,10 @@ Transaction Summary
         ''' Convert a user "TID" string of 2..4 into: (2, 4). '''
         def str2int(x):
             try:
-                if x == '--last' or x.startswith('--last-'):
+                if x == 'last' or x.startswith('last-'):
                     tid = old.tid
-                    if x.startswith('--last-'):
-                        off = int(x[len('--last-'):])
+                    if x.startswith('last-'):
+                        off = int(x[len('last-'):])
                         if off <= 0:
                             int("z")
                         tid -= off

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -1178,8 +1178,8 @@ Specifying Transactions
 =======================
 
 ``<transaction-spec>`` can be in one of several forms. If it is an integer, it
-specifies a transaction ID. Specifying ``--last`` is the same as specifying the ID
-of the most recent transaction. The last form is ``--last-<offset>``, where
+specifies a transaction ID. Specifying ``last`` is the same as specifying the ID
+of the most recent transaction. The last form is ``last-<offset>``, where
 ``<offset>`` is a positive integer. It specifies offset-th transaction preceding
 the most recent transaction.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -97,7 +97,7 @@ class BaseCliTest(support.ResultTestCase):
 
     def test_transaction_id_or_offset_last(self, _):
         """Test transaction_id_or_offset with the zero offset."""
-        id_or_offset = dnf.cli.cli.BaseCli.transaction_id_or_offset('--last')
+        id_or_offset = dnf.cli.cli.BaseCli.transaction_id_or_offset('last')
         self.assertEqual(id_or_offset, -1)
 
     def test_transaction_id_or_offset_negativeid(self, _):
@@ -107,7 +107,7 @@ class BaseCliTest(support.ResultTestCase):
 
     def test_transaction_id_or_offset_offset(self, _):
         """Test transaction_id_or_offset with an offset."""
-        id_or_offset = dnf.cli.cli.BaseCli.transaction_id_or_offset('--last-1')
+        id_or_offset = dnf.cli.cli.BaseCli.transaction_id_or_offset('last-1')
         self.assertEqual(id_or_offset, -2)
 
     def test_transaction_id_or_offset_positiveid(self, _):


### PR DESCRIPTION
After changes in argparser dnf did not recognise '--last' option. Fix of commit 1681a5fafbb66e115b8ab71ae9b374227aeb7c6c.
