### PR TITLE
Enable comps reduction to system basearch (RhBug:1337731)

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -1,6 +1,6 @@
 %global hawkey_version 0.7.0
 %global librepo_version 1.7.19
-%global libcomps_version 0.1.6
+%global libcomps_version 0.1.8
 %global rpm_version 4.13.0-0.rc1.29
 %global min_plugins_core 0.1.13
 %global dnf_langpacks_ver 0.15.1-6

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -401,7 +401,7 @@ class Base(object):
     def _activate_group_persistor(self):
         return dnf.persistor.GroupPersistor(self.conf.persistdir, self._comps)
 
-    def read_comps(self):
+    def read_comps(self, arch_filter=False):
         # :api
         """Create the groups object to access the comps metadata."""
         timer = dnf.logging.Timer('loading comps')
@@ -435,6 +435,9 @@ class Base(object):
                 logger.critical(msg, repo.id, e)
 
         self._group_persistor = self._activate_group_persistor()
+        if arch_filter:
+            self._comps._i.arch_filter(
+                [self._conf.substitutions['basearch']])
         timer()
         return self._comps
 

--- a/dnf/cli/commands/group.py
+++ b/dnf/cli/commands/group.py
@@ -104,7 +104,7 @@ class GroupCommand(commands.Command):
         return installed, available
 
     def _grp_setup(self):
-        self.base.read_comps()
+        self.base.read_comps(arch_filter=True)
 
     def _info(self, userlist):
         for strng in userlist:

--- a/dnf/cli/commands/install.py
+++ b/dnf/cli/commands/install.py
@@ -83,7 +83,7 @@ class InstallCommand(commands.Command):
 
         # Install groups.
         if self.opts.grp_specs and self.opts.command != ['localinstall']:
-            self.base.read_comps()
+            self.base.read_comps(arch_filter=True)
             try:
                 self.base.env_group_install(self.opts.grp_specs,
                                             self.base.conf.group_package_types,

--- a/dnf/cli/commands/remove.py
+++ b/dnf/cli/commands/remove.py
@@ -89,7 +89,7 @@ class RemoveCommand(commands.Command):
 
         # Remove groups.
         if self.opts.grp_specs:
-            self.base.read_comps()
+            self.base.read_comps(arch_filter=True)
             if self.base.env_group_remove(self.opts.grp_specs):
                 done = True
 

--- a/dnf/cli/commands/upgrade.py
+++ b/dnf/cli/commands/upgrade.py
@@ -83,7 +83,7 @@ class UpgradeCommand(commands.Command):
 
             # Update groups.
             if self.opts.grp_specs:
-                self.base.read_comps()
+                self.base.read_comps(arch_filter=True)
                 self.base.env_group_upgrade(self.opts.grp_specs)
                 done = True
         else:

--- a/doc/api_base.rst
+++ b/doc/api_base.rst
@@ -113,7 +113,7 @@
 
   .. method:: read_comps(arch_filter=False)
 
-    Read comps data from all the enabled repositories and initialize the :attr:`comps` object. If arch_filter=True then result is limited to system basearch.
+    Read comps data from all the enabled repositories and initialize the :attr:`comps` object. If `arch_filter` is set to ``True``, the result is limited to system basearch.
 
   .. method:: reset(**kwargs)
 

--- a/doc/api_base.rst
+++ b/doc/api_base.rst
@@ -111,9 +111,9 @@
 
     Read repository configuration from the main configuration file specified by :attr:`dnf.conf.Conf.config_file_path` and any ``.repo`` files under :attr:`dnf.conf.Conf.reposdir`. All the repositories found this way are added to :attr:`~.Base.repos`.
 
-  .. method:: read_comps()
+  .. method:: read_comps(arch_filter=False)
 
-    Read comps data from all the enabled repositories and initialize the :attr:`comps` object.
+    Read comps data from all the enabled repositories and initialize the :attr:`comps` object. If arch_filter=True then result is limited to system basearch.
 
   .. method:: reset(**kwargs)
 

--- a/doc/examples/install_extension.py
+++ b/doc/examples/install_extension.py
@@ -48,7 +48,7 @@ if __name__ == '__main__':
             sys.exit(e)
         # Comps data reading initializes the base.comps attribute.
         if GRP_SPECS:
-            base.read_comps()
+            base.read_comps(arch_filter=True)
         # Group marking methods set the user request.
         for grp_spec in GRP_SPECS:
             group = base.comps.group_by_pattern(grp_spec)

--- a/doc/examples/install_plugin.py
+++ b/doc/examples/install_plugin.py
@@ -61,8 +61,8 @@ class Command(dnf.cli.Command):
         except EnvironmentError as e:
             raise dnf.exceptions.Error(e)
         # Comps data reading initializes the base.comps attribute.
-        if grp_specs:
-            self.base.read_comps()
+        if self.opts.grp_specs:
+            self.base.read_comps(arch_filter=True)
         # Group marking methods set the user request.
         for grp_spec in self.opts.grp_specs:
             group = self.base.comps.group_by_pattern(grp_spec)


### PR DESCRIPTION
If in comps something like:
``<packagereq arch arch="x86_64 s390">pkg3</packagereq>``
Then the package 'pkg3' will be installed or listed with group only on machine
with listed basearch.

https://bugzilla.redhat.com/show_bug.cgi?id=1337731