### PR TITLE
'SpacewalkRepo' object has no attribute 'repofile' (RhBug:1395737)

### DIFF
--- a/dnf/repo.py
+++ b/dnf/repo.py
@@ -467,6 +467,7 @@ class Repo(dnf.yum.config.RepoConf):
         self.name = self.id
         self.key_import = _NullKeyImport()
         self.metadata = None # :api
+        self.repofile = None
         self.sync_strategy = self.DEFAULT_SYNC
         self.substitutions = dnf.conf.substitutions.Substitutions()
         self.max_mirror_tries = 0 # try them all


### PR DESCRIPTION
If dnf-plugin-spacewalk is enabled, dnf returns traceback in verbose mode.

```
>> dnf -v repolist
Traceback (most recent call last):
  File "/usr/bin/dnf", line 58, in <module>
    main.user_main(sys.argv[1:], exit_code=True)
  File "/usr/lib/python3.5/site-packages/dnf/cli/main.py", line 174, in user_main
    errcode = main(args)
  File "/usr/lib/python3.5/site-packages/dnf/cli/main.py", line 60, in main
    return _main(base, args)
  File "/usr/lib/python3.5/site-packages/dnf/cli/main.py", line 112, in _main
    cli.run()
  File "/usr/lib/python3.5/site-packages/dnf/cli/cli.py", line 1099, in run
    return self.command.run(self.base.extcmds)
  File "/usr/lib/python3.5/site-packages/dnf/cli/commands/repolist.py", line 216, in run
    if repo.repofile:
AttributeError: 'SpacewalkRepo' object has no attribute 'repofile'
```