### PR TITLE
Do not always overwrite the name with the repo ID

### DIFF
--- a/dnf/repo.py
+++ b/dnf/repo.py
@@ -465,7 +465,6 @@ class Repo(dnf.conf.RepoConf):
         self._md_pload = MDPayload(dnf.callback.NullDownloadProgress())
         self._key_import = _NullKeyImport()
         self.metadata = None  # :api
-        self.name = name  # :api
         self._sync_strategy = self.DEFAULT_SYNC
         self._substitutions = dnf.conf.substitutions.Substitutions()
         self._max_mirror_tries = 0  # try them all


### PR DESCRIPTION
The commit 49c7438d3e6de36414f66bc29f717b63dd491571 made it so that the repo ID was always used, even when the repo name does exist, because the repo ID was always overwriting the passed in full name.

The value is already set in `_build_repo()` in read.py anyway, and in the event there is nothing set there, we will fall back to 'unknown'.
