### PR TITLE
Fix doc example for `fill_sack` method

### DIFF
--- a/doc/api_base.rst
+++ b/doc/api_base.rst
@@ -82,9 +82,7 @@
       conf = base.conf
       conf.cachedir = CACHEDIR
       conf.substitutions['releasever'] = 22
-      repo = dnf.repo.Repo('my-repo', CACHEDIR)
-      repo.baseurl = [MY_REPO_URL]
-      base.repos.add(repo)
+      base.repos.add_new_repo('my-repo', conf, baseurl=[MY_REPO_URL])
       base.fill_sack()
 
   .. method:: do_transaction([display])


### PR DESCRIPTION
The example was passing only cache dir to a `Repo` object, while the whole config is needed. This can however be simplified a lot more by using the new `add_new_repo` method.