### PR TITLE
Explain how add negative num for --latest-limit (RhBug:1446641)

### DIFF
--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -823,7 +823,8 @@ resulting packages matching the specification. All packages are considered if no
 
 ``--latest-limit <number>``
     Limit the resulting set to <number> of latest packages for every package name and architecture.
-    If <number> is negative skip <number> of latest packages.
+    If <number> is negative skip <number> of latest packages. If negative number is used use syntax
+    ``--latest-limit=<number>``.
 
 ``--recent``
     Limit the resulting set to packages that were recently edited.

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -1009,7 +1009,7 @@ Display duplicated packages::
 
 Remove older versions of duplicated packages (an equivalent of yum's `package-cleanup --cleandups`)::
 
-    dnf remove $(dnf repoquery --duplicates --latest-limit -1 -q)
+    dnf remove --duplicates
 
 
 .. _repository-packages_command-label:


### PR DESCRIPTION
The problem here is in Python argparser that recognize negative number as
option. The patch describe work around how to eliminate the problem.

https://bugzilla.redhat.com/show_bug.cgi?id=1446641