### PR TITLE
Mark transaction_run() in Command() as API

### DIFF
--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -140,7 +140,7 @@ class Command(object):
         """Execute the command."""
         pass
 
-    def _run_transaction(self):
+    def run_transaction(self):
         """Finalize operations post-transaction."""
         pass
 

--- a/dnf/cli/commands/group.py
+++ b/dnf/cli/commands/group.py
@@ -408,7 +408,7 @@ class GroupCommand(commands.Command):
         if cmd == 'remove':
             return self.base.env_group_remove(extcmds)
 
-    def _run_transaction(self):
+    def run_transaction(self):
         if not self._remark:
             return
         goal = self.base._goal

--- a/dnf/cli/main.py
+++ b/dnf/cli/main.py
@@ -127,7 +127,7 @@ def _main(base, args):
         if ret:
             return ret
 
-    cli.command._run_transaction()
+    cli.command.run_transaction()
     return cli.demands.success_exit_status
 
 


### PR DESCRIPTION
This post-transaction method is used by group command, and can be used later on
by other plugins.

It reverts commit: d4af1b50f8850fc9cb9d57bc8db89b7012f7b3fd