### PR TITLE
automatic: add sendmail emitter

### DIFF
--- a/dnf/automatic/emitter.py
+++ b/dnf/automatic/emitter.py
@@ -107,6 +107,7 @@ class EmailEmitter(Emitter):
                 self._conf.email_host, exc)
             logger.error(msg)
 
+
 class SendmailEmitter(EmailEmitter):
     def commit(self):
         # Send the email
@@ -116,10 +117,10 @@ class SendmailEmitter(EmailEmitter):
         cmd = ['/usr/sbin/sendmail', '-bm', '-t']
         try:
             proc = subprocess.Popen(cmd,
-                universal_newlines=True,
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE)
+                                    universal_newlines=True,
+                                    stdin=subprocess.PIPE,
+                                    stdout=subprocess.PIPE,
+                                    stderr=subprocess.PIPE)
         except OSError as e:
             if e.errno == 2:
                 logger.error('%s, %s', cmd[0], e.strerror)

--- a/dnf/automatic/emitter.py
+++ b/dnf/automatic/emitter.py
@@ -25,6 +25,8 @@ from dnf.i18n import _
 import logging
 import dnf.pycomp
 import smtplib
+import email.utils
+import subprocess
 
 APPLIED = _("The following updates have been applied on '%s':")
 AVAILABLE = _("The following updates are available on '%s':")
@@ -81,28 +83,58 @@ class EmailEmitter(Emitter):
         elif self._available_msg:
             subj = _("Updates available on '%s'.") % self._system_name
         else:
-            return None, None
-        return subj, super(EmailEmitter, self)._prepare_msg()
+            return None
+        msg = dnf.pycomp.email_mime(super(EmailEmitter, self)._prepare_msg())
+        msg.set_charset('utf-8')
+        msg['Date'] = email.utils.formatdate()
+        msg['From'] = self._conf.email_from
+        msg['Subject'] = subj
+        msg['To'] = ','.join(self._conf.email_to)
+        msg['Message-ID'] = email.utils.make_msgid()
+        return msg.as_string()
 
     def commit(self):
-        subj, body = self._prepare_msg()
-        message = dnf.pycomp.email_mime(body)
-        message.set_charset('utf-8')
-        email_from = self._conf.email_from
-        email_to = self._conf.email_to
-        message['Subject'] = subj
-        message['From'] = email_from
-        message['To'] = ','.join(email_to)
-
         # Send the email
+        msg = self._prepare_msg()
+        if msg is None:
+            return
         try:
             smtp = smtplib.SMTP(self._conf.email_host)
-            smtp.sendmail(email_from, email_to, message.as_string())
+            smtp.sendmail(self._conf.email_from, self._conf.email_to, msg)
             smtp.close()
         except smtplib.SMTPException as exc:
             msg = _("Failed to send an email via '%s': %s") % (
                 self._conf.email_host, exc)
             logger.error(msg)
+
+class SendmailEmitter(EmailEmitter):
+    def commit(self):
+        # Send the email
+        msg = self._prepare_msg()
+        if msg is None:
+            return
+        cmd = ['/usr/sbin/sendmail', '-bm', '-t']
+        try:
+            proc = subprocess.Popen(cmd,
+                universal_newlines=True,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE)
+        except OSError as e:
+            if e.errno == 2:
+                logger.error('%s, %s', cmd[0], e.strerror)
+            else:
+                logger.error('error %d, %s', e.errno, e.strerror)
+            return
+        out, err = proc.communicate(msg)
+        if proc.returncode == 0:
+            if out:
+                logger.info(out)
+            if err:
+                logger.error(err)
+        else:
+            logger.error('error %d, %s', proc.returncode, err)
+
 
 class StdIoEmitter(Emitter):
     def commit(self):

--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -53,6 +53,9 @@ def build_emitters(conf):
             if name == 'email':
                 emitter = dnf.automatic.emitter.EmailEmitter(system_name, conf.email)
                 emitters.append(emitter)
+            elif name == 'sendmail':
+                emitter = dnf.automatic.emitter.SendmailEmitter(system_name, conf.email)
+                emitters.append(emitter)
             elif name == 'stdio':
                 emitter = dnf.automatic.emitter.StdIoEmitter(system_name)
                 emitters.append(emitter)

--- a/doc/automatic.rst
+++ b/doc/automatic.rst
@@ -94,7 +94,7 @@ Choosing how the results should be reported.
 ``emit_via``
     list, default: ``email, stdio, motd``
 
-    List of emitters to report the results through. Available emitters are ``stdio`` to print the result to standard output, ``email`` to send the report via email and ``motd`` sends the result to */etc/motd* file.
+    List of emitters to report the results through. Available emitters are ``stdio`` to print the result to standard output, ``email`` to send the report via email, ``sendmail`` to send the report via */usr/sbin/sendmail* and ``motd`` sends the result to */etc/motd* file.
 
 ``system_name``
     string, default: hostname of the given system

--- a/etc/dnf/automatic.conf
+++ b/etc/dnf/automatic.conf
@@ -25,10 +25,12 @@ random_sleep = 300
 # hostname.
 # system_name = my-host
 
-# How to send messages.  Valid options are stdio, email and motd.  If
+# How to send messages.  Valid options are stdio, email, sendmail and motd.  If
 # emit_via includes stdio, messages will be sent to stdout; this is useful
 # to have cron send the messages.  If emit_via includes email, this
 # program will send email itself according to the configured options.
+# If emit_via include sendmail then an email will be sent using
+# /usr/sbin/sendmail -bm -t.
 # If emit_via includes motd, /etc/motd file will have the messages.
 # Default is email,stdio.
 # If emit_via is None or left blank, no messages will be sent.
@@ -43,6 +45,7 @@ email_from = root@example.com
 email_to = root
 
 # Name of the host to connect to to send email messages.
+# Not required for sendmail.
 email_host = localhost
 
 


### PR DESCRIPTION
An alternative to the SMTP email emitter using host sendmail.

Addresses BZ1279773

- Adjust methods to support code reuse.
- Add required Date: header.
- Add optional Message-ID: header.
- new emit_via option: sendmail
- new emitter class using /usr/sbin/sendmail.