### PR TITLE
Enable search of provides in /usr/(s)bin (RgBug:1421618)

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1803,7 +1803,11 @@ class Base(object):
         providers = dnf.query._by_provides(self.sack, provides_spec)
         if providers:
             return providers
-        return self.sack.query().filter(file__glob=provides_spec)
+        providers = self.sack.query().filter(file__glob=provides_spec)
+        if providers:
+            return providers
+        binary_provides = [prefix + provides_spec for prefix in ['/usr/bin/', '/usr/sbin/']]
+        return self.sack.query().filter(file__glob=binary_provides)
 
     def _history_undo_operations(self, operations):
         """Undo the operations on packages by their NEVRAs.

--- a/dnf/yum/option_parser.py
+++ b/dnf/yum/option_parser.py
@@ -38,25 +38,3 @@ class YumOptionParser(OptionParser):
             action="store_true", default=None,
             help=_("resolve depsolve problems by skipping packages"))    """
         pass
-
-    @staticmethod
-    def transform_yum_arg(args):
-        transformed = []
-        for arg in args:
-            provides = arg
-            if arg.startswith("*") is False:
-                provides = "*" + provides
-
-            if arg.endswith("*") is False:
-                provides += "*"
-
-            transformed.append(provides)
-
-        return transformed
-
-    def parse_command_args(self, command, args):
-        opts = super(YumOptionParser, self).parse_command_args(command, args)
-        if opts.command == ['provides']:
-            opts.dependency = self.transform_yum_arg(opts.dependency)
-
-        return opts

--- a/tests/test_yumlayer.py
+++ b/tests/test_yumlayer.py
@@ -70,25 +70,6 @@ class YumArgumentParserTest(tests.support.TestCase):
         self.assertIsNone(arg_opts.best)
 
 
-class YumProvidesCommandTest(tests.support.TestCase):
-    def setUp(self):
-        self.cli = mock.Mock()
-        self.command = dnf.cli.commands.ProvidesCommand(self.cli)
-
-    def test_provides_command(self):
-        _parse(self.command, [u'provides', u'nf'])
-        self.assertEqual(self.command.opts.dependency, [u'*nf*'])
-
-        _parse(self.command, [u'provides', u'nf*'])
-        self.assertEqual(self.command.opts.dependency, [u'*nf*'])
-
-        _parse(self.command, [u'provides', u'*nf'])
-        self.assertEqual(self.command.opts.dependency, [u'*nf*'])
-
-        _parse(self.command, [u'provides', u'*nf*'])
-        self.assertEqual(self.command.opts.dependency, [u'*nf*'])
-
-
 class YumCustomCommandTest(tests.support.TestCase):
     def setUp(self):
         self.conf = dnf.yum.config.YumConf()


### PR DESCRIPTION
This is part of yum dnf compatibility, where dnf was unable to find match for
'df' argument (dnf provides df).

https://bugzilla.redhat.com/show_bug.cgi?id=1421618