### PR TITLE
Add -a and --all option for repoquery (RhBug:1412970)

### DIFF
--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -100,6 +100,9 @@ class RepoQueryCommand(commands.Command):
     def set_argparser(parser):
         parser.add_argument('key', nargs='*',
                             help=_('the key to search for'))
+        parser.add_argument('-a', '--all', dest='queryall', action='store_true',
+                            help=_("Query all packages (shorthand for repoquery '*' "
+                                   "or repoquery without argument)"))
         parser.add_argument('--arch', metavar='ARCH',
                             help=_('show only results from this ARCH'))
         parser.add_argument('-f', '--file', metavar='FILE', nargs='+',

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -783,6 +783,10 @@ resulting packages matching the specification. All packages are considered if no
     Package specification like: name[-[epoch:]version[-release]][.arch]. See :ref:`Specifying Packages
     <specifying_packages-label>`
 
+``-a``, ``--all``
+    Query all packages (for rpmquery compatibility / shorthand for repoquery '*' or repoquery
+    without argument)'
+
 ``--arch <arch>[,<arch>...]``
     Limit the resulting set only to packages of selected architectures.
 


### PR DESCRIPTION
Options represent default repoquery behavior without argument or with '*'
argument, but it is necessary for yum-dnf compatibility.

https://bugzilla.redhat.com/show_bug.cgi?id=1412970