### PR TITLE
Fix output for --resolve with --installed for repoquery

### DIFF
--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -238,6 +238,16 @@ class RepoQueryCommand(commands.Command):
         if self.opts.querytags:
             return
 
+        if self.opts.recursive:
+            if self.opts.exactdeps:
+                self.cli._option_conflict("--recursive", "--exactdeps")
+            if not any([self.opts.whatrequires,
+                        (self.opts.packageatr == "requires" and self.opts.resolve)]):
+                raise dnf.exceptions.Error(
+                    _("Option '--recursive' has to be used with '--whatrequires <REQ>' "
+                      "(optionaly with '--alldeps', but not with '--exactdeps'), or with "
+                      "'--requires <REQ> --resolve'"))
+
         if self.opts.srpm:
             self.base.repos.enable_source_repos()
 

--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -446,8 +446,10 @@ class RepoQueryCommand(commands.Command):
 
         if self.opts.resolve:
             # find the providing packages and show them
-            query = self.filter_repo_arch(
-                self.opts, self.base.sack.query().available())
+            if self.opts.list == "installed":
+                query = self.filter_repo_arch(self.opts, self.base.sack.query())
+            else:
+                query = self.filter_repo_arch(self.opts, self.base.sack.query().available())
             providers = query.filter(provides__glob=list(pkgs))
             if self.opts.recursive:
                 providers = providers.union(self._get_recursive_providers_query(query, providers))

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -965,8 +965,8 @@ are displayed in the standard NEVRA notation.
     by running ``dnf repoquery --querytags``.
 
 ``--recursive``
-    Query packages recursively. Can be used with ``--whatrequires <REQ>``
-    (optionaly with --alldeps, but it has no effect with --exactdeps), or with
+    Query packages recursively. Has to be used with ``--whatrequires <REQ>``
+    (optionaly with ``--alldeps``, but not with ``--exactdeps``), or with
     ``--requires <REQ> --resolve``.
 
 ``--resolve``


### PR DESCRIPTION
If someone wants to know what provides dependency of package on system, he/she
will receive correct installed packages and not empty list.
"dnf repoquery --requires iftop --resolve --installed"