### PR TITLE
search: do not generate error if not match anything (RhBug:1342157)

### DIFF
--- a/dnf/cli/commands/search.py
+++ b/dnf/cli/commands/search.py
@@ -113,7 +113,7 @@ class SearchCommand(commands.Command):
             self.base.output.matchcallback(pkg, counter.matched_haystacks(pkg), args)
 
         if len(counter) == 0:
-            raise dnf.exceptions.Error(_('No matches found.'))
+            logger.info(_('No matches found.'))
 
     def _search_counted(self, counter, attr, needle):
         fdict = {'%s__substr' % attr : needle}


### PR DESCRIPTION
Does not print "error" but only "No matches found" and returns 0 value (as "yum" does).