### PR TITLE
fix typo in supplements (RhBug:1446756)

### DIFF
--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -397,7 +397,7 @@ class RepoQueryCommand(commands.Command):
                 raise dnf.exceptions.Error(
                     _("No switch specified\nusage: dnf repoquery [--whatrequires|"
                         "--requires|--conflicts|--obsoletes|--enhances|--suggest|"
-                        "--provides|--suplements|--recommends] [key] [--tree]\n\n"
+                        "--provides|--supplements|--recommends] [key] [--tree]\n\n"
                         "description:\n  For the given packages print a tree of the packages."))
             self.tree_seed(q, orquery, self.opts)
             return

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -927,7 +927,7 @@ are displayed in the standard NEVRA notation.
 ``--tree``
     Display a recursive tree of packages with capabilities specified by one of the following supplementary options:
     ``--whatrequires``, ``--requires``, ``--conflicts``, ``--enhances``, ``--suggests``, ``--provides``,
-    ``--suplements``, ``--recommends``.
+    ``--supplements``, ``--recommends``.
 
 ``--deplist``
     Produces a list of all dependencies and what packages provide those


### PR DESCRIPTION
Reported-by: Göran Uddeborg <goeran@uddeborg.se>
References: https://bugzilla.redhat.com/show_bug.cgi?id=1446756
Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>