### PR TITLE
change '--disableplugins' to '--disableplugin'

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -811,7 +811,7 @@ class Cli(object):
         # store the main commands & summaries, before plugins are loaded
         self.optparser.add_commands(self.cli_commands, 'main')
         # store the plugin commands & summaries
-        self.base.init_plugins(opts.disableplugins, self)
+        self.base.init_plugins(opts.disableplugin, self)
         self.optparser.add_commands(self.cli_commands,'plugin')
 
         # show help if no command specified

--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -171,7 +171,7 @@ class OptionParser(argparse.ArgumentParser):
         main_parser.add_argument("--noplugins", action="store_false",
                                  default=None, dest='plugins',
                                  help=_("disable all plugins"))
-        main_parser.add_argument("--disableplugins", dest="disableplugins",
+        main_parser.add_argument("--disableplugin", dest="disableplugin",
                                  default=[], action=self._SplitCallback,
                                  help=_("disable plugins by name"),
                                  metavar='[plugin]')


### PR DESCRIPTION
Purpose of this is to unify the form of `--enable/disableplugin` options. On top of that, in documentation there is `--disableplugin`.