### PR TITLE
Add more repoquery querytags

### DIFF
--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -41,9 +41,10 @@ QFORMAT_DEFAULT = '%{name}-%{epoch}:%{version}-%{release}.%{arch}'
 QFORMAT_MATCH = re.compile(r'%([-\d]*?){([:\.\w]*?)}')
 
 QUERY_TAGS = """
-name, arch, epoch, version, release, reponame (repoid), evr
-installtime, buildtime, size, downloadsize, installsize
-provides, requires, obsoletes, conflicts, sourcerpm
+name, arch, epoch, version, release, reponame (repoid), evr,
+debug_name, source_name, source_debug_name,
+installtime, buildtime, size, downloadsize, installsize,
+provides, requires, obsoletes, conflicts, sourcerpm,
 description, summary, license, url
 """
 


### PR DESCRIPTION
debug_name, source_name, source_debug_name

"source_name" has the same meaning as requested "base_package_name" in Bug 1337459 - RFE: add base_package_name querytag 