### PR TITLE
Remove alwaysprompt option support (RhBug:1400714)

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -526,20 +526,7 @@ class BaseCli(dnf.Base):
         # shortcut for the always-off/always-on options
         if self.conf.assumeyes and not self.conf.assumeno:
             return False
-        if self.conf.alwaysprompt:
-            return True
-
-        # prompt if:
-        #  package was added to fill a dependency
-        #  package is being removed
-        #  package wasn't explicitly given on the command line
-        for txmbr in self.tsInfo.getMembers():
-            if txmbr.isDep or \
-                   txmbr.name not in self.extcmds:
-                return True
-
-        # otherwise, don't prompt
-        return False
+        return True
 
     def _history_get_transactions(self, extcmds):
         if not extcmds:

--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -689,7 +689,6 @@ class MainConf(BaseConfig):
         self._add_option('assumeno', BoolOption(False))
         self._add_option('check_config_file_age', BoolOption(True))
         self._add_option('defaultyes', BoolOption(False))
-        self._add_option('alwaysprompt', BoolOption(True))
         self._add_option('diskspacecheck', BoolOption(True))
         self._add_option('gpgcheck', BoolOption(False))
         self._add_option('repo_gpgcheck', BoolOption(False))

--- a/dnf/yum/config.py
+++ b/dnf/yum/config.py
@@ -29,7 +29,7 @@ class YumConf(MainConf):
         super(YumConf, self).__init__()
 
         self._add_inherited_option(super(YumConf, self), [
-            'alwaysprompt', 'assumeno', 'assumeyes', 'bandwidth',
+            'assumeno', 'assumeyes', 'bandwidth',
             'bugtracker_url', 'cachedir', 'color',
             'color_list_available_downgrade',
             'color_list_available_install', 'color_list_available_reinstall',

--- a/doc/cli_vs_yum.rst
+++ b/doc/cli_vs_yum.rst
@@ -167,6 +167,12 @@ The relevant repository configuration files have been fixed to respect this, see
 the related `Fedora bug 948788
 <https://bugzilla.redhat.com/show_bug.cgi?id=948788>`_.
 
+=================================
+ ``alwaysprompt`` dropped
+=================================
+
+Unsupported to simplify the configuration.
+
 .. _group_package_types_dropped:
 
 =================================


### PR DESCRIPTION
This option wasn't properly implemented. In fact "alwaysprompt=no" caused crash. 