### PR TITLE
Honor weak_deps setting only for install (RhBug:1278196)

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -746,6 +746,9 @@ class Cli(object):
             self.base.fill_sack(load_system_repo='auto',
                                 load_available_repos=self.demands.available_repos)
 
+        if not demands.honor_weak_deps:
+            self.base.conf.install_weak_deps = False
+
     def _parse_commands(self, opts, args):
         """Check that the requested CLI command exists."""
 

--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -369,6 +369,7 @@ class RepoPkgsCommand(Command):
             demands.sack_activation = True
             demands.resolving = True
             demands.root_user = True
+            demands.honor_weak_deps = True
 
         def run_on_repo(self):
             """Execute the command with respect to given arguments *cli_args*."""

--- a/dnf/cli/commands/group.py
+++ b/dnf/cli/commands/group.py
@@ -362,7 +362,8 @@ class GroupCommand(commands.Command):
             demands.available_repos = False
         else:
             demands.available_repos = True
-
+        if cmd == 'install':
+            demands.honor_weak_deps = True
         commands._checkEnabledRepo(self.base)
 
         if cmd in ('install', 'upgrade'):

--- a/dnf/cli/commands/install.py
+++ b/dnf/cli/commands/install.py
@@ -61,6 +61,7 @@ class InstallCommand(commands.Command):
         demands.root_user = True
         commands._checkGPGKey(self.base, self.cli)
         commands._checkEnabledRepo(self.base, self.opts.filenames)
+        demands.honor_weak_deps = True
 
     def run(self):
         strict = self.base.conf.strict

--- a/dnf/cli/commands/shell.py
+++ b/dnf/cli/commands/shell.py
@@ -40,6 +40,7 @@ class ShellDemandSheet(object):
     root_user = True
     sack_activation = True
     success_exit_status = 0
+    honor_weak_deps = False
     cacheonly = False
     fresh_metadata = True
     freshest_metadata = False

--- a/dnf/cli/demand.py
+++ b/dnf/cli/demand.py
@@ -50,7 +50,7 @@ class DemandSheet(object):
     root_user = _BoolDefault(False)
     sack_activation = _BoolDefault(False)
     success_exit_status = 0
-
+    honor_weak_deps = _BoolDefault(False)
     cacheonly = _BoolDefault(False)
     fresh_metadata = _BoolDefault(True)
     freshest_metadata = _BoolDefault(False)

--- a/doc/api_cli.rst
+++ b/doc/api_cli.rst
@@ -61,6 +61,11 @@ When packaging your custom command, we recommend you to define a virtual provide
 
       The return status of the DNF command on success. Defaults to ``0``.
 
+    .. attribute:: honor_weak_deps
+
+      If ``False``, it automatically reset conf.install_weak_deps to ``False``. Use weak setting and
+      set this demand to ``True`` is important only for install commands. Defaults to ``False``.
+
     .. attribute:: transaction_display
 
       An additional instance of a subclass of :class:`dnf.callback.TransactionProgress` used to report information about an ongoing transaction.


### PR DESCRIPTION
If install_weak_deps is True it try to install weak deps on upgrade, and
downgrade transaction. The patch allows use weak_deps setting only on demand
request.

https://bugzilla.redhat.com/show_bug.cgi?id=1278196