### PR TITLE
report all problem rules (RhBug:1148627)

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -565,9 +565,9 @@ class Base(object):
                 goal.log_decisions()
             msg = ""
             count_problems = (goal.count_problems() > 1)
-            for i, rs in enumerate(goal.problem_rules):
+            for i, rs in enumerate(goal.problem_rules, start=1):
                 if count_problems:
-                    msg += "\n " + _("Problem") +  " %s: " % (i+1)
+                    msg += "\n " + _("Problem") +  " %d: " % i
                 msg += "\n  - ".join(rs)
             exc = dnf.exceptions.DepsolveError(msg)
         else:

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -567,7 +567,7 @@ class Base(object):
             count_problems = (goal.count_problems() > 1)
             for i, rs in enumerate(goal.problem_rules):
                 if count_problems:
-                    msg += "\n " + _("Problem") +  " %s: " % i
+                    msg += "\n " + _("Problem") +  " %s: " % (i+1)
                 msg += "\n  - ".join(rs)
             exc = dnf.exceptions.DepsolveError(msg)
         else:

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -563,7 +563,13 @@ class Base(object):
         if not self._run_hawkey_goal(goal, allow_erasing):
             if self.conf.debuglevel >= 6:
                 goal.log_decisions()
-            exc = dnf.exceptions.DepsolveError('.\n'.join(goal.problems))
+            msg = ""
+            count_problems = (goal.count_problems() > 1)
+            for i, rs in enumerate(goal.problem_rules):
+                if count_problems:
+                    msg += "\n " + _("Problem") +  " %s: " % i
+                msg += "\n  - ".join(rs)
+            exc = dnf.exceptions.DepsolveError(msg)
         else:
             self._transaction = self._goal2transaction(goal)
 


### PR DESCRIPTION
get more info from libsolv about failed transactions; e.g.
```
./bin/dnf-2 install libreoffice gimp -x xml-commons-apis,xdg-utils
Last metadata expiration check: 0:56:40 ago on Tue Sep 20 14:31:28 2016 CEST.
Error: 
 Problem 0: conflicting requests
  - nothing provides xdg-utils needed by gimp-2:2.8.16-1.fc24.1.x86_64
  - nothing provides xdg-utils needed by gimp-2:2.8.18-1.fc24.x86_64
 Problem 1: conflicting requests
  - package libreoffice-1:5.1.3.2-6.fc24.x86_64 requires libreoffice-base(x86-64) = 1:5.1.3.2-6.fc24, but none of the providers can be installed
  - package libreoffice-1:5.1.5.2-6.fc24.x86_64 requires libreoffice-base(x86-64) = 1:5.1.5.2-6.fc24, but none of the providers can be installed
  - package libreoffice-base-1:5.1.3.2-6.fc24.x86_64 requires pentaho-reporting-flow-engine, but none of the providers can be installed
  - package libreoffice-base-1:5.1.5.2-6.fc24.x86_64 requires pentaho-reporting-flow-engine, but none of the providers can be installed
  - package pentaho-reporting-flow-engine-1:0.9.4-12.fc24.noarch requires liblayout >= 0.2.10, but none of the providers can be installed
  - nothing provides xml-commons-apis needed by liblayout-0.2.10-12.fc24.noarch
(try to add '--allowerasing' to command line to replace conflicting packages)
```

requires rpm-software-management/libhif#191