### PR TITLE
systemd: Disable daemons on ostree-managed systems

### DIFF
--- a/etc/systemd/dnf-automatic-download.service
+++ b/etc/systemd/dnf-automatic-download.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=dnf automatic download updates
+# See comment in dnf-makecache.service
+ConditionPathExists=!/run/ostree-booted
 
 [Service]
 Type=oneshot

--- a/etc/systemd/dnf-automatic-download.timer
+++ b/etc/systemd/dnf-automatic-download.timer
@@ -1,5 +1,7 @@
 [Unit]
 Description=dnf-automatic-download timer
+# See comment in dnf-makecache.service
+ConditionPathExists=!/run/ostree-booted
 
 [Timer]
 OnBootSec=1h

--- a/etc/systemd/dnf-automatic-install.service
+++ b/etc/systemd/dnf-automatic-install.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=dnf automatic install updates
+# See comment in dnf-makecache.service
+ConditionPathExists=!/run/ostree-booted
 
 [Service]
 Type=oneshot

--- a/etc/systemd/dnf-automatic-install.timer
+++ b/etc/systemd/dnf-automatic-install.timer
@@ -1,5 +1,7 @@
 [Unit]
 Description=dnf-automatic-install timer
+# See comment in dnf-makecache.service
+ConditionPathExists=!/run/ostree-booted
 
 [Timer]
 OnBootSec=1h

--- a/etc/systemd/dnf-automatic-notifyonly.service
+++ b/etc/systemd/dnf-automatic-notifyonly.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=dnf automatic notification of updates
+# See comment in dnf-makecache.service
+ConditionPathExists=!/run/ostree-booted
 
 [Service]
 Type=oneshot

--- a/etc/systemd/dnf-automatic-notifyonly.timer
+++ b/etc/systemd/dnf-automatic-notifyonly.timer
@@ -1,5 +1,7 @@
 [Unit]
 Description=dnf-automatic-notifyonly timer
+# See comment in dnf-makecache.service
+ConditionPathExists=!/run/ostree-booted
 
 [Timer]
 OnBootSec=1h

--- a/etc/systemd/dnf-makecache.service
+++ b/etc/systemd/dnf-makecache.service
@@ -1,5 +1,9 @@
 [Unit]
 Description=dnf makecache
+# On systems managed by either rpm-ostree/ostree, dnf is read-only;
+# while someone might theoretically want the cache updated, in practice
+# anyone who wants that could override this via a file in /etc.
+ConditionPathExists=!/run/ostree-booted
 
 [Service]
 Type=oneshot

--- a/etc/systemd/dnf-makecache.timer
+++ b/etc/systemd/dnf-makecache.timer
@@ -1,6 +1,8 @@
 [Unit]
 Description=dnf makecache timer
 ConditionKernelCommandLine=!rd.live.image
+# See comment in dnf-makecache.service
+ConditionPathExists=!/run/ostree-booted
 
 [Timer]
 OnBootSec=10min


### PR DESCRIPTION
[rpm-ostree](https://github.com/projectatomic/rpm-ostree) is the hybrid
package/image system that works on ostree-managed systems; we don't
want to enable dnf daemon functionality if somehow it gets pulled in
via dependencies.

https://bugzilla.redhat.com/show_bug.cgi?id=1415709