### PR TITLE
Fix problem in repolist when repo.name is None

### DIFF
--- a/dnf/cli/commands/repolist.py
+++ b/dnf/cli/commands/repolist.py
@@ -50,7 +50,7 @@ def _num2ui_num(num):
 
 def _repo_match(repo, patterns):
     rid = repo.id.lower()
-    rnm = repo.name.lower()
+    rnm = "" if repo.name is None else repo.name.lower()
     for pat in patterns:
         if fnmatch.fnmatch(rid, pat):
             return True
@@ -160,7 +160,7 @@ class RepoListCommand(commands.Command):
                     mdts = repo.metadata._timestamp
                     if mdts > repo.metadata._md_timestamp:
                         rid = '*' + rid
-                cols.append((rid, repo.name,
+                cols.append((rid, repo.name if repo.name is not None else "",
                              (ui_enabled, ui_endis_wid), ui_num))
             else:
                 if enabled:


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/bin/dnf", line 58, in <module>
    main.user_main(sys.argv[1:], exit_code=True)
  File "/usr/lib/python3.5/site-packages/dnf/cli/main.py", line 175, in user_main
    errcode = main(args)
  File "/usr/lib/python3.5/site-packages/dnf/cli/main.py", line 61, in main
    return _main(base, args)
  File "/usr/lib/python3.5/site-packages/dnf/cli/main.py", line 99, in _main
    return cli_run(cli, base)
  File "/usr/lib/python3.5/site-packages/dnf/cli/main.py", line 115, in cli_run
    cli.run()
  File "/usr/lib/python3.5/site-packages/dnf/cli/cli.py", line 936, in run
    return self.command.run()
  File "/usr/lib/python3.5/site-packages/dnf/cli/commands/repolist.py", line 250, in run
    if nm_len < exact_width(rname):
  File "/usr/lib/python3.5/site-packages/dnf/i18n.py", line 176, in exact_width
    return sum(_exact_width_char(c) for c in msg)
TypeError: 'NoneType' object is not iterable