### PR TITLE
Redirect information about unknown option according to debug level

### DIFF
--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -78,6 +78,7 @@ class AutomaticConfig(object):
         self._parser = None
         self._load(filename)
         self.commands.imply()
+        self.filename = filename
 
     def _load(self, filename):
         parser = iniparse.compat.ConfigParser()
@@ -87,13 +88,13 @@ class AutomaticConfig(object):
         except iniparse.compat.ParsingError as e:
             raise dnf.exceptions.ConfigError("Parsing file failed: %s" % e)
 
-        self.commands._populate(parser, 'commands', dnf.conf.PRIO_AUTOMATICCONFIG)
-        self.email._populate(parser, 'email', dnf.conf.PRIO_AUTOMATICCONFIG)
-        self.emitters._populate(parser, 'emitters', dnf.conf.PRIO_AUTOMATICCONFIG)
+        self.commands._populate(parser, 'commands', filename, dnf.conf.PRIO_AUTOMATICCONFIG)
+        self.email._populate(parser, 'email', filename, dnf.conf.PRIO_AUTOMATICCONFIG)
+        self.emitters._populate(parser, 'emitters', filename, dnf.conf.PRIO_AUTOMATICCONFIG)
         self._parser = parser
 
     def update_baseconf(self, baseconf):
-        baseconf._populate(self._parser, 'base', dnf.conf.PRIO_AUTOMATICCONFIG)
+        baseconf._populate(self._parser, 'base', self.filename, dnf.conf.PRIO_AUTOMATICCONFIG)
 
 
 class CommandsConfig(dnf.conf.BaseConfig):

--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -532,11 +532,11 @@ class BaseConfig(object):
                     try:
                         opt._set(value, priority)
                     except dnf.exceptions.ConfigError as e:
-                        logger.warning(_('Unknown configuration value: '
+                        logger.debug(_('Unknown configuration value: '
                                          '%s=%s; %s'),
                                        ucd(name), ucd(value), e.raw_error)
                 else:
-                    logger.warning(_('Unknown configuration option: %s = %s'),
+                    logger.debug(_('Unknown configuration option: %s = %s'),
                                    ucd(name), ucd(value))
 
     def _config_items(self):

--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -533,9 +533,8 @@ class BaseConfig(object):
                         opt._set(value, priority)
                     except dnf.exceptions.ConfigError as e:
                         logger.debug(_('Unknown configuration value: '
-                                         '%s=%s in %s; %s'),
-                                       ucd(name), ucd(value), ucd(filename),
-                                     e.raw_error)
+                                       '%s=%s in %s; %s'), ucd(name),
+                                     ucd(value), ucd(filename), e.raw_error)
                 else:
                     logger.debug(
                         _('Unknown configuration option: %s = %s in %s'),

--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -522,7 +522,7 @@ class BaseConfig(object):
     def _set_value(self, name, value, priority=PRIO_RUNTIME):
         return self._option[name]._set(value, priority)
 
-    def _populate(self, parser, section, priority=PRIO_DEFAULT):
+    def _populate(self, parser, section, filename, priority=PRIO_DEFAULT):
         """Set option values from an INI file section."""
         if parser.has_section(section):
             for name in parser.options(section):
@@ -533,11 +533,13 @@ class BaseConfig(object):
                         opt._set(value, priority)
                     except dnf.exceptions.ConfigError as e:
                         logger.debug(_('Unknown configuration value: '
-                                         '%s=%s; %s'),
-                                       ucd(name), ucd(value), e.raw_error)
+                                         '%s=%s in %s; %s'),
+                                       ucd(name), ucd(value), ucd(filename),
+                                     e.raw_error)
                 else:
-                    logger.debug(_('Unknown configuration option: %s = %s'),
-                                   ucd(name), ucd(value))
+                    logger.debug(
+                        _('Unknown configuration option: %s = %s in %s'),
+                        ucd(name), ucd(value), ucd(filename))
 
     def _config_items(self):
         """Yield (name, value) pairs for every option in the instance."""
@@ -869,7 +871,7 @@ class MainConf(BaseConfig):
             self._parser.readfp(config_pp)
         except ParsingError as e:
             raise dnf.exceptions.ConfigError("Parsing file failed: %s" % e)
-        self._populate(self._parser, self._section, priority)
+        self._populate(self._parser, self._section, filename, priority)
 
         # update to where we read the file from
         self._set_value('config_file_path', filename, priority)

--- a/dnf/conf/read.py
+++ b/dnf/conf/read.py
@@ -51,12 +51,12 @@ class RepoReader(object):
                 logger.warning(_("Warning: failed loading '%s', skipping."),
                                repofn)
 
-    def _build_repo(self, parser, id_):
+    def _build_repo(self, parser, id_, repofn):
         """Build a repository using the parsed data."""
 
         repo = dnf.repo.Repo(id_, self.conf)
         try:
-            repo._populate(parser, id_, dnf.conf.PRIO_REPOCONFIG)
+            repo._populate(parser, id_, repofn, dnf.conf.PRIO_REPOCONFIG)
         except ValueError as e:
             msg = _("Repository '%s': Error parsing config: %s" % (id_, e))
             raise dnf.exceptions.ConfigError(msg)
@@ -100,7 +100,7 @@ class RepoReader(object):
                 continue
 
             try:
-                thisrepo = self._build_repo(parser, section)
+                thisrepo = self._build_repo(parser, section, repofn)
             except (dnf.exceptions.RepoError, dnf.exceptions.ConfigError) as e:
                 logger.warning(e)
                 continue


### PR DESCRIPTION
It allows with standard DNF setting to write unknown option or value to dnf.log,
but with -v option to terminal and log. It prevents to confuze standard user
with new behavior of conf parser, but it allows to get all information in
verbose mod.