### PR TITLE
Clarify purpose and behavior of automatic units

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -245,13 +245,19 @@ popd
 %systemd_postun_with_restart dnf-makecache.timer
 
 %post automatic
-%systemd_post dnf-automatic.timer
+%systemd_post dnf-automatic-notifyonly.timer
+%systemd_post dnf-automatic-download.timer
+%systemd_post dnf-automatic-install.timer
 
 %preun automatic
-%systemd_preun dnf-automatic.timer
+%systemd_preun dnf-automatic-notifyonly.timer
+%systemd_preun dnf-automatic-download.timer
+%systemd_preun dnf-automatic-install.timer
 
 %postun automatic
-%systemd_postun_with_restart dnf-automatic.timer
+%systemd_postun_with_restart dnf-automatic-notifyonly.timer
+%systemd_postun_with_restart dnf-automatic-download.timer
+%systemd_postun_with_restart dnf-automatic-install.timer
 
 %files -f %{name}.lang
 %{_bindir}/%{name}
@@ -313,8 +319,12 @@ popd
 %{_bindir}/%{name}-automatic
 %config(noreplace) %{confdir}/automatic.conf
 %{_mandir}/man8/%{name}.automatic.8.gz
-%{_unitdir}/%{name}-automatic.service
-%{_unitdir}/%{name}-automatic.timer
+%{_unitdir}/%{name}-automatic-notifyonly.service
+%{_unitdir}/%{name}-automatic-notifyonly.timer
+%{_unitdir}/%{name}-automatic-download.service
+%{_unitdir}/%{name}-automatic-download.timer
+%{_unitdir}/%{name}-automatic-install.service
+%{_unitdir}/%{name}-automatic-install.timer
 %if %{with python3}
 %{python3_sitelib}/%{name}/automatic/
 %else

--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -68,17 +68,28 @@ def parse_arguments(args):
     parser = argparse.ArgumentParser()
     parser.add_argument('conf_path', nargs='?', default=dnf.const.CONF_AUTOMATIC_FILENAME)
     parser.add_argument('--timer', action='store_true')
+    parser.add_argument('--installupdates', action='store_true')
+    parser.add_argument('--downloadupdates', action='store_true')
 
     return parser.parse_args(args), parser
 
 
 class AutomaticConfig(object):
-    def __init__(self, filename):
+    def __init__(self, filename=None, downloadupdates=False,
+                 installupdates=False):
+        if not filename:
+            filename = dnf.const.CONF_AUTOMATIC_FILENAME
         self.commands = CommandsConfig()
         self.email = EmailConfig()
         self.emitters = EmittersConfig()
         self._parser = None
         self._load(filename)
+
+        if downloadupdates:
+            self.commands.download_updates = True
+        if installupdates:
+            self.commands.apply_updates = True
+
         self.commands.imply()
         self.filename = filename
 
@@ -134,7 +145,8 @@ def main(args):
     (opts, parser) = parse_arguments(args)
 
     try:
-        conf = AutomaticConfig(opts.conf_path)
+        conf = AutomaticConfig(opts.conf_path, opts.downloadupdates,
+                               opts.installupdates)
         with dnf.Base() as base:
             cli = dnf.cli.Cli(base)
             cli._read_conf_file()

--- a/doc/automatic.rst
+++ b/doc/automatic.rst
@@ -35,6 +35,20 @@ The operation of the tool is completely controlled by the configuration file and
 
 The tool synchronizes package metadata as needed and then checks for updates available for the given system and then either exits, downloads the packages or downloads and applies the packages. The outcome of the operation is then reported by a selected mechanism, for instance via the standard output, email or motd messages.
 
+A few default systemd units are provided to enable some standard configurations:
+
+- dnf-automatic-notifyonly
+- dnf-automatic-download
+- dnf-automatic-install
+
+===================
+ Run dnf-automatic
+===================
+
+You can select on that most closely fits your needs, customize ``/etc/dnf/automatic.conf`` for any specific behaviors, and enable the timer unit.
+
+For example:``systemctl enable dnf-automatic-notifyonly.timer && systemctl start dnf-automatic-notifyonly.timer``
+
 ===========================
  Configuration File Format
 ===========================
@@ -114,8 +128,3 @@ The email emitter configuration.
 
 Can be used to override settings from DNF's main configuration file. See :doc:`conf_ref`.
 
-===================
- Run dnf-automatic
-===================
-
-Once you are finished with configuration, execute ``systemctl enable dnf-automatic.timer && systemctl start dnf-automatic.timer`` to enable and start the systemd timer.

--- a/etc/dnf/automatic.conf
+++ b/etc/dnf/automatic.conf
@@ -5,13 +5,19 @@
 upgrade_type = default
 random_sleep = 300
 
+# To just recieve updates use dnf-automatic-notifyonly.timer
+
 # Whether updates should be downloaded when they are available.
-download_updates = yes
+#
+# To download updates automatically use dnf-automatic-download.timer
+# download_updates = yes
 
 # Whether updates should be applied when they are available.
 # Note that if this is set to no, downloaded packages will be left in the
 # cache regardless of the keepcache setting.
-apply_updates = no
+#
+# To install updates automatically use dnf-automatic-install.timer
+# apply_updates = no
 
 
 [emitters]

--- a/etc/systemd/CMakeLists.txt
+++ b/etc/systemd/CMakeLists.txt
@@ -1,6 +1,11 @@
 SET (systemd_FILES
-     dnf-automatic.service
-     dnf-automatic.timer
+     dnf-automatic-notifyonly.service
+     dnf-automatic-notifyonly.timer
+     dnf-automatic-install.service
+     dnf-automatic-download.service
+     dnf-automatic-download.timer
+     dnf-automatic-install.service
+     dnf-automatic-install.timer
      dnf-makecache.service
      dnf-makecache.timer)
 

--- a/etc/systemd/dnf-automatic-download.service
+++ b/etc/systemd/dnf-automatic-download.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=dnf automatic download updates
+
+[Service]
+Type=oneshot
+Nice=19
+IOSchedulingClass=2
+IOSchedulingPriority=7
+Environment="ABRT_IGNORE_PYTHON=1"
+ExecStart=/usr/bin/dnf-automatic /etc/dnf/automatic.conf --timer --downloadupdates

--- a/etc/systemd/dnf-automatic-download.timer
+++ b/etc/systemd/dnf-automatic-download.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=dnf-automatic-download timer
+
+[Timer]
+OnBootSec=1h
+OnUnitInactiveSec=1d
+
+[Install]
+WantedBy=basic.target

--- a/etc/systemd/dnf-automatic-install.service
+++ b/etc/systemd/dnf-automatic-install.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=dnf automatic install updates
+
+[Service]
+Type=oneshot
+Nice=19
+IOSchedulingClass=2
+IOSchedulingPriority=7
+Environment="ABRT_IGNORE_PYTHON=1"
+ExecStart=/usr/bin/dnf-automatic /etc/dnf/automatic.conf --timer --installupdates

--- a/etc/systemd/dnf-automatic-install.timer
+++ b/etc/systemd/dnf-automatic-install.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=dnf-automatic-install timer
+
+[Timer]
+OnBootSec=1h
+OnUnitInactiveSec=1d
+
+[Install]
+WantedBy=basic.target

--- a/etc/systemd/dnf-automatic-notifyonly.service
+++ b/etc/systemd/dnf-automatic-notifyonly.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=dnf automatic
+Description=dnf automatic notification of updates
 
 [Service]
 Type=oneshot

--- a/etc/systemd/dnf-automatic-notifyonly.timer
+++ b/etc/systemd/dnf-automatic-notifyonly.timer
@@ -1,5 +1,5 @@
 [Unit]
-Description=dnf-automatic timer
+Description=dnf-automatic-notifyonly timer
 
 [Timer]
 OnBootSec=1h


### PR DESCRIPTION
Relates to #639 but leaves the existing dnf-automatic service in place.  Not sure what the best migration strategy would be overall, but the cleaner names should help describe the expected behavior.
