### PR TITLE
repo: Fix usage of private property

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -78,6 +78,7 @@ DNF CONTRIBUTORS
     Neal Gompa <ngompa13@gmail.com>
     Olivier Andrieu <olivier.andrieu@esterel-technologies.com>
     Padraig Brady <P@draigBrady.com>
+    Pavel Grunt <pgrunt@redhat.com>
     Peter Hjalmarsson <kanelxake@gmail.com>
     Peter Simonyi <pts@petersimonyi.ca>
     Petr Spacek <pspacek@redhat.com>

--- a/dnf/repo.py
+++ b/dnf/repo.py
@@ -606,7 +606,7 @@ class Repo(dnf.conf.RepoConf):
         return Metadata(result, handle)
 
     def _handle_load_with_pubring(self, handle):
-        with dnf.crypto.pubring_dir(self.pubring_dir):
+        with dnf.crypto.pubring_dir(self._pubring_dir):
             return self._handle_load_core(handle)
 
     def _handle_new_local(self, destdir):


### PR DESCRIPTION
Commit 4e66869e80cce61d3b9a5bd75e1474e3fe92a3fd renamed pubring_dir to
_pubring_dir, however this change wasn't reflected in the code causing:

Traceback (most recent call last):
  File "/usr/lib/python3.5/site-packages/dnf/cli/main.py", line 60, in main
    return _main(base, args)
  File "/usr/lib/python3.5/site-packages/dnf/cli/main.py", line 111, in _main
    cli.run()
  File "/usr/lib/python3.5/site-packages/dnf/cli/cli.py", line 946, in run
    self._process_demands()
  File "/usr/lib/python3.5/site-packages/dnf/cli/cli.py", line 788, in _process_demands
    load_available_repos=self.demands.available_repos)
  File "/usr/lib/python3.5/site-packages/dnf/base.py", line 252, in fill_sack
    self._add_repo_to_sack(r)
  File "/usr/lib/python3.5/site-packages/dnf/base.py", line 109, in _add_repo_to_sack
    repo.load()
  File "/usr/lib/python3.5/site-packages/dnf/repo.py", line 800, in load
    if self.metadata or self._try_cache():
  File "/usr/lib/python3.5/site-packages/dnf/repo.py", line 723, in _try_cache
    self.metadata = self._handle_load(handle)
  File "/usr/lib/python3.5/site-packages/dnf/repo.py", line 592, in _handle_load
    return self._handle_load_with_pubring(handle)
  File "/usr/lib/python3.5/site-packages/dnf/repo.py", line 609, in _handle_load_with_pubring
    with dnf.crypto.pubring_dir(self.pubring_dir):
AttributeError: 'Repo' object has no attribute 'pubring_dir