### PR TITLE
Dnf timers should require systemd network target(RhBug:1247083)

### DIFF
--- a/etc/systemd/dnf-automatic-download.timer
+++ b/etc/systemd/dnf-automatic-download.timer
@@ -9,4 +9,4 @@ OnUnitInactiveSec=1d
 
 [Install]
 WantedBy=basic.target
-WantedBy=network-online.target
+After=network-online.target

--- a/etc/systemd/dnf-automatic-download.timer
+++ b/etc/systemd/dnf-automatic-download.timer
@@ -2,6 +2,8 @@
 Description=dnf-automatic-download timer
 # See comment in dnf-makecache.service
 ConditionPathExists=!/run/ostree-booted
+Wants=network-online.target
+After=network-online.target
 
 [Timer]
 OnBootSec=1h
@@ -9,4 +11,3 @@ OnUnitInactiveSec=1d
 
 [Install]
 WantedBy=basic.target
-After=network-online.target

--- a/etc/systemd/dnf-automatic-download.timer
+++ b/etc/systemd/dnf-automatic-download.timer
@@ -9,3 +9,4 @@ OnUnitInactiveSec=1d
 
 [Install]
 WantedBy=basic.target
+WantedBy=network-online.target

--- a/etc/systemd/dnf-automatic-install.timer
+++ b/etc/systemd/dnf-automatic-install.timer
@@ -9,4 +9,4 @@ OnUnitInactiveSec=1d
 
 [Install]
 WantedBy=basic.target
-WantedBy=network-online.target
+After=network-online.target

--- a/etc/systemd/dnf-automatic-install.timer
+++ b/etc/systemd/dnf-automatic-install.timer
@@ -2,6 +2,8 @@
 Description=dnf-automatic-install timer
 # See comment in dnf-makecache.service
 ConditionPathExists=!/run/ostree-booted
+Wants=network-online.target
+After=network-online.target
 
 [Timer]
 OnBootSec=1h
@@ -9,4 +11,3 @@ OnUnitInactiveSec=1d
 
 [Install]
 WantedBy=basic.target
-After=network-online.target

--- a/etc/systemd/dnf-automatic-install.timer
+++ b/etc/systemd/dnf-automatic-install.timer
@@ -9,3 +9,4 @@ OnUnitInactiveSec=1d
 
 [Install]
 WantedBy=basic.target
+WantedBy=network-online.target

--- a/etc/systemd/dnf-automatic-notifyonly.timer
+++ b/etc/systemd/dnf-automatic-notifyonly.timer
@@ -9,4 +9,4 @@ OnUnitInactiveSec=1d
 
 [Install]
 WantedBy=basic.target
-WantedBy=network-online.target
+After=network-online.target

--- a/etc/systemd/dnf-automatic-notifyonly.timer
+++ b/etc/systemd/dnf-automatic-notifyonly.timer
@@ -2,6 +2,8 @@
 Description=dnf-automatic-notifyonly timer
 # See comment in dnf-makecache.service
 ConditionPathExists=!/run/ostree-booted
+Wants=network-online.target
+After=network-online.target
 
 [Timer]
 OnBootSec=1h
@@ -9,4 +11,3 @@ OnUnitInactiveSec=1d
 
 [Install]
 WantedBy=basic.target
-After=network-online.target

--- a/etc/systemd/dnf-automatic-notifyonly.timer
+++ b/etc/systemd/dnf-automatic-notifyonly.timer
@@ -9,3 +9,4 @@ OnUnitInactiveSec=1d
 
 [Install]
 WantedBy=basic.target
+WantedBy=network-online.target

--- a/etc/systemd/dnf-makecache.timer
+++ b/etc/systemd/dnf-makecache.timer
@@ -3,6 +3,8 @@ Description=dnf makecache timer
 ConditionKernelCommandLine=!rd.live.image
 # See comment in dnf-makecache.service
 ConditionPathExists=!/run/ostree-booted
+Wants=network-online.target
+After=network-online.target
 
 [Timer]
 OnBootSec=10min
@@ -11,4 +13,3 @@ Unit=dnf-makecache.service
 
 [Install]
 WantedBy=basic.target
-After=network-online.target

--- a/etc/systemd/dnf-makecache.timer
+++ b/etc/systemd/dnf-makecache.timer
@@ -11,4 +11,4 @@ Unit=dnf-makecache.service
 
 [Install]
 WantedBy=basic.target
-WantedBy=network-online.target
+After=network-online.target

--- a/etc/systemd/dnf-makecache.timer
+++ b/etc/systemd/dnf-makecache.timer
@@ -11,3 +11,4 @@ Unit=dnf-makecache.service
 
 [Install]
 WantedBy=basic.target
+WantedBy=network-online.target


### PR DESCRIPTION
Dnf timers will run even if there is no running Network manager. 'network-online.target' is a target that actively waits until the nework is "up", where the definition of "up" is defined by the network management software. This means that all timers can still run if there is no internet connection, but there needs to be running network manager.