### PR TITLE
Refactored detection of releasever

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -281,7 +281,7 @@ class Base(object):
 
         if timer:
             persistor.reset_last_makecache = True
-        self.fill_sack()  # performs the md sync
+        self.fill_sack(load_system_repo=False, load_available_repos=True)  # performs the md sync
         logger.info(_('Metadata cache created.'))
         return True
 

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -881,6 +881,8 @@ class Cli(object):
         # cachedir, logs, releasever, and gpgkey are taken from or stored in installroot
         if releasever is None:
             releasever = dnf.rpm.detect_releasever(conf.installroot)
+        elif releasever == '/':
+            releasever = dnf.rpm.detect_releasever(releasever)
         conf.releasever = releasever
         subst = conf.substitutions
         subst.update_from_etc(conf.installroot)

--- a/dnf/rpm/__init__.py
+++ b/dnf/rpm/__init__.py
@@ -30,38 +30,35 @@ def detect_releasever(installroot):
     # :api
     """Calculate the release version for the system."""
 
-    # if installroot is empty dir releasever is None,
-    # that's why releasever is checked from '/'
-    for root in [installroot, "/"]:
-        ts = transaction.initReadOnlyTransaction(root=root)
-        ts.pushVSFlags(~(rpm._RPMVSF_NOSIGNATURES | rpm._RPMVSF_NODIGESTS))
-        for distroverpkg in dnf.const.DISTROVERPKG:
-            try:
-                idx = ts.dbMatch('provides', distroverpkg)
-            except (TypeError, rpm.error) as e:
-                raise dnf.exceptions.Error('Error: %s' % str(e))
-            if not len(idx):
-                continue
-            try:
-                hdr = next(idx)
-            except StopIteration:
-                msg = 'Error: rpmdb failed to list provides. Try: rpm --rebuilddb'
-                raise dnf.exceptions.Error(msg)
-            releasever = hdr['version']
-            try:
-                off = hdr[rpm.RPMTAG_PROVIDENAME].index(distroverpkg)
-                flag = hdr[rpm.RPMTAG_PROVIDEFLAGS][off]
-                ver = hdr[rpm.RPMTAG_PROVIDEVERSION][off]
-                if flag == rpm.RPMSENSE_EQUAL and ver:
-                    if hdr['name'] != distroverpkg:
-                        # override the package version
-                        releasever = ver
-            except (ValueError, KeyError, IndexError):
-                pass
+    ts = transaction.initReadOnlyTransaction(root=installroot)
+    ts.pushVSFlags(~(rpm._RPMVSF_NOSIGNATURES | rpm._RPMVSF_NODIGESTS))
+    for distroverpkg in dnf.const.DISTROVERPKG:
+        try:
+            idx = ts.dbMatch('provides', distroverpkg)
+        except (TypeError, rpm.error) as e:
+            raise dnf.exceptions.Error('Error: %s' % str(e))
+        if not len(idx):
+            continue
+        try:
+            hdr = next(idx)
+        except StopIteration:
+            msg = 'Error: rpmdb failed to list provides. Try: rpm --rebuilddb'
+            raise dnf.exceptions.Error(msg)
+        releasever = hdr['version']
+        try:
+            off = hdr[rpm.RPMTAG_PROVIDENAME].index(distroverpkg)
+            flag = hdr[rpm.RPMTAG_PROVIDEFLAGS][off]
+            ver = hdr[rpm.RPMTAG_PROVIDEVERSION][off]
+            if flag == rpm.RPMSENSE_EQUAL and ver:
+                if hdr['name'] != distroverpkg:
+                    # override the package version
+                    releasever = ver
+        except (ValueError, KeyError, IndexError):
+            pass
 
-            if is_py3bytes(releasever):
-                releasever = str(releasever, "utf-8")
-            return releasever
+        if is_py3bytes(releasever):
+            releasever = str(releasever, "utf-8")
+        return releasever
     return None
 
 

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -205,10 +205,9 @@ Options
  Note: You may also want to use the command-line option
  ``--releasever=<release>`` when creating the installroot otherwise the
  *$releasever* value is taken from the rpmdb within the installroot (and thus
- it is empty at time of creation and *$releasever* is taken from rpmdb using
- installroot=/).
- The new installroot path at time of creation do not contain *repository*,
- *releasever*, and *dnf.conf* file.
+ it is empty at time of creation, the transaction will fail). If ``--releasever=/`` is used, the
+ releasever will be detected from host (``/``) system. The new installroot path at time of creation
+ does not contain *repository*, *releasever*, and *dnf.conf* file.
 
  Installroot examples:
 


### PR DESCRIPTION
It uses yum stile of autodetection for empty installroot: ``--releasever=/``