### PR TITLE
Adds new emitters for dnf-automatic.

### DIFF
--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -59,6 +59,9 @@ def build_emitters(conf):
             elif name == 'motd':
                 emitter = dnf.automatic.emitter.MotdEmitter(system_name)
                 emitters.append(emitter)
+            elif name == 'command_email':
+                emitter = dnf.automatic.emitter.CommandEmailEmitter(system_name, conf.command_email)
+                emitters.append(emitter)
             else:
                 raise dnf.exceptions.ConfigError("Unknowr emitter option: %s" % name)
     return emitters
@@ -82,6 +85,7 @@ class AutomaticConfig(object):
         self.commands = CommandsConfig()
         self.email = EmailConfig()
         self.emitters = EmittersConfig()
+        self.command_email = CommandEmailConfig()
         self._parser = None
         self._load(filename)
 
@@ -132,6 +136,28 @@ class EmailConfig(dnf.conf.BaseConfig):
         self._add_option('email_from',  dnf.conf.Option("root"))
         self._add_option('email_host',  dnf.conf.Option("localhost"))
         self._add_option('email_port',  dnf.conf.IntOption(25))
+
+
+class CommandConfig(dnf.conf.BaseConfig):
+    _default_command_format = "cat"
+    _default_stdin_format = "{body}"
+
+    def __init__(self, section='command', parser=None):
+        super(CommandConfig, self).__init__(section, parser)
+        self._add_option('command_format',
+                         dnf.conf.Option(self._default_command_format))
+        self._add_option('stdin_format',
+                         dnf.conf.Option(self._default_stdin_format))
+
+
+class CommandEmailConfig(CommandConfig):
+    _default_command_format = "mail -s {subject} -r {email_from} {email_to}"
+
+    def __init__(self, section='command_email', parser=None):
+        super(CommandEmailConfig, self).__init__(section, parser)
+        self._add_option('email_to', dnf.conf.ListOption(["root"]))
+        self._add_option('email_from', dnf.conf.Option("root"))
+
 
 class EmittersConfig(dnf.conf.BaseConfig):
     def __init__(self, section='emiter', parser=None):

--- a/dnf/pycomp.py
+++ b/dnf/pycomp.py
@@ -33,6 +33,7 @@ if PY3:
     from io import StringIO
     import queue
     import urllib.parse
+    import shlex
 
     # functions renamed in py3
     Queue = queue.Queue
@@ -46,6 +47,7 @@ if PY3:
     base64_decodebytes = base64.decodebytes
     urlparse = urllib.parse
     urllib_quote = urlparse.quote
+    shlex_quote = shlex.quote
 
     def gettext_setup(t):
         _ = t.gettext
@@ -67,7 +69,6 @@ if PY3:
         f.write(content)
     def email_mime(body):
         return email.mime.text.MIMEText(body)
-
 else:
     # functions renamed in py3
     from __builtin__ import unicode, basestring, long, xrange, raw_input
@@ -75,11 +76,13 @@ else:
     import Queue
     import urllib
     import urlparse
+    import pipes
 
     Queue = Queue.Queue
     filterfalse = itertools.ifilterfalse
     base64_decodebytes = base64.decodestring
     urllib_quote = urllib.quote
+    shlex_quote = pipes.quote
 
     def gettext_setup(t):
         _ = t.ugettext

--- a/doc/automatic.rst
+++ b/doc/automatic.rst
@@ -94,12 +94,54 @@ Choosing how the results should be reported.
 ``emit_via``
     list, default: ``email, stdio, motd``
 
-    List of emitters to report the results through. Available emitters are ``stdio`` to print the result to standard output, ``email`` to send the report via email and ``motd`` sends the result to */etc/motd* file.
+    List of emitters to report the results through. Available emitters are ``stdio`` to print the result to standard output, ``command`` to send the result to a custom command, ``command_email`` to send an email using a command, and ``email`` to send the report via email and ``motd`` sends the result to */etc/motd* file.
 
 ``system_name``
     string, default: hostname of the given system
 
     How the system is called in the reports.
+
+---------------------
+``[command]`` section
+---------------------
+
+The command emitter configuration. Variables useable in format string arguments are ``body`` with the message body.
+
+``command_format``
+    format string, default: ``cat``
+
+    The shell command to execute.
+
+``stdin_format``
+    format string, default: ``{body}``
+
+    The data to pass to the command on stdin.
+
+---------------------------
+``[command_email]`` section
+---------------------------
+
+The command email emitter configuration. Variables useable in format string arguments are ``body`` with message body, ``subject`` with email subject, ``email_from`` with the "From:" address and ``email_to`` with a space-separated list of recipients.
+
+``command_format``
+    format string, default: ``mail -s {subject} -r {email_from} {email_to}``
+
+    The shell command to execute.
+
+``stdin_format``
+    format string, default: ``{body}``
+
+    The data to pass to the command on stdin.
+
+``email_from``
+    string, default: ``root``
+
+    Message's "From:" address.
+
+``email_to``
+    list, default: ``root``
+
+    List of recipients of the message.
 
 -------------------
 ``[email]`` section

--- a/doc/automatic.rst
+++ b/doc/automatic.rst
@@ -56,7 +56,7 @@ For example:``systemctl enable dnf-automatic-notifyonly.timer && systemctl start
 The configuration file is separated into topical sections.
 
 ---------------------
-``[command]`` section
+``[commands]`` section
 ---------------------
 
 Setting the mode of operation of the program.

--- a/etc/dnf/automatic.conf
+++ b/etc/dnf/automatic.conf
@@ -29,7 +29,9 @@ random_sleep = 300
 # emit_via includes stdio, messages will be sent to stdout; this is useful
 # to have cron send the messages.  If emit_via includes email, this
 # program will send email itself according to the configured options.
-# If emit_via includes motd, /etc/motd file will have the messages.
+# If emit_via includes motd, /etc/motd file will have the messages. if
+# emit_via includes command_email, then messages will be send via a shell
+# command compatible with sendmail.
 # Default is email,stdio.
 # If emit_via is None or left blank, no messages will be sent.
 emit_via = stdio
@@ -44,6 +46,34 @@ email_to = root
 
 # Name of the host to connect to to send email messages.
 email_host = localhost
+
+
+[command]
+# The shell command to execute. This is a Python format string, as used in
+# str.format(). The format function will pass a shell-quoted argument called
+# `body`.
+# command_format = "cat"
+
+# The contents of stdin to pass to the command. It is a format string with the
+# same arguments as `command_format`.
+# stdin_format = "{body}"
+
+
+[email_command]
+# The shell command to use to send email. This is a Python format string,
+# as used in str.format(). The format function will pass shell-quoted arguments
+# called body, subject, email_from, email_to.
+# command_format = "mail -s {subject} -r {email_from} {email_to}"
+
+# The contents of stdin to pass to the command. It is a format string with the
+# same arguments as `command_format`.
+# stdin_format = "{body}"
+
+# The address to send email messages from.
+email_from = root@example.com
+
+# List of addresses to send messages to.
+email_to = root
 
 
 [base]


### PR DESCRIPTION
Continued from pull request #476 

The change introduces a "base" class: `CommandEmitterMixIn`, which can be used to create a specialized emitter with custom variables passed either on the command line or on stdin (see the docs in config file).

A basic implementation, `CommandEmitter`, passes the body of a message on stdin.

An implementation called `CommandEmailEmitter` defines additional properties to pass to either command line or stdin: subject, email_from, email_to.
