### PR TITLE
Fix repo-pkgs and commands initialization in shell

### DIFF
--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -762,6 +762,7 @@ class RepoPkgsCommand(Command):
             metavar=_('REPO'))
         subparser = parser.add_subparsers(dest='subcmd',
                                           parser_class=argparse.ArgumentParser)
+        subparser.required = True
         for subcommand in self._subcmd_name2obj.keys():
             p = subparser.add_parser(subcommand)
             self._subcmd_name2obj[subcommand].set_argparser(p)

--- a/dnf/cli/commands/shell.py
+++ b/dnf/cli/commands/shell.py
@@ -106,10 +106,9 @@ class ShellCommand(commands.Command, cmd.Cmd):
         else:
             cmd_cls = self.cli.cli_commands.get(opts.command)
             if cmd_cls is not None:
-                cmd = cmd_cls(self)
+                cmd = cmd_cls(self.cli)
                 try:
                     opts = self.cli.optparser.parse_command_args(cmd, s_line)
-                    cmd.cli = self.cli
                     cmd.cli.demands = copy.deepcopy(self.cli.demands)
                     cmd.configure()
                     cmd.run()


### PR DESCRIPTION
Before this fix:
```
# dnf shell
> repo-pkgs base list
<fails with ugly traceback>

# dnf shell
> repo-pkgs base
...
TypeError: Can't convert 'NoneType' object to str implicitly
and shell crashed.
``` 