### PR TITLE
history: removed unused variable

### DIFF
--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -1509,7 +1509,6 @@ Transaction Summary
             old = self.history.last(complete_transactions_only=False)
             if old is not None:
                 tids.add(old.tid)
-                utids.add(old.tid)
 
         if not tids:
             logger.critical(_('No transaction ID, or package, given'))


### PR DESCRIPTION
This variable was introduced in 99b7058 but now it's no longet in use
and accesing it (because uninitialized) could cause crashes