### PR TITLE
fix LockTest when username contains non-alphanumeric character

### DIFF
--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -74,7 +74,7 @@ class LockTest(tests.support.TestCase):
         with mock.patch('dnf.util.am_i_root', return_value=False):
             dir_ = dnf.lock._fit_lock_dir(orig)
             match = re.match(
-                r'/var/tmp/dnf-\w+-\w+/locks/8e58d9adbd213a8b602f30604a8875f2',
+                r'/var/tmp/dnf-[^:]+-[^/]+/locks/8e58d9adbd213a8b602f30604a8875f2',
                 dir_)
             self.assertTrue(match)
 


### PR DESCRIPTION
This is the test failure observed here: https://github.com/rpm-software-management/dnf/pull/601#issuecomment-246376159  The test failed while being run as the user "alan-sysop".

Usernames can contain any character (apart from ':').
Nor does the man page for mkdtemp() specify what characters are used.

I didn't test a username containing '/', but I don't expect that's common.

