### PR TITLE
Do not raise assertion if group inst and rmv pkgs (RhBug:1438438)

### DIFF
--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -947,7 +947,6 @@ class Output(object):
             grp_name = comps._group_by_id(grp_id).ui_name
             rows.extend(_spread_in_columns(4, "@" + grp_name, pkgs))
         if diff.removed_groups:
-            assert not rows
             out.append(_('Marking packages as removed by the group:'))
         for grp_id in diff.removed_groups:
             pkgs = list(diff.removed_packages(grp_id))


### PR DESCRIPTION
It looks like that it is possible to experience case where during group install
some packages are marked as group removed, but the code raises assertion
therefore it is very difficult to investigate the issue behind and impossible to
reproduce.

https://bugzilla.redhat.com/show_bug.cgi?id=1438438