### PR TITLE
spec: stop recommending bash-completion

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -112,7 +112,6 @@ BuildRequires:  python2-pygpgme
 %endif
 BuildRequires:  pyliblzma
 BuildRequires:  rpm-python >= %{rpm_version}
-Recommends:     bash-completion
 Requires:       pyliblzma
 Requires:       %{name}-conf = %{version}-%{release}
 Requires:       deltarpm
@@ -147,7 +146,6 @@ BuildRequires:  python3-librepo >= %{librepo_version}
 BuildRequires:  python3-nose
 BuildRequires:  python3-pygpgme
 BuildRequires:  rpm-python3 >= %{rpm_version}
-Recommends:     bash-completion
 Requires:       %{name}-conf = %{version}-%{release}
 Requires:       deltarpm
 Requires:       python3-hawkey >= %{hawkey_version}


### PR DESCRIPTION
This is unpleassant to users since we do installation of weak deps
by default.

Reported-by: Lubomir Rintel <lkundrak@v3.sk>
Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>