### PR TITLE
Add pretransaction hook for plugins (RhBug:1173542)

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -717,6 +717,8 @@ class Base(object):
                 for display_ in cb.displays:
                     display_.output = False
 
+            self._plugins.run_pre_transaction()
+
             logger.info(_('Running transaction'))
             self._run_transaction(cb=cb)
         timer()

--- a/dnf/plugin.py
+++ b/dnf/plugin.py
@@ -73,6 +73,10 @@ class Plugin(object):
         # :api
         pass
 
+    def pre_transaction(self):
+        # :api
+        pass
+
     def transaction(self):
         # :api
         pass
@@ -125,6 +129,7 @@ class Plugins(object):
 
     run_sack = _caller('sack')
     run_resolved = _caller('resolved')
+    run_pre_transaction = _caller('pre_transaction')
     run_transaction = _caller('transaction')
 
     def _unload(self):

--- a/doc/api_plugins.rst
+++ b/doc/api_plugins.rst
@@ -55,6 +55,10 @@ When DNF CLI runs it loads the plugins found in the paths during the CLI's initi
 
     Plugin can override this. This hook is called immediately after :attr:`.Base.sack` is initialized with data from all the enabled repos.
 
+  .. method:: pre_transaction
+
+    Plugin can override this. This hook is called just before transaction execution. This means after a successful transaction test. RPMDB is locked during that time.
+
   .. method:: transaction
 
     Plugin can override this. This hook is called immediately after a successful transaction.

--- a/doc/api_vs_yum.rst
+++ b/doc/api_vs_yum.rst
@@ -39,7 +39,7 @@ Hook Number  Yum hook           DNF hook
 ``8``        ``exclude``        ``resolved``
 ``9``        ``preresolve``              
 ``10``       ``postresolve``    ``resolved but no re-resolve``
-``11``       ``pretrans``              
+``11``       ``pretrans``       ``pre_transaction``
 ``12``       ``postrans``       ``transaction``
 ``13``       ``close``          ``transaction``
 ``14``       ``clean``                   


### PR DESCRIPTION
Hook is called just before the transaction run. This means after a successful transaction check and successful transaction test. Rpmdb is locked during that time.

I suppose this will be usable for snapper plugin. Snapper plugin will use "pretransaction" hook instead of "transaction" hook.
@ignatenkobrain It is what you need?