### PR TITLE
KeyImport: Mark _confirm as private

### DIFF
--- a/dnf/callback.py
+++ b/dnf/callback.py
@@ -40,7 +40,7 @@ TRANS_POST = dnf.yum.rpmtrans.TransactionDisplay.TRANS_POST  # :api
 
 
 class KeyImport(object):
-    def confirm(self, _keyinfo):
+    def _confirm(self, _keyinfo):
         """Ask the user if the key should be imported."""
         return False
 

--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -1957,7 +1957,7 @@ class CliKeyImport(dnf.callback.KeyImport):
         self.base = base
         self.output = output
 
-    def confirm(self, keyinfo):
+    def _confirm(self, keyinfo):
         dnf.crypto.log_key_import(keyinfo)
         if self.base.conf.assumeyes:
             return True


### PR DESCRIPTION
Follow up to dc063ad55472b4a19c4afe6c9c7af44f9547d3dd

Fixes the Traceback (most recent call last):
  File "/usr/bin/dnf", line 58, in <module>
    main.user_main(sys.argv[1:], exit_code=True)
  File "/usr/lib/python3.5/site-packages/dnf/cli/main.py", line 170, in user_main
    errcode = main(args)
  File "/usr/lib/python3.5/site-packages/dnf/cli/main.py", line 60, in main
    return _main(base, args)
  File "/usr/lib/python3.5/site-packages/dnf/cli/main.py", line 111, in _main
    cli.run()
  File "/usr/lib/python3.5/site-packages/dnf/cli/cli.py", line 948, in run
    self._process_demands()
  File "/usr/lib/python3.5/site-packages/dnf/cli/cli.py", line 790, in _process_demands
    load_available_repos=self.demands.available_repos)
  File "/usr/lib/python3.5/site-packages/dnf/base.py", line 252, in fill_sack
    self._add_repo_to_sack(r)
  File "/usr/lib/python3.5/site-packages/dnf/base.py", line 109, in _add_repo_to_sack
    repo.load()
  File "/usr/lib/python3.5/site-packages/dnf/repo.py", line 842, in load
    self._handle_load(handle)
  File "/usr/lib/python3.5/site-packages/dnf/repo.py", line 598, in _handle_load
    dnf.crypto.import_repo_keys(self)
  File "/usr/lib/python3.5/site-packages/dnf/crypto.py", line 58, in import_repo_keys
    if not repo._key_import._confirm(keyinfo):
 AttributeError: 'CliKeyImport' object has no attribute '_confirm'