### PR TITLE
Add CLI option --destdir (RhBug:1279001)

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -2,7 +2,7 @@
 %global librepo_version 1.7.19
 %global libcomps_version 0.1.8
 %global rpm_version 4.13.0-0.rc1.29
-%global min_plugins_core 0.1.13
+%global min_plugins_core 2.1.3
 %global dnf_langpacks_ver 0.15.1-6
 
 %global confdir %{_sysconfdir}/%{name}
@@ -24,7 +24,7 @@
 %global _docdir_fmt %{name}
 
 Name:           dnf
-Version:        2.6.0
+Version:        2.6.1
 Release:        1%{?dist}
 Summary:        Package manager forked from Yum, using libsolv as a dependency resolver
 # For a breakdown of the licensing, see PACKAGE-LICENSING

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -64,6 +64,7 @@ import operator
 import re
 import rpm
 import time
+import shutil
 
 logger = logging.getLogger("dnf")
 
@@ -1073,6 +1074,11 @@ class Base(object):
                         "(%d.1%% wasted)")
             percent = 100 - real / full * 100
             logger.info(msg, full / 1024 ** 2, real / 1024 ** 2, percent)
+
+        if self.conf.destdir:
+            dnf.util.ensure_dir(self.conf.destdir)
+            for pload in payloads:
+                shutil.copy2(pload.pkg.repo.pkgdir + "/" + os.path.basename(pload.pkg.location), self.conf.destdir)
 
     def add_remote_rpms(self, path_list, strict=True):
         # :api

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1078,7 +1078,15 @@ class Base(object):
         if self.conf.destdir:
             dnf.util.ensure_dir(self.conf.destdir)
             for pload in payloads:
-                shutil.copy2(pload.pkg.repo.pkgdir + "/" + os.path.basename(pload.pkg.location), self.conf.destdir)
+                payloadlocation = os.path.join(
+                    pload.pkg.repo.pkgdir,
+                    os.path.basename(pload.pkg.location)
+                )
+                shutil.copy(payloadlocation, self.conf.destdir)
+                os.chmod(
+                    os.path.join(self.conf.destdir, os.path.basename(pload.pkg.location)),
+                    0o755
+                )
 
     def add_remote_rpms(self, path_list, strict=True):
         # :api

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -839,8 +839,10 @@ class Cli(object):
             sys.exit(1)
         if opts.destdir is not None:
             self.base.conf.destdir = opts.destdir
-            if not self.base.conf.downloadonly:
-                logger.critical(_('--destdir cannot be used without --downloadonly. Exiting.'))
+            if not self.base.conf.downloadonly and opts.command != 'download':
+                logger.critical(
+                    _('--destdir must be used with --downloadonly or download command.')
+                )
                 sys.exit(1)
 
         if opts.sleeptime is not None:

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -837,6 +837,11 @@ class Cli(object):
             e = '%s: %s' % (ucd(e.args[1]), repr(e.filename))
             logger.critical(_('Config error: %s'), e)
             sys.exit(1)
+        if opts.destdir is not None:
+            self.base.conf.destdir = opts.destdir
+            if not self.base.conf.downloadonly:
+                logger.critical(_('--destdir cannot be used without --downloadonly. Exiting.'))
+                sys.exit(1)
 
         if opts.sleeptime is not None:
             time.sleep(random.randrange(opts.sleeptime * 60))

--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -277,6 +277,8 @@ class OptionParser(argparse.ArgumentParser):
         main_parser.add_argument("-6", dest="ip_resolve", default=None,
                                  help=_("resolve to IPv6 addresses only"),
                                  action="store_const", const='ipv6')
+        main_parser.add_argument("--destdir", dest="destdir", default=None,
+                                 help=_("set directory to copy packages to"))
         main_parser.add_argument("--downloadonly", dest="downloadonly",
                                  action="store_true", default=False,
                                  help=_("only download packages"))

--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -277,7 +277,7 @@ class OptionParser(argparse.ArgumentParser):
         main_parser.add_argument("-6", dest="ip_resolve", default=None,
                                  help=_("resolve to IPv6 addresses only"),
                                  action="store_const", const='ipv6')
-        main_parser.add_argument("--destdir", dest="destdir", default=None,
+        main_parser.add_argument("--destdir", "--downloaddir", dest="destdir", default=None,
                                  help=_("set directory to copy packages to"))
         main_parser.add_argument("--downloadonly", dest="downloadonly",
                                  action="store_true", default=False,

--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -768,7 +768,7 @@ class MainConf(BaseConfig):
                                                  'default': 'commands'}))
         self._add_option('upgrade_group_objects_upgrade',
                          BoolOption(True))  # :api
-
+        self._add_option('destdir', PathOption(None))
         # runtime only options
         self._add_option('downloadonly', BoolOption(False, runtimeonly=True))
 


### PR DESCRIPTION
Solves [bug 1279001](https://bugzilla.redhat.com/show_bug.cgi?id=1279001).

Because we can't define CLI option --destdir twice (once in download plugin, once in dnf), I removed its definition from the download plugin too and made the download plugin use the copying from dnf instead of its own.

This pull request and the [pull request for dnf-plugins-core](https://github.com/rpm-software-management/dnf-plugins-core/pull/220) have to be accepted at the same time, because one doesn't work without the other (breaks download plugin).