### PR TITLE
subject: Check validity of nevra before usage

### DIFF
--- a/dnf/subject.py
+++ b/dnf/subject.py
@@ -78,7 +78,9 @@ class Subject(object):
         if forms is not None:
             kwargs['form'] = forms
         nevra = first(self.subj.nevra_possibilities_real(sack, **kwargs))
-        return nevra._has_just_name()
+        if nevra:
+            return nevra._has_just_name()
+        return False
 
     def get_best_query(self, sack, with_provides=True, forms=None):
         # :api


### PR DESCRIPTION
Silence traceback:

Traceback (most recent call last):
  File "/bin/dnf", line 58, in <module>
    main.user_main(sys.argv[1:], exit_code=True)
  File "/usr/lib/python3.5/site-packages/dnf/cli/main.py", line 175, in user_main
    errcode = main(args)
  File "/usr/lib/python3.5/site-packages/dnf/cli/main.py", line 61, in main
    return _main(base, args)
  File "/usr/lib/python3.5/site-packages/dnf/cli/main.py", line 99, in _main
    return cli_run(cli, base)
  File "/usr/lib/python3.5/site-packages/dnf/cli/main.py", line 115, in cli_run
    cli.run()
  File "/usr/lib/python3.5/site-packages/dnf/cli/cli.py", line 982, in run
    return self.command.run()
  File "/usr/lib/python3.5/site-packages/dnf/cli/commands/install.py", line 100, in run
    self.base.install(pkg_spec, strict=strict)
  File "/usr/lib/python3.5/site-packages/dnf/base.py", line 1479, in install
    sltrs = subj._get_best_selectors(self.sack)
  File "/usr/lib/python3.5/site-packages/dnf/subject.py", line 134, in _get_best_selectors
    if self._has_nevra_just_name(sack, forms=forms):
  File "/usr/lib/python3.5/site-packages/dnf/subject.py", line 81, in _has_nevra_just_name
    return nevra._has_just_name()
AttributeError: 'NoneType' object has no attribute '_has_just_name'