### PR TITLE
Add --nodocs option for dnf (RhBug:1379628)

### DIFF
--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -169,6 +169,8 @@ class OptionParser(argparse.ArgumentParser):
                                  help=_("show DNF version and exit"))
         main_parser.add_argument("--installroot", help=_("set install root"),
                                  metavar='[path]')
+        main_parser.add_argument("--nodocs", action="store_const", const=['nodocs'], dest='tsflags',
+                                 help=_("do not install documentations"))
         main_parser.add_argument("--noplugins", action="store_false",
                                  default=None, dest='plugins',
                                  help=_("disable all plugins"))

--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -683,7 +683,7 @@ class MainConf(BaseConfig):
         self._add_option('installonly_limit',
                          PositiveIntOption(0, range_min=2,
                                            names_of_0=["0", "<off>"])) # :api
-        self._add_option('tsflags', ListOption()) # :api
+        self._add_option('tsflags', ListAppendOption())  # :api
 
         self._add_option('assumeyes', BoolOption(False)) # :api
         self._add_option('assumeno', BoolOption(False))
@@ -827,7 +827,7 @@ class MainConf(BaseConfig):
                        'best', 'assumeyes', 'assumeno', 'gpgcheck',
                        'showdupesfromrepos', 'plugins', 'ip_resolve',
                        'rpmverbosity', 'disable_excludes',
-                       'color', 'downloadonly', 'exclude', 'excludepkgs', "skip_broken"]
+                       'color', 'downloadonly', 'exclude', 'excludepkgs', "skip_broken", 'tsflags']
 
         for name in config_args:
             value = getattr(opts, name, None)

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -222,6 +222,9 @@ Options
 ``--newpackage``
     Include newpackage relevant packages. Applicable for upgrade command.
 
+``--nodocs``
+    do not install documentations by using rpm flag 'RPMTRANS_FLAG_NODOCS'
+
 ``--nogpgcheck``
     skip checking GPG signatures on packages
 


### PR DESCRIPTION
The option add nodocs keyword into conf.tsflags that result to add rpm flag
'RPMTRANS_FLAG_NODOCS'

https://bugzilla.redhat.com/show_bug.cgi?id=1379628