### PR TITLE
util/on_metered_connection: be more polite to failures

### DIFF
--- a/dnf/util.py
+++ b/dnf/util.py
@@ -234,11 +234,14 @@ def on_metered_connection():
         import dbus
     except ImportError:
         return None
-    bus = dbus.SystemBus()
-    proxy = bus.get_object("org.freedesktop.NetworkManager",
-                           "/org/freedesktop/NetworkManager")
-    iface = dbus.Interface(proxy, "org.freedesktop.DBus.Properties")
-    metered = iface.Get("org.freedesktop.NetworkManager", "Metered")
+    try:
+        bus = dbus.SystemBus()
+        proxy = bus.get_object("org.freedesktop.NetworkManager",
+                               "/org/freedesktop/NetworkManager")
+        iface = dbus.Interface(proxy, "org.freedesktop.DBus.Properties")
+        metered = iface.Get("org.freedesktop.NetworkManager", "Metered")
+    except DBusException:
+        return None
     if metered == 0: # NM_METERED_UNKNOWN
         return None
     elif metered in (1, 3): # NM_METERED_YES, NM_METERED_GUESS_YES

--- a/dnf/util.py
+++ b/dnf/util.py
@@ -240,7 +240,7 @@ def on_metered_connection():
                                "/org/freedesktop/NetworkManager")
         iface = dbus.Interface(proxy, "org.freedesktop.DBus.Properties")
         metered = iface.Get("org.freedesktop.NetworkManager", "Metered")
-    except DBusException:
+    except dbus.DBusException:
         return None
     if metered == 0: # NM_METERED_UNKNOWN
         return None


### PR DESCRIPTION
* dbus.SystemBus() will fail if DBus is not running
* bus.get_object() will fail if NetworkManager is not installed

Also make sure if other stuff fails, we just return None
instead of crashing.

Reported-by: Neal Gompa <ngompa13@gmail.com>
Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>