### PR TITLE
Make `dnf repoquery --unsatisfied` work again.

### DIFF
--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -272,7 +272,7 @@ class RepoQueryCommand(commands.Command):
         elif self.opts.pkgfilter == "installonly":
             q = self.base._get_installonly_query(q)
         elif self.opts.pkgfilter == "unsatisfied":
-            rpmdb = dnf.sack.rpmdb_sack(self.base)
+            rpmdb = dnf.sack._rpmdb_sack(self.base)
             goal = dnf.goal.Goal(rpmdb)
             solved = goal.run(verify=True)
             if not solved:


### PR DESCRIPTION
Use 'privatized' dnf.sack._rpmdb_sack(), amends commit
bc69cde0f9b3bf8ee577a1e45ed0df8dfa3536c8.