### PR TITLE
Mark installonlypkgs correctly as user installed (RhBug:1349314)

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -899,8 +899,7 @@ class Base(object):
             yumdb_info = self._yumdb.get_package(po)
             yumdb_info.from_repo = rpo.repoid
 
-            yumdb_info.reason = tsi._propagated_reason(self._yumdb,
-                                                      self.conf.installonlypkgs)
+            yumdb_info.reason = tsi._propagated_reason(self._yumdb, self._get_installonly_query())
             yumdb_info.releasever = self.conf.releasever
             if hasattr(self, 'args') and self.args:
                 yumdb_info.command_line = ' '.join(self.args)

--- a/dnf/transaction.py
+++ b/dnf/transaction.py
@@ -107,6 +107,19 @@ class TransactionItem(object):
             previously = yumdb.get_package(self.erased).get('reason')
             if previously:
                 return previously
+        if self.obsoleted:
+            reasons = set()
+            for obs in self.obsoleted:
+                reasons.add(yumdb.get_package(obs).get('reason'))
+            if reasons:
+                if 'user' in reasons:
+                    return 'user'
+                if 'group' in reasons:
+                    return 'group'
+                if 'dep' in reasons:
+                    return 'dep'
+                if 'weak' in reasons:
+                    return 'weak'
         return self.reason
 
     def removes(self):

--- a/dnf/transaction.py
+++ b/dnf/transaction.py
@@ -98,10 +98,10 @@ class TransactionItem(object):
     def _obsoleting_history_state(self):
         return 'Obsoleting'
 
-    def _propagated_reason(self, yumdb, installonlypkgs):
+    def _propagated_reason(self, yumdb, installonlypkgs_query):
         if self.reason == 'user':
             return self.reason
-        if self.installed.name in installonlypkgs:
+        if installonlypkgs_query.filter(name=self.installed.name):
             return 'user'
         if self.op_type in [DOWNGRADE, REINSTALL, UPGRADE]:
             previously = yumdb.get_package(self.erased).get('reason')

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -94,22 +94,23 @@ class TransactionItemTest(tests.support.TestCase):
     def test_propagated_reason(self):
         yumdb = mock.Mock()
         yumdb.get_package().get = lambda s: 'dep'
-
+        self.base = tests.support.BaseCliStub()
+        self.base._sack = tests.support.mock_sack('main', 'search')
         tsi = dnf.transaction.TransactionItem(
             dnf.transaction.INSTALL, installed=self.newpkg, reason='user')
-        self.assertEqual(tsi._propagated_reason(yumdb, []), 'user')
+        self.assertEqual(tsi._propagated_reason(yumdb, self.base._sack.query().filter(empty=True)), 'user')
         tsi = dnf.transaction.TransactionItem(
             dnf.transaction.UPGRADE, installed=self.newpkg, erased=self.oldpkg)
-        self.assertEqual(tsi._propagated_reason(yumdb, []), 'dep')
+        self.assertEqual(tsi._propagated_reason(yumdb, self.base._sack.query().filter(empty=True)), 'dep')
         tsi = dnf.transaction.TransactionItem(
             dnf.transaction.DOWNGRADE,
             installed=self.newpkg, erased=self.oldpkg)
-        self.assertEqual(tsi._propagated_reason(yumdb, []), 'dep')
+        self.assertEqual(tsi._propagated_reason(yumdb, self.base._sack.query().filter(empty=True)), 'dep')
 
         # test the call can survive if no reason is known:
         yumdb = mock.Mock()
         yumdb.get_package().get = lambda s: None
-        self.assertEqual(tsi._propagated_reason(yumdb, []), 'unknown')
+        self.assertEqual(tsi._propagated_reason(yumdb, self.base._sack.query().filter(empty=True)), 'unknown')
 
     def test_removes(self):
         tsi = dnf.transaction.TransactionItem(

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -98,19 +98,23 @@ class TransactionItemTest(tests.support.TestCase):
         self.base._sack = tests.support.mock_sack('main', 'search')
         tsi = dnf.transaction.TransactionItem(
             dnf.transaction.INSTALL, installed=self.newpkg, reason='user')
-        self.assertEqual(tsi._propagated_reason(yumdb, self.base._sack.query().filter(empty=True)), 'user')
+        self.assertEqual(tsi._propagated_reason(yumdb, self.base._sack.query().filter(empty=True)),
+                         'user')
         tsi = dnf.transaction.TransactionItem(
             dnf.transaction.UPGRADE, installed=self.newpkg, erased=self.oldpkg)
-        self.assertEqual(tsi._propagated_reason(yumdb, self.base._sack.query().filter(empty=True)), 'dep')
+        self.assertEqual(tsi._propagated_reason(yumdb, self.base._sack.query().filter(empty=True)),
+                         'dep')
         tsi = dnf.transaction.TransactionItem(
             dnf.transaction.DOWNGRADE,
             installed=self.newpkg, erased=self.oldpkg)
-        self.assertEqual(tsi._propagated_reason(yumdb, self.base._sack.query().filter(empty=True)), 'dep')
+        self.assertEqual(tsi._propagated_reason(yumdb, self.base._sack.query().filter(empty=True)),
+                         'dep')
 
         # test the call can survive if no reason is known:
         yumdb = mock.Mock()
         yumdb.get_package().get = lambda s: None
-        self.assertEqual(tsi._propagated_reason(yumdb, self.base._sack.query().filter(empty=True)), 'unknown')
+        self.assertEqual(tsi._propagated_reason(yumdb, self.base._sack.query().filter(empty=True)),
+                         'unknown')
 
     def test_removes(self):
         tsi = dnf.transaction.TransactionItem(


### PR DESCRIPTION
It recognized packages as install_only by name and not by provide. It was fixed
by this patch.

https://bugzilla.redhat.com/show_bug.cgi?id=1349314