### PR TITLE
Not print help if empty line in script for shell command

### DIFF
--- a/dnf/cli/commands/shell.py
+++ b/dnf/cli/commands/shell.py
@@ -88,7 +88,7 @@ class ShellCommand(commands.Command, cmd.Cmd):
         self.base.fill_sack()
 
     def onecmd(self, line):
-        if not line:
+        if not line or line == '\n':
             return
         if line == 'EOF':
             line = 'quit'

--- a/dnf/cli/commands/shell.py
+++ b/dnf/cli/commands/shell.py
@@ -189,7 +189,7 @@ class ShellCommand(commands.Command, cmd.Cmd):
                     if not line.startswith('#'):
                         self.onecmd(line)
         except IOError:
-            logger.info(_('Error: Cannot open %s for reading'.format(file)))
+            logger.info(_('Error: Cannot open %s for reading'), self.base.output.term.bold(file))
             sys.exit(1)
 
     def _transaction(self, args=None):


### PR DESCRIPTION
If empty line was in script it prints help because shlex.split(line) was unable
to split it. It could be confusing for some users to see help for no obvious
reason.