### PR TITLE
Change installonlypkgs option behavior (RhBug:1348766)

### DIFF
--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -176,13 +176,11 @@ class ListAppendOption(ListOption):
     """A list option which appends not sets values."""
 
     def _set(self, value, priority=PRIO_RUNTIME):
-        """Set option's value if priority is equal or higher
-           than curent priority."""
+        """Append option's value"""
+        new = self._make_value(value, priority)
         if self._is_default():
-            super(ListAppendOption, self)._set(value, priority)
+            self._actual = Value(self._default.value + new.value, priority)
         else:
-            # append
-            new = self._make_value(value, priority)
             self._actual = Value(self._actual.value + new.value, priority)
 
 
@@ -675,7 +673,7 @@ class MainConf(BaseConfig):
                                     "glob:/etc/dnf/protected.d/*.conf")) #:api
         self._add_option('username', Option()) # :api
         self._add_option('password', Option()) # :api
-        self._add_option('installonlypkgs', ListOption(dnf.const.INSTALLONLYPKGS))
+        self._add_option('installonlypkgs', ListAppendOption(dnf.const.INSTALLONLYPKGS))
         self._add_option('group_package_types', ListOption(dnf.const.GROUP_PACKAGE_TYPES))
             # NOTE: If you set this to 2, then because it keeps the current
             # kernel it means if you ever install an "old" kernel it'll get rid

--- a/dnf/const.py.in
+++ b/dnf/const.py.in
@@ -25,10 +25,10 @@ CONF_FILENAME='/etc/dnf/dnf.conf' # :api
 CONF_AUTOMATIC_FILENAME='/etc/dnf/automatic.conf'
 DISTROVERPKG=('system-release(releasever)', 'redhat-release')
 GROUP_PACKAGE_TYPES = ('mandatory', 'default') # :api
-INSTALLONLYPKGS=('kernel', 'kernel-PAE',
+INSTALLONLYPKGS=['kernel', 'kernel-PAE',
                  'installonlypkg(kernel)',
                  'installonlypkg(kernel-module)',
-                 'installonlypkg(vm)')
+                 'installonlypkg(vm)']
 LOG='dnf.log'
 LOG_HAWKEY='hawkey.log'
 LOG_LIBREPO='dnf.librepo.log'

--- a/doc/cli_vs_yum.rst
+++ b/doc/cli_vs_yum.rst
@@ -257,6 +257,12 @@ Contrary to Yum, when multiple downloads run simultaneously the total
 downloading speed is throttled. This was not possible in Yum since
 downloaders ran in different processes.
 
+===================================
+ ``installonlypkgs`` config option
+===================================
+
+Compared to Yum, DNF appends list values from the ``installonlypkgs`` config option to DNF defaults, where YUM overwrites the defaults by option values.
+
 ==============================
  The usage of Delta RPM files
 ==============================

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -129,8 +129,9 @@ or :ref:`mirrorlist <mirrorlist-label>` option definition.
     installed as dependencies (see
     :ref:`clean_requirements_on_remove <clean_requirements_on_remove-label>`
     for auto removal details).
-    This option overrides the default installonlypkgs list used by DNF.
-    The number of kept package versions is regulated by :ref:`installonly_limit <installonly-limit-label>`.
+    This option append the list values to the default installonlypkgs list used
+    by DNF. The number of kept package versions is regulated
+    by :ref:`installonly_limit <installonly-limit-label>`.
 
 .. _installonly-limit-label:
 


### PR DESCRIPTION
installonlypkgs option will now append packages into default list. In present
time users if they want to extend list of installonlypkgs, they have to first
add default pkgs to keep same dnf behavior.

https://bugzilla.redhat.com/show_bug.cgi?id=1348766