### PR TITLE
Report excludes includes into logger.debug (RhBug:1381988)

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -154,7 +154,22 @@ class BaseCli(dnf.Base):
            errors.  A negative return code indicates that errors
            occurred in the pre-transaction checks
         """
-
+        exclude_include_reports = []
+        if self.conf.excludepkgs:
+            exclude_include_reports.append(
+                'Excludes in dnf.conf: ' + ", ".join(sorted(set(self.conf.excludepkgs))))
+        if self.conf.includepkgs:
+            exclude_include_reports.append(
+                'Includes in dnf.conf: ' + ", ".join(sorted(set(self.conf.includepkgs))))
+        for repo in self.repos.iter_enabled():
+            if repo.excludepkgs:
+                exclude_include_reports.append(
+                    'Excludes in repo ' + repo.id + ": " + ", ".join(sorted(set(repo.excludepkgs))))
+            if repo.includepkgs:
+                exclude_include_reports.append(
+                    'Includes in repo ' + repo.id + ": " + ", ".join(sorted(set(repo.includepkgs))))
+        for exclude_include_report in exclude_include_reports:
+            logger.debug(exclude_include_report)
         grp_diff = self._groups_diff()
         grp_str = self.output.list_group_transaction(self.comps, self._group_persistor, grp_diff)
         if grp_str:

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -154,22 +154,20 @@ class BaseCli(dnf.Base):
            errors.  A negative return code indicates that errors
            occurred in the pre-transaction checks
         """
-        exclude_include_reports = []
+
+        # Reports about excludes and includes (but not from plugins)
         if self.conf.excludepkgs:
-            exclude_include_reports.append(
-                'Excludes in dnf.conf: ' + ", ".join(sorted(set(self.conf.excludepkgs))))
+            logger.debug('Excludes in dnf.conf: ' + ", ".join(sorted(set(self.conf.excludepkgs))))
         if self.conf.includepkgs:
-            exclude_include_reports.append(
-                'Includes in dnf.conf: ' + ", ".join(sorted(set(self.conf.includepkgs))))
+            logger.debug('Includes in dnf.conf: ' + ", ".join(sorted(set(self.conf.includepkgs))))
         for repo in self.repos.iter_enabled():
             if repo.excludepkgs:
-                exclude_include_reports.append(
+                logger.debug(
                     'Excludes in repo ' + repo.id + ": " + ", ".join(sorted(set(repo.excludepkgs))))
             if repo.includepkgs:
-                exclude_include_reports.append(
+                logger.debug(
                     'Includes in repo ' + repo.id + ": " + ", ".join(sorted(set(repo.includepkgs))))
-        for exclude_include_report in exclude_include_reports:
-            logger.debug(exclude_include_report)
+
         grp_diff = self._groups_diff()
         grp_str = self.output.list_group_transaction(self.comps, self._group_persistor, grp_diff)
         if grp_str:


### PR DESCRIPTION
It reports separately this information for each repo and general excludes in
dnf.conf. If excludes or includes are set from commandline they are recognized
as they origin from .repo of .conf source.

https://bugzilla.redhat.com/show_bug.cgi?id=1381988