### PR TITLE
Set default repo.name as repo._section

### DIFF
--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -898,7 +898,7 @@ class RepoConf(BaseConfig):
 
     def __init__(self, parent, section=None, parser=None):
         super(RepoConf, self).__init__(section, parser)
-        self._add_option('name', Option()) # :api
+        self._add_option('name', Option(default=self._section))  # :api
         self._add_option('enabled', inherit(parent._get_option('enabled')))
         self._add_option('basecachedir', inherit(parent._get_option('cachedir')))
         self._add_option('baseurl', UrlListOption()) # :api

--- a/dnf/conf/read.py
+++ b/dnf/conf/read.py
@@ -62,8 +62,8 @@ class RepoReader(object):
             raise dnf.exceptions.ConfigError(msg)
 
         # Ensure that the repo name is set
-        if not repo.name:
-            repo.name = id_
+        repo_name_object = repo._get_option('name')
+        if repo_name_object._get_priority() == dnf.conf.PRIO_DEFAULT:
             msg = _("Repository '%s' is missing name in configuration, using id.")
             logger.warning(msg, id_)
         repo.name = ucd(repo.name)


### PR DESCRIPTION
It prevents if plugin user creates repo without name like local plugin that
results in traceback with repolist

Traceback (most recent call last):
  File "/usr/bin/dnf", line 58, in <module>
    main.user_main(sys.argv[1:], exit_code=True)
  File "/usr/lib/python3.5/site-packages/dnf/cli/main.py", line 175, in user_main
    errcode = main(args)
  File "/usr/lib/python3.5/site-packages/dnf/cli/main.py", line 61, in main
    return _main(base, args)
  File "/usr/lib/python3.5/site-packages/dnf/cli/main.py", line 99, in _main
    return cli_run(cli, base)
  File "/usr/lib/python3.5/site-packages/dnf/cli/main.py", line 115, in cli_run
    cli.run()
  File "/usr/lib/python3.5/site-packages/dnf/cli/cli.py", line 936, in run
    return self.command.run()
  File "/usr/lib/python3.5/site-packages/dnf/cli/commands/repolist.py", line 250, in run
    if nm_len < exact_width(rname):
  File "/usr/lib/python3.5/site-packages/dnf/i18n.py", line 176, in exact_width
    return sum(_exact_width_char(c) for c in msg)
TypeError: 'NoneType' object is not iterable