### PR TITLE
const: add kernel-PAE to installonlypkgs (RhBug:1333591)

### DIFF
--- a/dnf/const.py.in
+++ b/dnf/const.py.in
@@ -25,7 +25,7 @@ CONF_FILENAME='/etc/dnf/dnf.conf' # :api
 CONF_AUTOMATIC_FILENAME='/etc/dnf/automatic.conf'
 DISTROVERPKG=('system-release(releasever)', 'redhat-release')
 GROUP_PACKAGE_TYPES = ('mandatory', 'default') # :api
-INSTALLONLYPKGS=('kernel',
+INSTALLONLYPKGS=('kernel', 'kernel-PAE',
                  'installonlypkg(kernel)',
                  'installonlypkg(kernel-module)',
                  'installonlypkg(vm)')


### PR DESCRIPTION
Reported-by: Adam Williamson <awilliam@redhat.com>
References: https://bugzilla.redhat.com/show_bug.cgi?id=1333591
Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>