### PR TITLE
Add autocheck_running_kernel config option

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -930,6 +930,24 @@ class Cli(object):
         if stderr is not None:
             self.base._logging.stderr_handler.setLevel(stderr)
 
+    def _check_running_kernel(self):
+        kernel = self.base.sack.get_running_kernel()
+        if kernel is None:
+            return
+
+        q = self.base.sack.query().filter(provides='kernel-core')
+        q = q.installed()
+        q = q.filter(advisory_type='security')
+
+        ikpkg = kernel
+        for pkg in q:
+            if pkg > ikpkg:
+                ikpkg = pkg
+
+        if ikpkg > kernel:
+            print(('Security: %s is an installed security update') % ikpkg)
+            print(('Security: %s is the currently running version') % kernel)
+
     def _option_conflict(self, option_string_1, option_string_2):
         print(self.optparser.print_usage())
         raise dnf.exceptions.Error(_("argument {}: not allowed with argument {}".format(

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -935,7 +935,7 @@ class Cli(object):
         if kernel is None:
             return
 
-        q = self.base.sack.query().filter(provides='kernel-core')
+        q = self.base.sack.query().filter(provides=kernel.name)
         q = q.installed()
         q = q.filter(advisory_type='security')
 
@@ -945,8 +945,8 @@ class Cli(object):
                 ikpkg = pkg
 
         if ikpkg > kernel:
-            print(('Security: %s is an installed security update') % ikpkg)
-            print(('Security: %s is the currently running version') % kernel)
+            print('Security: %s is an installed security update' % ikpkg)
+            print('Security: %s is the currently running version' % kernel)
 
     def _option_conflict(self, option_string_1, option_string_2):
         print(self.optparser.print_usage())

--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -267,6 +267,9 @@ class CheckUpdateCommand(Command):
         if found:
             self.cli.demands.success_exit_status = 100
 
+        if self.base.conf.autocheck_running_kernel:
+            self.cli._check_running_kernel()
+
 
 class RepoPkgsCommand(Command):
     """Implementation of the repository-packages command."""

--- a/dnf/cli/commands/updateinfo.py
+++ b/dnf/cli/commands/updateinfo.py
@@ -222,11 +222,12 @@ class UpdateInfoCommand(commands.Command):
                                                                pkadin[1].severity)
         return collections.Counter(id2type.values())
 
-    @classmethod
-    def display_summary(cls, apkg_adv_insts, mixed, description):
+    def display_summary(self, apkg_adv_instssl, mixed, description):
         """Display the summary of advisories."""
-        typ2cnt = cls._summary(apkg_adv_insts)
+        typ2cnt = self._summary(apkg_adv_insts)
         if not typ2cnt:
+            if self.base.conf.autocheck_running_kernel:
+                self.cli._check_running_kernel()
             return
         print(_('Updates Information Summary: ') + description)
         # Convert types to strings and order the entries.
@@ -253,6 +254,8 @@ class UpdateInfoCommand(commands.Command):
         width = _maxlen(v[1] for v in label2value.values())
         for label, (indent, value) in label2value.items():
             print('    %*s %s' % (width + 4 * indent, value, label))
+        if self.base.conf.autocheck_running_kernel:
+            self.cli._check_running_kernel()
 
     @staticmethod
     def _list(apkg_adv_insts):

--- a/dnf/cli/commands/updateinfo.py
+++ b/dnf/cli/commands/updateinfo.py
@@ -222,7 +222,7 @@ class UpdateInfoCommand(commands.Command):
                                                                pkadin[1].severity)
         return collections.Counter(id2type.values())
 
-    def display_summary(self, apkg_adv_instssl, mixed, description):
+    def display_summary(self, apkg_adv_insts, mixed, description):
         """Display the summary of advisories."""
         typ2cnt = self._summary(apkg_adv_insts)
         if not typ2cnt:

--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -759,6 +759,7 @@ class MainConf(BaseConfig):
         self._add_option('rpmverbosity', Option('info'))
         self._add_option('strict', BoolOption(True)) # :api
         self._add_option('skip_broken', BoolOption(False))  # :yum-compatibility
+        self._add_option('autocheck_running_kernel', BoolOption(True))  # :yum-compatibility
         self._add_option('clean_requirements_on_remove', BoolOption(True))
         self._add_option('history_list_view',
                          SelectionOption('commands',

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -378,6 +378,8 @@ Check Update Command
 
     Please note that having a specific newer version available for an installed package (and reported by ``check-update``) does not imply that subsequent ``dnf upgrade`` will install it. The difference is that ``dnf upgrade`` must also ensure the satisfiability of all dependencies and other restrictions.
 
+    Output is affected by config option :ref:`autocheck_running_kernel <autocheck_running_kernel-label>`
+
 .. _clean_command-label:
 
 -------------
@@ -1174,6 +1176,8 @@ Updateinfo Command
     ``<spec>``, the advisory is not taken into account. The matching is
     case-sensitive and in the case of advisory IDs and package names, globbing
     is supported.
+
+    Output of option ``--summary`` is affected by config option :ref:`autocheck_running_kernel <autocheck_running_kernel-label>`
 
 .. _upgrade_command-label:
 

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -54,6 +54,13 @@ or :ref:`mirrorlist <mirrorlist-label>` option definition.
     If enabled dnf will assume ``Yes`` where it would normally prompt for
     confirmation from user input (see also :ref:`defaultyes <defaultyes-label>`). Default is False.
 
+.. _autocheck_running_kernel-label:
+
+``autocheck_running_kernel``
+    :ref:`boolean <boolean-label>`
+
+    Automatic check whether there is installed newer kernel module with security update than currently running kernel. Default is True.
+
 ``best``
     :ref:`boolean <boolean-label>`
 


### PR DESCRIPTION
It is part of dnf-yum compatibility. This configuration option checks whether there is installed newer kernel with security updates that is not running. Point of this option is to give a hint to sysadmin that maybe they forgot to reboot to the latest kernel. This option changes output of commands 'check-update' and 'updateinfo'.