### PR TITLE
Fix problem with duplicated --obsoletes in argparser

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -931,6 +931,10 @@ class Cli(object):
         if stderr is not None:
             self.base._logging.stderr_handler.setLevel(stderr)
 
+    def _option_conflict(self, option_string_1, option_string_2):
+        print(self.optparser.print_usage())
+        raise dnf.exceptions.Error(_("argument {}: not allowed with argument {}".format(
+            option_string_1, option_string_2)))
 
     def register_command(self, command_cls):
         """Register a Command. :api"""

--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -182,9 +182,6 @@ class InfoCommand(Command):
         narrows.add_argument('--recent', dest='_packages_action',
                              action='store_const', const='recent',
                              help=_("show only recently changed packages"))
-        narrows.add_argument('--obsoletes', dest='_packages_action',
-                             action='store_const', const='obsoletes',
-                             help=_("show only obsoletes packages"))
         parser.add_argument('packages', nargs='*', metavar=_('PACKAGE'),
                             choices=cls.pkgnarrows, default=cls.DEFAULT_PKGNARROW,
                             action=OptionParser.PkgNarrowCallback)
@@ -196,6 +193,12 @@ class InfoCommand(Command):
         demands.sack_activation = True
         if self.opts._packages_action:
             self.opts.packages_action = self.opts._packages_action
+        if self.opts.obsoletes:
+            if self.opts._packages_action:
+                raise dnf.exceptions.Error(_("argument {}: not allowed with argument {}".format(
+                    "--obsoletes", "--" + self.opts._packages_action)))
+            else:
+                self.opts.packages_action = 'obsoletes'
         if self.opts.packages_action == 'updates':
             self.opts.packages_action = 'upgrades'
 
@@ -308,6 +311,12 @@ class RepoPkgsCommand(Command):
             demands.sack_activation = True
             if self.opts._pkg_specs_action:
                 self.opts.pkg_specs_action = self.opts._pkg_specs_action
+            if self.opts.obsoletes:
+                if self.opts._pkg_specs_action:
+                    raise dnf.exceptions.Error(_("argument {}: not allowed with argument {}".format(
+                        "--obsoletes", "--" + self.opts._pkg_specs_action)))
+                else:
+                    self.opts.pkg_specs_action = 'obsoletes'
 
         @staticmethod
         def set_argparser(parser):
@@ -341,9 +350,6 @@ class RepoPkgsCommand(Command):
             narrows.add_argument('--recent', dest='_pkg_specs_action',
                                  action='store_const', const='recent',
                                  help=_("show only recently changed packages"))
-            narrows.add_argument('--obsoletes', dest='_pkg_specs_action',
-                                 action='store_const', const='obsoletes',
-                                 help=_("show only obsoletes packages"))
             parser.add_argument('pkg_specs', nargs='*', metavar=_('PACKAGE'),
                                 choices=pkgnarrows, default=DEFAULT_PKGNARROW,
                                 action=OptionParser.PkgNarrowCallback)

--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -195,8 +195,7 @@ class InfoCommand(Command):
             self.opts.packages_action = self.opts._packages_action
         if self.opts.obsoletes:
             if self.opts._packages_action:
-                raise dnf.exceptions.Error(_("argument {}: not allowed with argument {}".format(
-                    "--obsoletes", "--" + self.opts._packages_action)))
+                self.cli._option_conflict("--obsoletes", "--" + self.opts._packages_action)
             else:
                 self.opts.packages_action = 'obsoletes'
         if self.opts.packages_action == 'updates':
@@ -313,8 +312,7 @@ class RepoPkgsCommand(Command):
                 self.opts.pkg_specs_action = self.opts._pkg_specs_action
             if self.opts.obsoletes:
                 if self.opts._pkg_specs_action:
-                    raise dnf.exceptions.Error(_("argument {}: not allowed with argument {}".format(
-                        "--obsoletes", "--" + self.opts._pkg_specs_action)))
+                    self.cli._option_conflict("--obsoletes", "--" + self.opts._pkg_specs_action)
                 else:
                     self.opts.pkg_specs_action = 'obsoletes'
 

--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -267,7 +267,7 @@ class RepoQueryCommand(commands.Command):
             q = self.base.sack.query().filter(pkg=pkgs)
 
         if self.opts.recent:
-            q.recent(self.base.conf.recent)
+            q._recent(self.base.conf.recent)
         if self.opts.available:
             if self.opts.list and self.opts.list != "installed":
                 print(self.cli.optparser.print_usage())

--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -205,9 +205,7 @@ class RepoQueryCommand(commands.Command):
         demands = self.cli.demands
 
         if self.opts.obsoletes and self.opts.packageatr:
-            print(self.cli.optparser.print_usage())
-            raise dnf.exceptions.Error(_("argument {}: not allowed with argument {}".format(
-                "--obsoletes", "--" + self.opts.packageatr)))
+            self.cli._option_conflict("--obsoletes", "--" + self.opts.packageatr)
 
         if not self.opts.verbose and not self.opts.quiet:
             self.cli.redirect_logger(stdout=logging.WARNING, stderr=logging.INFO)

--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -218,7 +218,7 @@ class OptionParser(argparse.ArgumentParser):
                                  action="store_true",
                                  help=_("enables dnf's obsoletes processing logic "
                                         "for upgrade or display capabilities that "
-                                        "the package obsoletes for repoquery"))
+                                        "the package obsoletes for repoquery, and info"))
         main_parser.add_argument("--rpmverbosity", default=None,
                                  help=_("debugging output level for rpm"),
                                  metavar='[debug level name]')

--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -218,7 +218,7 @@ class OptionParser(argparse.ArgumentParser):
                                  action="store_true",
                                  help=_("enables dnf's obsoletes processing logic "
                                         "for upgrade or display capabilities that "
-                                        "the package obsoletes for repoquery, and info"))
+                                        "the package obsoletes for info, list and repoquery"))
         main_parser.add_argument("--rpmverbosity", default=None,
                                  help=_("debugging output level for rpm"),
                                  metavar='[debug level name]')


### PR DESCRIPTION
The info commands has --obsoletes but also there is --obsoletes as general dnf
option. The commit fix the problem

ArgumentError: argument --obsoletes: conflicting option string: --obsoletes