### PR TITLE
YUM compat group handling

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1296,12 +1296,12 @@ class Base(object):
                 query_args = {'name': pkg.name}
                 if (pkg.basearchonly):
                     query_args.update({'arch': basearch})
-                if not self.sack.query().filter(**query_args) and \
-                        not cond_check(pkg):
+                q = self.sack.query().filter(**query_args).run()
+                if not q and not cond_check(pkg):
                     # a conditional package with unsatisfied requiremensts
                     continue
                 sltr = dnf.selector.Selector(self.sack)
-                sltr.set(pkg=self.sack.query().filter(**query_args))
+                sltr.set(pkg=q)
                 fn(select=sltr)
                 self._goal.group_members.add(pkg.name)
 

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1335,7 +1335,8 @@ class Base(object):
     _COMPS_TRANSLATION = {
         'default': dnf.comps.DEFAULT,
         'mandatory': dnf.comps.MANDATORY,
-        'optional': dnf.comps.OPTIONAL
+        'optional': dnf.comps.OPTIONAL,
+        'conditional': dnf.comps.CONDITIONAL
     }
 
     @staticmethod

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -81,6 +81,7 @@ class Base(object):
         self._transaction = None
         self._priv_ts = None
         self._comps = None
+        self._comps_trans = dnf.comps.TransactionBunch()
         self._history = None
         self._tempfiles = set()
         self._trans_tempfiles = set()
@@ -544,6 +545,7 @@ class Base(object):
         # :api
         """Build the transaction set."""
         exc = None
+        self._finalize_comps_trans()
 
         timer = dnf.logging.Timer('depsolve')
         self._ds_callback.start()
@@ -1268,30 +1270,40 @@ class Base(object):
         return ygh
 
     def _add_comps_trans(self, trans):
-        cnt = 0
+        self._comps_trans += trans
+        return len(trans)
+
+    def _finalize_comps_trans(self):
+        trans = self._comps_trans
         clean_deps = self.conf.clean_requirements_on_remove
-        attr_fn = ((trans.install, self._goal.install),
-                   (trans.install_opt,
+        basearch = self.conf.substitutions['basearch']
+
+        def cond_check(pkg):
+            if not pkg.requires:
+                return True
+            return self.sack.query().installed().filter(name=pkg.requires) or \
+                pkg.requires in (pkg.name for pkg in self._goal._installs) or \
+                pkg.requires in [pkg.name for pkg in trans.install]
+
+        attr_fn = ((trans.install,
                     functools.partial(self._goal.install, optional=True)),
                    (trans.upgrade, self._goal.upgrade),
                    (trans.remove,
                     functools.partial(self._goal.erase, clean_deps=clean_deps)))
 
         for (attr, fn) in attr_fn:
-            for it in attr:
-                if not self.sack.query().filter(name=it):
-                    # a comps item that doesn't refer to anything real
-                    if (attr == trans.install):
-                        self._group_persistor._rollback()
-                        raise dnf.exceptions.MarkingError(it)
+            for pkg in attr:
+                query_args = {'name': pkg.name}
+                if (pkg.basearchonly):
+                    query_args.update({'arch': basearch})
+                if not self.sack.query().filter(**query_args) and \
+                        not cond_check(pkg):
+                    # a conditional package with unsatisfied requiremensts
                     continue
                 sltr = dnf.selector.Selector(self.sack)
-                sltr.set(name=it)
+                sltr.set(pkg=self.sack.query().filter(**query_args))
                 fn(select=sltr)
-                cnt += 1
-        self._goal.group_members.update(trans.install)
-        self._goal.group_members.update(trans.install_opt)
-        return cnt
+                self._goal.group_members.add(pkg.name)
 
     def _build_comps_solver(self):
         def reason_fn(pkgname):

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1281,7 +1281,8 @@ class Base(object):
         def cond_check(pkg):
             if not pkg.requires:
                 return True
-            return self.sack.query().installed().filter(name=pkg.requires) or \
+            installed = self.sack.query().installed().filter(name=pkg.requires).run()
+            return len(installed) > 0 or \
                 pkg.requires in (pkg.name for pkg in self._goal._installs) or \
                 pkg.requires in [pkg.name for pkg in trans.install]
 
@@ -1297,7 +1298,7 @@ class Base(object):
                 if (pkg.basearchonly):
                     query_args.update({'arch': basearch})
                 q = self.sack.query().filter(**query_args).run()
-                if not q and not cond_check(pkg):
+                if not q or not cond_check(pkg):
                     # a conditional package with unsatisfied requiremensts
                     continue
                 sltr = dnf.selector.Selector(self.sack)

--- a/dnf/comps.py
+++ b/dnf/comps.py
@@ -639,9 +639,10 @@ class Solver(object):
         p_grp.full_list.extend(self._full_package_set(group))
 
         trans = TransactionBunch()
-        trans.install = new_set - old_set
-        trans.remove = old_set - new_set
-        trans.upgrade = old_set - trans.remove
+        trans.install = {pkg for pkg in new_set if pkg.name not in old_set}
+        trans.remove = {name for name in old_set
+                        if name not in [pkg.name for pkg in new_set]}
+        trans.upgrade = {pkg for pkg in new_set if pkg.name in old_set}
         return trans
 
     def _exclude_packages_from_installed_groups(self, base):

--- a/dnf/comps.py
+++ b/dnf/comps.py
@@ -486,7 +486,8 @@ class Solver(object):
     @staticmethod
     def _full_package_set(grp):
         return {pkg.name for pkg in grp.mandatory_packages +
-                grp.default_packages + grp.optional_packages}
+                grp.default_packages + grp.optional_packages +
+                grp.conditional_packages}
 
     @staticmethod
     def _pkgs_of_type(group, pkg_types, exclude=[]):
@@ -501,6 +502,8 @@ class Solver(object):
             pkgs.update(filter(group.default_packages))
         if pkg_types & OPTIONAL:
             pkgs.update(filter(group.optional_packages))
+        if pkg_types & CONDITIONAL:
+            pkgs.update(filter(group.conditional_packages))
         return pkgs
 
     def _removable_pkg(self, pkg_name):

--- a/dnf/const.py.in
+++ b/dnf/const.py.in
@@ -24,7 +24,7 @@ import distutils.sysconfig
 CONF_FILENAME='/etc/dnf/dnf.conf' # :api
 CONF_AUTOMATIC_FILENAME='/etc/dnf/automatic.conf'
 DISTROVERPKG=('system-release(releasever)', 'redhat-release')
-GROUP_PACKAGE_TYPES = ('mandatory', 'default') # :api
+GROUP_PACKAGE_TYPES = ('mandatory', 'default', 'conditional') # :api
 INSTALLONLYPKGS=['kernel', 'kernel-PAE',
                  'installonlypkg(kernel)',
                  'installonlypkg(kernel-module)',

--- a/dnf/goal.py
+++ b/dnf/goal.py
@@ -31,6 +31,7 @@ class Goal(hawkey.Goal):
     def __init__(self, sack):
         super(Goal, self).__init__(sack)
         self.group_members = set()
+        self._installs = []
 
     def get_reason(self, pkg):
         code = super(Goal, self).get_reason(pkg)
@@ -50,6 +51,13 @@ class Goal(hawkey.Goal):
         if current_reason == 'unknown' and pkg.name in self.group_members:
             return 'group'
         return current_reason
+
+    def install(self, *args, **kwargs):
+        if args:
+            self._installs.extend(args)
+        if 'select' in kwargs:
+            self._installs.extend(kwargs['select'].matches())
+        return super(Goal, self).install(*args, **kwargs)
 
     def push_userinstalled(self, query, yumdb):
         msg = _('--> Finding unneeded leftover dependencies')

--- a/dnf/util.py
+++ b/dnf/util.py
@@ -164,7 +164,10 @@ def is_glob_pattern(pattern):
     return (isinstance(pattern, list) and any(set(p) & set("*[?") for p in pattern))
 
 def is_string_type(obj):
-    return isinstance(obj, basestring)
+    if PY3:
+        return isinstance(obj, str)
+    else:
+        return isinstance(obj, basestring)
 
 def lazyattr(attrname):
     """Decorator to get lazy attribute initialization.

--- a/tests/cli/commands/test_group.py
+++ b/tests/cli/commands/test_group.py
@@ -45,13 +45,10 @@ class GroupCommandStaticTest(support.TestCase):
     def test_split_extcmds(self):
         cmd = group.GroupCommand(support.mock.MagicMock())
         cmd.base.conf = dnf.conf.Conf()
-        support.command_run(cmd, ['install', '--with-optional', 'crack'])
-        cmd.base.env_group_install.assert_called_with(
-            ['crack'], ('mandatory', 'default', 'optional'),
-            cmd.base.conf.strict)
         support.command_run(cmd, ['install', 'crack'])
         cmd.base.env_group_install.assert_called_with(
-            ['crack'], ('mandatory', 'default'), cmd.base.conf.strict)
+            ['crack'], ('mandatory', 'default', 'conditional'),
+            cmd.base.conf.strict)
 
 
 class GroupCommandTest(support.TestCase):

--- a/tests/support.py
+++ b/tests/support.py
@@ -614,6 +614,9 @@ class TestCase(unittest.TestCase):
         traces = (match.group() for match in TRACEBACK_RE.finditer(string))
         self.assertTrue(any(trace.endswith(end) for trace in traces))
 
+    def assertTransEqual(self, trans_pkgs, list):
+        return self.assertCountEqual([pkg.name for pkg in trans_pkgs], list)
+
 
 class ResultTestCase(TestCase):
 

--- a/tests/test_comps.py
+++ b/tests/test_comps.py
@@ -155,8 +155,8 @@ class TestTransactionBunch(support.TestCase):
         t2.install = {'pepper'}
         t2.upgrade = {'right'}
         t1 += t2
-        self.assertCountEqual(t1.install, ('right', 'pepper'))
-        self.assertCountEqual(t1.upgrade, ('tour', 'right'))
+        self.assertTransEqual(t1.install, ('right', 'pepper'))
+        self.assertTransEqual(t1.upgrade, ('tour', 'right'))
         self.assertEmpty(t1.remove)
 
 
@@ -181,13 +181,6 @@ class SolverGroupTest(SolverTestMixin, support.TestCase):
         self.assertCountEqual(p_grp.pkg_exclude, ['right'])
         self.assertEqual(p_grp.pkg_types, dnf.comps.MANDATORY)
 
-    def test_install_opt(self):
-        grp = self.comps.group_by_pattern('somerset')
-        types = dnf.comps.DEFAULT | dnf.comps.OPTIONAL
-        trans = self.solver._group_install(grp.id, types, [])
-        self.assertLength(trans.install, 0)
-        self.assertLength(trans.install_opt, 1)
-
     def test_removable_pkg(self):
         p_grp1 = self.persistor.group('base')
         p_grp2 = self.persistor.group('tune')
@@ -211,7 +204,7 @@ class SolverGroupTest(SolverTestMixin, support.TestCase):
         for grp in grps:
             trans = self.solver._group_remove(grp)
             self.assertFalse(p_grp.installed)
-            self.assertCountEqual(trans.remove, ('tour',))
+            self.assertTransEqual(trans.remove, ('tour',))
 
     def test_upgrade(self):
         # setup of the "current state"
@@ -221,9 +214,9 @@ class SolverGroupTest(SolverTestMixin, support.TestCase):
 
         grp = self.comps.group_by_pattern('base')
         trans = self.solver._group_upgrade(grp.id)
-        self.assertCountEqual(trans.install, ('tour',))
-        self.assertCountEqual(trans.remove, ('handerson',))
-        self.assertCountEqual(trans.upgrade, ('pepper',))
+        self.assertTransEqual(trans.install, ('tour',))
+        self.assertTransEqual(trans.remove, ('handerson',))
+        self.assertTransEqual(trans.upgrade, ('pepper',))
         self.assertCountEqual(p_grp.full_list, ('tour', 'pepper'))
 
 
@@ -236,7 +229,8 @@ class SolverEnvironmentTest(SolverTestMixin, support.TestCase):
     def test_install(self):
         env = self.comps.environment_by_pattern('sugar-desktop-environment')
         trans = self._install(env)
-        self.assertCountEqual(trans.install, ('pepper', 'trampoline', 'hole'))
+        self.assertCountEqual([pkg.name for pkg in trans.install],
+                              ('pepper', 'trampoline', 'hole'))
         sugar = self.persistor.environment('sugar-desktop-environment')
         self.assertCountEqual(sugar.full_list, ('Peppers', 'somerset'))
         somerset = self.persistor.group('somerset')
@@ -252,7 +246,7 @@ class SolverEnvironmentTest(SolverTestMixin, support.TestCase):
         trans = self.solver._environment_remove(env.id)
 
         p_env = self.persistor.environment('sugar-desktop-environment')
-        self.assertCountEqual(trans.remove, ('pepper', 'trampoline', 'hole'))
+        self.assertTransEqual(trans.remove, ('pepper', 'trampoline', 'hole'))
         self.assertFalse(p_env.grp_types)
         self.assertFalse(p_env.pkg_types)
 
@@ -265,5 +259,5 @@ class SolverEnvironmentTest(SolverTestMixin, support.TestCase):
 
         env = self.comps.environment_by_pattern('sugar-desktop-environment')
         trans = self.solver._environment_upgrade(env.id)
-        self.assertCountEqual(trans.install, ('hole', 'lotus'))
+        self.assertTransEqual(trans.install, ('hole', 'lotus'))
         self.assertEmpty(trans.upgrade)

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -58,18 +58,15 @@ class EmptyPersistorTest(support.ResultTestCase):
         cnt = self.base.group_install(grp.id, ('optional',), exclude=('x*',))
         self.assertEqual(cnt, 1)
 
-    def test_add_comps_trans(self):
+    def test_finalize_comps_trans(self):
         trans = dnf.comps.TransactionBunch()
-        trans.install.add('trampoline')
+        trans.install = ('trampoline',)
         self.assertGreater(self.base._add_comps_trans(trans), 0)
+        self.base._finalize_comps_trans()
         self.assertIn('trampoline', self.base._goal.group_members)
         (installed, removed) = self.installed_removed(self.base)
         self.assertCountEqual(map(str, installed), ('trampoline-2.1-1.noarch',))
         self.assertEmpty(removed)
-
-        trans = dnf.comps.TransactionBunch()
-        trans.install_opt.add('waltz')
-        self.assertEqual(self.base._add_comps_trans(trans), 0)
 
 
 class PresetPersistorTest(support.ResultTestCase):
@@ -104,7 +101,7 @@ class PresetPersistorTest(support.ResultTestCase):
     def test_env_upgrade(self):
         prst = self.base._group_persistor
         cnt = self.base.environment_upgrade("sugar-desktop-environment")
-        self.assertEqual(4, cnt)
+        self.assertEqual(5, cnt)
         peppers = prst.group('Peppers')
         somerset = prst.group('somerset')
         self.assertTrue(peppers.installed)
@@ -122,6 +119,8 @@ class PresetPersistorTest(support.ResultTestCase):
         self.assertEmpty(removed)
         self.assertTrue(p_grp.installed)
 
+    """
+    this should be reconsidered once relengs document comps
     def test_group_install_broken(self):
         prst = self.base._group_persistor
         grp = self.base.comps.group_by_pattern('Broken Group')
@@ -142,6 +141,7 @@ class PresetPersistorTest(support.ResultTestCase):
         self.assertEmpty(removed)
         p_grp = prst.group('broken-group')
         self.assertTrue(p_grp.installed)
+    """
 
     def test_group_remove(self):
         prst = self.base._group_persistor


### PR DESCRIPTION
This is a first part of a long term solution that I plan to finish once somebody comes up with a proper documentation of COMPS. I temporarily turned off the strict installation of Mandatory packages and treat the whole installation as a best effort process. YUM compatibility is improved by installation of all types of comps packages (mandatory, conditional, optional, ...) and by respecting the group_package_types conf option.

requires https://github.com/rpm-software-management/ci-dnf-stack/pull/194
