### PR TITLE
Add armv5tl to arm basearch

### DIFF
--- a/dnf/rpm/__init__.py
+++ b/dnf/rpm/__init__.py
@@ -77,7 +77,7 @@ _BASEARCH_MAP = _invert({
     'aarch64': ('aarch64',),
     'alpha': ('alpha', 'alphaev4', 'alphaev45', 'alphaev5', 'alphaev56',
               'alphaev6', 'alphaev67', 'alphaev68', 'alphaev7', 'alphapca56'),
-    'arm': ('armv5tejl', 'armv5tel', 'armv6l', 'armv7l'),
+    'arm': ('armv5tejl', 'armv5tel', 'armv5tl', 'armv6l', 'armv7l'),
     'armhfp': ('armv6hl', 'armv7hl', 'armv7hnl', 'armv8l'),
     'i386': ('i386', 'athlon', 'geode', 'i386', 'i486', 'i586', 'i686'),
     'ia64': ('ia64',),


### PR DESCRIPTION
This is required to properly support armv5tl for Mageia 6.

Depends on rpm-software-management/libdnf#277.
(Sort of) depends on rpm-software-management/rpm#179.