### PR TITLE
repo: add 'rpm' as alias for 'rpm-md' (RhBug:1380580)

### DIFF
--- a/dnf/repo.py
+++ b/dnf/repo.py
@@ -893,7 +893,7 @@ class Repo(dnf.conf.RepoConf):
     def _valid(self):
         if len(self.baseurl) == 0 and not self.metalink and not self.mirrorlist:
             return "Repository %s has no mirror or baseurl set." % self.id
-        supported_types = ['rpm-md', 'repomd', 'rpmmd', 'yum', 'YUM']
+        supported_types = ['rpm-md', 'rpm', 'repomd', 'rpmmd', 'yum', 'YUM']
         if self.type and self.type not in supported_types:
             return "Repository '{}' has unsupported type: 'type={}', " \
                    "skipping.".format(self.id, self.type)


### PR DESCRIPTION
libzypp does this as well for some time:
https://github.com/openSUSE/libzypp/commit/6b22871a0aab134538edcb6e3d0321330817baaa

Reported-by: Kevin Fenzi <kevin@scrye.com>
References: https://bugzilla.redhat.com/show_bug.cgi?id=1380580
Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>