### PR TITLE
Add unit file and config for ease of setting up automatic install

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -246,12 +246,15 @@ popd
 
 %post automatic
 %systemd_post dnf-automatic.timer
+%systemd_post dnf-automatic-install.timer
 
 %preun automatic
 %systemd_preun dnf-automatic.timer
+%systemd_preun dnf-automatic-install.timer
 
 %postun automatic
 %systemd_postun_with_restart dnf-automatic.timer
+%systemd_postun_with_restart dnf-automatic-install.timer
 
 %files -f %{name}.lang
 %{_bindir}/%{name}
@@ -312,9 +315,12 @@ popd
 %files automatic
 %{_bindir}/%{name}-automatic
 %config(noreplace) %{confdir}/automatic.conf
+%config(noreplace) %{confdir}/automatic-install.conf
 %{_mandir}/man8/%{name}.automatic.8.gz
 %{_unitdir}/%{name}-automatic.service
 %{_unitdir}/%{name}-automatic.timer
+%{_unitdir}/%{name}-automatic-install.service
+%{_unitdir}/%{name}-automatic-install.timer
 %if %{with python3}
 %{python3_sitelib}/%{name}/automatic/
 %else

--- a/etc/dnf/CMakeLists.txt
+++ b/etc/dnf/CMakeLists.txt
@@ -1,2 +1,2 @@
-INSTALL (FILES "dnf.conf" "automatic.conf" DESTINATION ${SYSCONFDIR}/dnf)
+INSTALL (FILES "dnf.conf" "automatic.conf" "automatic-install.conf" DESTINATION ${SYSCONFDIR}/dnf)
 ADD_SUBDIRECTORY (protected.d)

--- a/etc/dnf/automatic-install.conf
+++ b/etc/dnf/automatic-install.conf
@@ -1,0 +1,47 @@
+[commands]
+#  What kind of upgrade to perform:
+# default                            = all available upgrades
+# security                           = only the security upgrades
+upgrade_type = default
+random_sleep = 300
+
+# Whether updates should be downloaded when they are available.
+download_updates = yes
+
+# Whether updates should be applied when they are available.
+# Note that if this is set to no, downloaded packages will be left in the
+# cache regardless of the keepcache setting.
+apply_updates = yes
+
+
+[emitters]
+# Name to use for this system in messages that are emitted.  Default is the
+# hostname.
+# system_name = my-host
+
+# How to send messages.  Valid options are stdio, email and motd.  If
+# emit_via includes stdio, messages will be sent to stdout; this is useful
+# to have cron send the messages.  If emit_via includes email, this
+# program will send email itself according to the configured options.
+# If emit_via includes motd, /etc/motd file will have the messages.
+# Default is email,stdio.
+# If emit_via is None or left blank, no messages will be sent.
+emit_via = stdio
+
+
+[email]
+# The address to send email messages from.
+email_from = root@example.com
+
+# List of addresses to send messages to.
+email_to = root
+
+# Name of the host to connect to to send email messages.
+email_host = localhost
+
+
+[base]
+# This section overrides dnf.conf
+
+# Use this to filter DNF core messages
+debuglevel = 1

--- a/etc/systemd/CMakeLists.txt
+++ b/etc/systemd/CMakeLists.txt
@@ -1,6 +1,8 @@
 SET (systemd_FILES
      dnf-automatic.service
      dnf-automatic.timer
+     dnf-automatic-install.service
+     dnf-automatic-install.timer
      dnf-makecache.service
      dnf-makecache.timer)
 

--- a/etc/systemd/dnf-automatic-install.service
+++ b/etc/systemd/dnf-automatic-install.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=dnf automatic install
+
+[Service]
+Type=oneshot
+Nice=19
+IOSchedulingClass=2
+IOSchedulingPriority=7
+Environment="ABRT_IGNORE_PYTHON=1"
+ExecStart=/usr/bin/dnf-automatic /etc/dnf/automatic-install.conf --timer

--- a/etc/systemd/dnf-automatic-install.timer
+++ b/etc/systemd/dnf-automatic-install.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=dnf-automatic-install timer
+
+[Timer]
+OnBootSec=1h
+OnUnitInactiveSec=1d
+
+[Install]
+WantedBy=basic.target


### PR DESCRIPTION
With this setup you can either enable dnf-automatic to use the existing setup for nightly downloads or enable dnf-automaitic-install to download and install updates nightly.

This allows someone to drop in a systemd override to enable automatic installation without relying on the user to customize /etc/dnf/automatic.conf

If there is interest I can build up a patch to change dnf-automatic to dnf-automatic-download so that the names are clearer about what is happening.