### PR TITLE
tests: catch ModuleNotFoundError as well

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -93,6 +93,6 @@ class PluginNonExistentTest(tests.support.TestCase):
         with tests.support.wiretap_logs('dnf', dnf.logging.SUBDEBUG, stream):
             dnf.plugin._import_modules(package, ('nonexistent.py',))
 
-        end = ('ImportError: No module named \'testpkg\'\n' if dnf.pycomp.PY3
-               else 'ImportError: No module named testpkg.nonexistent\n')
+        end = ('Error: No module named \'testpkg\'\n' if dnf.pycomp.PY3
+               else 'Error: No module named testpkg.nonexistent\n')
         self.assertTracebackIn(end, stream.getvalue())


### PR DESCRIPTION
From What's New in Python 3.6:
Import now raises the new exception ModuleNotFoundError (subclass of ImportError)
when it cannot find a module. Code that currently checks for
ImportError (in try-except) will still work. (Contributed by Eric Snow in issue 15767.)

Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>