### PR TITLE
Add information about "hidden" option in dnf doc (RhBug:1349247)

### DIFF
--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -442,8 +442,9 @@ Groups are virtual collections of packages. DNF keeps track of groups that the u
 
 ``dnf [options] group list <group-spec>...``
     List all matching groups, either among installed or available groups. If
-    nothing is specified list all known groups. Options ``installed`` and ``available`` narrows down the requested list.
+    nothing is specified list all known groups. Options ``--installed`` and ``--available`` narrows down the requested list.
     Records are ordered by `display_order` tag defined in comps.xml file.
+    Provides a list of all hidden groups by using option ``--hidden``.
     Provides more detailed information when ``-v`` option is used.
 
 ``dnf [options] group remove <group-spec>...``


### PR DESCRIPTION
DNF group list "hidden" provides a list of all hidden
groups available to normal user.
This fix provides doc reference to user about this option.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1349247

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>