### PR TITLE
dnf-2.0: dnf-automatic wasn't working

### DIFF
--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -134,7 +134,7 @@ def main(args):
         conf = AutomaticConfig(opts.conf_path)
         with dnf.Base() as base:
             cli = dnf.cli.Cli(base)
-            cli._read_conf_file(conf.commands.base_config_file)
+            cli._read_conf_file()
             conf.update_baseconf(base.conf)
             logger.debug('Started dnf-automatic.')
 


### PR DESCRIPTION
dnf-automatic failed to synchronized cache with fedora repo because of bad url.