### PR TITLE
Return just name from Package.source_name

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -70,6 +70,7 @@ DNF CONTRIBUTORS
     Haïkel Guémar <haikel.guemar@gmail.com>
     Kevin Kofler <kevin.kofler@chello.at>
     Kushal Das <kushaldas@gmail.com>
+    Lubomír Sedlář <lsedlar@redhat.com>
     Matt Sturgeon <matt@sturgeon.me.uk
     Matthew Miller <mattdm@mattdm.org>
     Max Prokhorov <prokhorov.max@outlook.com>

--- a/dnf/package.py
+++ b/dnf/package.py
@@ -115,9 +115,12 @@ class Package(hawkey.Package):
         if self.sourcerpm is not None:
             # trim suffix first
             srcname = dnf.util.rtrim(self.sourcerpm, ".src.rpm")
-            # source package filenames may not contain epoch, handle both cases
-            srcname = dnf.util.rtrim(srcname, "-{}".format(self.evr))
-            srcname = dnf.util.rtrim(srcname, "-{0.version}-{0.release}".format(self))
+            # sourcerpm should be in form of name-version-release now, so we
+            # will strip the two rightmost parts separated by dash.
+            # Using rtrim with version and release of self is not sufficient
+            # because the package can have different version to the source
+            # package.
+            srcname = srcname.rsplit('-', 2)[0]
         else:
             srcname = None
         return srcname


### PR DESCRIPTION
If the version of package and its corresponding source do not match, the source_name returned would actually contain source version. This patch assumes sourcerpm is a correct NVR and just strips the last two dash-separated components from it.

It's supposed to fix https://bugzilla.redhat.com/show_bug.cgi?id=1418298

Please review carefully. I'm not completely sure this does not break something horribly.