### PR TITLE
Revert "Show progress for DRPM (RhBug:1198975)"

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1008,9 +1008,7 @@ class Base(object):
 
             beg_download = time.time()
             est_remote_size = sum(pload.download_size for pload in payloads)
-            total_drpm = len(
-                [payload for payload in payloads if isinstance(payload, dnf.drpm.DeltaPayload)])
-            progress.start(len(payloads), est_remote_size, total_drpms=total_drpm)
+            progress.start(len(payloads), est_remote_size)
             errors = dnf.repo._download_payloads(payloads, drpm)
 
             if errors._irrecoverable:

--- a/dnf/callback.py
+++ b/dnf/callback.py
@@ -88,7 +88,7 @@ class DownloadProgress(object):
 
         pass
 
-    def start(self, total_files, total_size, total_drpms=0):
+    def start(self, total_files, total_size):
         """Start new progress metering. :api
 
         `total_files` the number of files that will be downloaded,

--- a/dnf/cli/progress.py
+++ b/dnf/cli/progress.py
@@ -51,11 +51,9 @@ class MultiFileProgressMeter(dnf.callback.DownloadProgress):
     def message(self, msg):
         dnf.util._terminal_messenger('write_flush', msg, self.fo)
 
-    def start(self, total_files, total_size, total_drpms=0):
+    def start(self, total_files, total_size):
         self.total_files = total_files
         self.total_size = total_size
-        self.total_drpm = total_drpms
-        self.done_drpm = 0
 
         # download state
         self.done_files = 0
@@ -147,10 +145,8 @@ class MultiFileProgressMeter(dnf.callback.DownloadProgress):
         size = int(payload.download_size)
 
         # update state
-        if status == dnf.callback.STATUS_MIRROR:
+        if status in (dnf.callback.STATUS_MIRROR, dnf.callback.STATUS_DRPM):
             pass
-        elif status == dnf.callback.STATUS_DRPM:
-            self.done_drpm += 1
         elif text in self.state:
             start, done = self.state.pop(text)
             self.active.remove(text)
@@ -163,11 +159,7 @@ class MultiFileProgressMeter(dnf.callback.DownloadProgress):
 
         if status:
             # the error message, no trimming
-            if status is dnf.callback.STATUS_DRPM and self.total_drpm > 1:
-                msg = '[%s %d/%d] %s: ' % (self.STATUS_2_STR[status], self.done_drpm,
-                                           self.total_drpm, text)
-            else:
-                msg = '[%s] %s: ' % (self.STATUS_2_STR[status], text)
+            msg = '[%s] %s: ' % (self.STATUS_2_STR[status], text)
             left = _term_width() - len(msg) - 1
             msg = '%s%-*s\n' % (msg, left, err_msg)
         else:

--- a/doc/api_callback.rst
+++ b/doc/api_callback.rst
@@ -58,11 +58,9 @@
 
     Report ongoing progress on the given `payload`. `done` is the number of bytes already downloaded from `payload`.
 
-  .. method:: start(total_files, total_size, total_drpms=0)
+  .. method:: start(total_files, total_size)
 
-    Report start of a download batch. `total_files` is the total number of payloads in the batch.
-    `total_size` is the total number of bytes to be downloaded. `total_drpms` is the total number
-    of drpms payloads in the batch.
+    Report start of a download batch. `total_files` is the total number of payloads in the batch. `total_size` is the total number of bytes to be downloaded.
 
 .. class:: TransactionProgress
 


### PR DESCRIPTION
It breaks api, because callbacks get an extra argument. Either we should
find a way to check what function expects and print warning or find a way
to not change API at all (I prefer latter).

This reverts commit 9288d90d7fa6d0c168ec020e6a32d01185504220.

References: https://bugzilla.redhat.com/show_bug.cgi?id=1454854