### PR TITLE
crypto: port to the official gpgme bindings

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -111,11 +111,8 @@ BuildRequires:  python-iniparse
 BuildRequires:  python-libcomps >= %{libcomps_version}
 BuildRequires:  python-librepo >= %{librepo_version}
 BuildRequires:  python-nose
-%if 0%{?rhel} && 0%{?rhel} <= 7
-BuildRequires:  pygpgme
-%else
-BuildRequires:  python2-pygpgme
-%endif
+BuildRequires:  python2-gpg
+Requires:       python2-gpg
 BuildRequires:  pyliblzma
 BuildRequires:  rpm-python >= %{rpm_version}
 Requires:       pyliblzma
@@ -125,11 +122,6 @@ Requires:       python-hawkey >= %{hawkey_version}
 Requires:       python-iniparse
 Requires:       python-libcomps >= %{libcomps_version}
 Requires:       python-librepo >= %{librepo_version}
-%if 0%{?rhel} && 0%{?rhel} <= 7
-Requires:       pygpgme
-%else
-Requires:       python2-pygpgme
-%endif
 Requires:       rpm-plugin-systemd-inhibit
 Requires:       rpm-python >= %{rpm_version}
 # dnf-langpacks package is retired in F25
@@ -150,7 +142,8 @@ BuildRequires:  python3-iniparse
 BuildRequires:  python3-libcomps >= %{libcomps_version}
 BuildRequires:  python3-librepo >= %{librepo_version}
 BuildRequires:  python3-nose
-BuildRequires:  python3-pygpgme
+BuildRequires:  python3-gpg
+Requires:       python3-gpg
 BuildRequires:  rpm-python3 >= %{rpm_version}
 Requires:       %{name}-conf = %{version}-%{release}
 Requires:       deltarpm
@@ -158,7 +151,6 @@ Requires:       python3-hawkey >= %{hawkey_version}
 Requires:       python3-iniparse
 Requires:       python3-libcomps >= %{libcomps_version}
 Requires:       python3-librepo >= %{librepo_version}
-Requires:       python3-pygpgme
 Requires:       rpm-plugin-systemd-inhibit
 Requires:       rpm-python3 >= %{rpm_version}
 # dnf-langpacks package is retired in F25

--- a/dnf/crypto.py
+++ b/dnf/crypto.py
@@ -23,10 +23,10 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from dnf.i18n import _
 import contextlib
-import dnf.i18n
+import dnf.pycomp
 import dnf.util
 import dnf.yum.misc
-import gpgme
+import gpg
 import io
 import logging
 import os
@@ -67,8 +67,7 @@ def keyids_from_pubring(gpgdir):
     if not os.path.exists(gpgdir):
         return []
 
-    with pubring_dir(gpgdir):
-        ctx = gpgme.Context()
+    with pubring_dir(gpgdir), gpg.Context() as ctx:
         keyids = []
         for k in ctx.keylist():
             subkey = _extract_signing_subkey(k)
@@ -82,7 +81,7 @@ def log_key_import(keyinfo):
              ' Userid     : "%s"\n'
              ' Fingerprint: %s\n'
              ' From       : %s') %
-           (keyinfo.short_id, dnf.i18n.ucd(keyinfo.userid),
+           (keyinfo.short_id, keyinfo.userid,
             _printable_fingerprint(keyinfo.fingerprint),
             keyinfo.url.replace("file://", "")))
     logger.critical("%s", msg)
@@ -102,9 +101,8 @@ def pubring_dir(pubring_dir):
 def rawkey2infos(key_fo):
     pb_dir = tempfile.mkdtemp()
     keyinfos = []
-    with pubring_dir(pb_dir):
-        ctx = gpgme.Context()
-        ctx.import_(key_fo)
+    with pubring_dir(pb_dir), gpg.Context() as ctx:
+        ctx.op_import(key_fo)
         for key in ctx.keylist():
             subkey = _extract_signing_subkey(key)
             if subkey is None:
@@ -112,9 +110,10 @@ def rawkey2infos(key_fo):
             keyinfos.append(Key(key, subkey))
         ctx.armor = True
         for info in keyinfos:
-            buf = io.BytesIO()
-            ctx.export(info.id_, buf)
-            info.raw_key = buf.getvalue()
+            with gpg.Data() as sink:
+                ctx.op_export(info.id_, 0, sink)
+                sink.seek(0, os.SEEK_SET)
+                info.raw_key = sink.read()
     dnf.util.rm_rf(pb_dir)
     return keyinfos
 
@@ -138,7 +137,8 @@ class Key(object):
 
     @property
     def short_id(self):
-        return self.id_[-8:].rjust(8, '0')
+        rj = '0' if dnf.pycomp.PY3 else b'0'
+        return self.id_[-8:].rjust(8, rj)
 
     @property
     def rpm_id(self):


### PR DESCRIPTION
Given that pygpgme was broken couple of times with newest gnupg2,
still doesn't have patch and completely dead it's time to migrate
to official GnuPG Python bindings.

**Note**: it removes support for pygpgme entirely which we don't want at this moment because EL7 is outdated for many years and it is very hard to get newest gpgme there (it requires newer libgpg-error and other libraries).