### PR TITLE
Fix crash and translation with nonexistent locale

### DIFF
--- a/dnf/cli/main.py
+++ b/dnf/cli/main.py
@@ -86,8 +86,6 @@ def main(args, conf_class=Conf, cli_class=Cli, option_parser_class=OptionParser)
 def _main(base, args, cli_class, option_parser):
     """Run the dnf program from a command line interface."""
 
-    dnf.i18n.setup_locale()
-    dnf.i18n.setup_translation()
     dnf.i18n.setup_stdout()
 
     # our core object for the cli

--- a/dnf/cli/main.py
+++ b/dnf/cli/main.py
@@ -87,6 +87,7 @@ def _main(base, args, cli_class, option_parser):
     """Run the dnf program from a command line interface."""
 
     dnf.i18n.setup_locale()
+    dnf.i18n.setup_translation()
     dnf.i18n.setup_stdout()
 
     # our core object for the cli

--- a/dnf/i18n.py
+++ b/dnf/i18n.py
@@ -298,5 +298,33 @@ def translation(name):
     t = dnf.pycomp.gettext.translation(name, fallback=True)
     return map(ucd_wrapper, dnf.pycomp.gettext_setup(t))
 
-# setup translations
-_, P_ = translation("dnf")
+
+def _gettext(message):
+    # Fallback code. Used until setup_translation() is called.
+    return message
+
+
+def _ngettext(singular, plural, n):
+    # Fallback code. Used until setup_translation() is called.
+    return singular if n == 1 else plural
+
+
+def setup_translation():
+    """ Setup translation according to current global domain, language, and locale directory """
+    global _gettext, _ngettext
+    _gettext, _ngettext = translation("dnf")
+
+
+def _(message):
+    """ Return the localized translation of message.
+        Call setup_translation() at first. """
+    return _gettext(message)
+
+
+def P_(singular, plural, n):
+    """ Return the localized translation of message like _(), but consider plural forms.
+        If a translation is found, apply the plural formula to n, and return the resulting message
+        (some languages have more than two plural forms).
+        If no translation is found, return singular if n is 1; return plural otherwise.
+        Call setup_translation() at first. """
+    return _ngettext(singular, plural, n)

--- a/dnf/i18n.py
+++ b/dnf/i18n.py
@@ -293,38 +293,11 @@ def translation(name):
     # :api, deprecated in 2.0.0, will be erased when python2 is abandoned
     """ Easy gettext translations setup based on given domain name """
 
+    setup_locale()
     def ucd_wrapper(fnc):
         return lambda *w: ucd(fnc(*w))
     t = dnf.pycomp.gettext.translation(name, fallback=True)
     return map(ucd_wrapper, dnf.pycomp.gettext_setup(t))
 
-
-def _gettext(message):
-    # Fallback code. Used until setup_translation() is called.
-    return message
-
-
-def _ngettext(singular, plural, n):
-    # Fallback code. Used until setup_translation() is called.
-    return singular if n == 1 else plural
-
-
-def setup_translation():
-    """ Setup translation according to current global domain, language, and locale directory """
-    global _gettext, _ngettext
-    _gettext, _ngettext = translation("dnf")
-
-
-def _(message):
-    """ Return the localized translation of message.
-        Call setup_translation() at first. """
-    return _gettext(message)
-
-
-def P_(singular, plural, n):
-    """ Return the localized translation of message like _(), but consider plural forms.
-        If a translation is found, apply the plural formula to n, and return the resulting message
-        (some languages have more than two plural forms).
-        If no translation is found, return singular if n is 1; return plural otherwise.
-        Call setup_translation() at first. """
-    return _ngettext(singular, plural, n)
+# setup translations
+_, P_ = translation("dnf")

--- a/dnf/logging.py
+++ b/dnf/logging.py
@@ -160,6 +160,7 @@ class Logging(object):
         handler = _create_filehandler(logfile)
         logger_rpm.addHandler(handler)
         _paint_mark(logger_rpm)
+        logging.raiseExceptions = False
 
     def _setup_from_dnf_conf(self, conf):
         verbose_level_r = _cfg_verbose_val2level(conf.debuglevel)


### PR DESCRIPTION
Fixes crash with nonexistent locale. Eg. someone use "ru" instead of "ru_RU".
setup_locale() sets locale to "C" for nonexistent locales. But setting of locale must be done before initialization of translation. Otherwise translation ignores this setting. This pull request change the order of initialization (setup_locale() moved from main.py to i18n.py before translation settings). And also disables exception in logging.