### PR TITLE
Change search priority in Subject().get_best* (RhBug:1096506)

### DIFF
--- a/dnf/subject.py
+++ b/dnf/subject.py
@@ -95,11 +95,6 @@ class Subject(object):
                   'icase': self.icase}
         if forms:
             kwargs['form'] = forms
-        nevra = first(self.subj.nevra_possibilities_real(sack, **kwargs))
-        if nevra:
-            q = self._nevra_to_filters(sack.query(), nevra)
-            if q:
-                return q
 
         if with_provides:
             reldeps = self.subj.reldep_possibilities_real(sack, icase=self.icase)
@@ -108,6 +103,12 @@ class Subject(object):
                 q = sack.query().filter(provides=reldep)
                 if q:
                     return q
+
+        nevra = first(self.subj.nevra_possibilities_real(sack, **kwargs))
+        if nevra:
+            q = self._nevra_to_filters(sack.query(), nevra)
+            if q:
+                return q
 
         if self._filename_pattern:
             return sack.query().filter(file__glob=pat)
@@ -120,18 +121,18 @@ class Subject(object):
         kwargs = {'allow_globs': True}
         if forms:
             kwargs['form'] = forms
-        nevra = first(self.subj.nevra_possibilities_real(sack, **kwargs))
-        if nevra:
-            sltr = dnf.selector.Selector(sack)
-            s = self._nevra_to_selector(sltr, nevra)
-            if len(s.matches()) > 0:
-                return s
-
         reldep = first(self.subj.reldep_possibilities_real(sack))
         if reldep:
             sltr = dnf.selector.Selector(sack)
             dep = str(reldep)
             s = sltr.set(provides=dep)
+            if len(s.matches()) > 0:
+                return s
+
+        nevra = first(self.subj.nevra_possibilities_real(sack, **kwargs))
+        if nevra:
+            sltr = dnf.selector.Selector(sack)
+            s = self._nevra_to_selector(sltr, nevra)
             if len(s.matches()) > 0:
                 return s
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -198,7 +198,7 @@ class InstalledMatchingTest(support.ResultTestCase):
 
     def test_query_matching(self):
         subj = dnf.subject.Subject("pepper")
-        query = subj.get_best_query(self.sack)
+        query = subj.get_best_query(self.sack, with_provides=False)
         inst, avail = self.base._query_matches_installed(query)
         self.assertCountEqual(['pepper-20-0.x86_64'], map(str, inst))
         self.assertCountEqual(['pepper-20-0.src'], map(str, avail))


### PR DESCRIPTION
It solves different behavior of dnf with yum, where if installing package was
obsoleted and provide by other package, it try to search in provides first,
therefore obsoleting package will be installed.

https://bugzilla.redhat.com/show_bug.cgi?id=1096506