### PR TITLE
Handle info message when DRPM wastes data

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -984,8 +984,12 @@ class Base(object):
 
         (real, full) = saving
         if real != full:
-            msg = _("Delta RPMs reduced %.1f MB of updates to %.1f MB "
-                    "(%d.1%% saved)")
+            if real < full:
+                msg = _("Delta RPMs reduced %.1f MB of updates to %.1f MB "
+                        "(%d.1%% saved)")
+            elif real > full:
+                msg = _("Failed Delta RPMs increased %.1f MB of updates to %.1f MB "
+                        "(%d.1%% wasted)")
             percent = 100 - real / full * 100
             logger.info(msg, full / 1024 ** 2, real / 1024 ** 2, percent)
 


### PR DESCRIPTION
When Delta RPMs fails to reconstruct the full RPM it has to download
the full RPM in addition to the already downloaded DRPM. This can
result in situations were download data is increased rather than
reduced.

E.g. I just got this info message:
“Delta RPMs reduced 83.7 MB of updates to 83.8 MB (0.1% saved)”