### PR TITLE
doc: add documentation for rpmverbosity

### DIFF
--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -224,8 +224,9 @@ Options
     ``--disablerepo="*" --enablerepo=<repoid>`` and is mutually exclusive with
     ``--disablerepo`` option.
 
-``--rpmverbosity=<debug level name>``
-    debugging output level for rpm
+``--rpmverbosity=<name>``
+    RPM debug scriptlet output level. Sets the debug level to ``<name>`` for RPM scriptlets.
+    For available levels, see ``rpmverbosity`` configuration option.
 
 ``--setopt=<option>=<value>``
     override a config option from the config file. To override config options from repo files, use ``repoid.option`` for the ``<option>``.

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -195,6 +195,12 @@ or :ref:`mirrorlist <mirrorlist-label>` option definition.
     ``reposdir``. The behavior of ``reposdir`` could differ when it is used
     along with \-\ :ref:`-installroot <installroot-label>` option.
 
+``rpmverbosity``
+    :ref:`string <string-label>`
+
+    RPM debug scriptlet output level. One of: ``critical``, ``emergency``,
+    ``error``, ``warn``, ``info`` or ``debug``. Default is ``info``.
+
 ``upgrade_group_objects_upgrade``
     :ref:`boolean <boolean-label>`
 


### PR DESCRIPTION
For conf option and option for cli. For yum compatibility.

Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>