### PR TITLE
Create a warning if releasever is None

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -883,6 +883,9 @@ class Cli(object):
             releasever = dnf.rpm.detect_releasever(conf.installroot)
         elif releasever == '/':
             releasever = dnf.rpm.detect_releasever(releasever)
+        if releasever is None:
+            logger.warning(_("Unable to detect release version (use '--releasever' to specify "
+                             "release version)"))
         conf.releasever = releasever
         subst = conf.substitutions
         subst.update_from_etc(conf.installroot)


### PR DESCRIPTION
It should help users to find out why it is impossible to download a metadata in
empty installroot.