### PR TITLE
Make armv8l alias for armhfp

### DIFF
--- a/dnf/rpm/__init__.py
+++ b/dnf/rpm/__init__.py
@@ -67,7 +67,7 @@ _BASEARCH_MAP = _invert({
     'alpha': ('alpha', 'alphaev4', 'alphaev45', 'alphaev5', 'alphaev56',
               'alphaev6', 'alphaev67', 'alphaev68', 'alphaev7', 'alphapca56'),
     'arm': ('armv5tejl', 'armv5tel', 'armv6l', 'armv7l'),
-    'armhfp': ('armv6hl', 'armv7hl', 'armv7hnl'),
+    'armhfp': ('armv6hl', 'armv7hl', 'armv7hnl', 'armv8l'),
     'i386': ('i386', 'athlon', 'geode', 'i386', 'i486', 'i586', 'i686'),
     'ia64': ('ia64',),
     'mips': ('mips',),

--- a/tests/test_arch.py
+++ b/tests/test_arch.py
@@ -28,6 +28,7 @@ class ArchTest(tests.support.TestCase):
         fn = dnf.rpm.basearch
         self.assertEqual(fn('armv6hl'), 'armhfp')
         self.assertEqual(fn('armv7hl'), 'armhfp')
+        self.assertEqual(fn('armv8l'), 'armhfp')
         self.assertEqual(fn('i686'), 'i386')
         self.assertEqual(fn('noarch'), 'noarch')
         self.assertEqual(fn('ppc64iseries'), 'ppc64')


### PR DESCRIPTION
I've installed Fedora on my Adnroid phone, into Termux, I've followed https://nmilosev.svbtle.com/termuxfedora-install-fedora-on-your-phone-with-termux but I cannot use dnf. This should fix my issue.
