### PR TITLE
Enable download progress bar if redirected output (RhBug:1161950)

### DIFF
--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -1237,7 +1237,7 @@ Transaction Summary
            output bars based on debug level.
         """
         progressbar = None
-        if self.conf.debuglevel >= 2 and sys.stdout.isatty():
+        if self.conf.debuglevel >= 2:
             progressbar = dnf.cli.progress.MultiFileProgressMeter(fo=sys.stdout)
             self.progress = dnf.cli.progress.MultiFileProgressMeter(fo=sys.stdout)
 

--- a/dnf/cli/progress.py
+++ b/dnf/cli/progress.py
@@ -48,6 +48,7 @@ class MultiFileProgressMeter(dnf.callback.DownloadProgress):
         self.rate_average = rate_average
         self.unknown_progres = 0
         self.total_drpm = 0
+        self.isatty = sys.stdout.isatty()
 
     def message(self, msg):
         dnf.util._terminal_messenger('write_flush', msg, self.fo)
@@ -102,7 +103,8 @@ class MultiFileProgressMeter(dnf.callback.DownloadProgress):
                 self.rate = rate
         self.last_time = now
         self.last_size = self.done_size
-
+        if not self.isatty:
+            return
         # pick one of the active downloads
         text = self.active[int(now/self.tick_period) % len(self.active)]
         if self.total_files > 1:

--- a/tests/test_cli_progress.py
+++ b/tests/test_cli_progress.py
@@ -54,13 +54,13 @@ class ProgressTest(tests.support.TestCase):
              mock.patch('dnf.cli.progress.time', lambda: now):
 
             p = dnf.cli.progress.MultiFileProgressMeter(fo)
+            p.isatty = True
             pload = FakePayload('dummy-text', 5)
             p.start(1, 1)
             for i in range(6):
                 now += 1.0
                 p.progress(pload, i)
             p.end(pload, None, None)
-
         self.assertEqual(fo.lines(), [
             'dummy-text  0% [          ] ---  B/s |   0  B     --:-- ETA\r',
             'dummy-text 20% [==        ] 1.0  B/s |   1  B     00:04 ETA\r',
@@ -73,6 +73,7 @@ class ProgressTest(tests.support.TestCase):
     def test_mirror(self):
         fo = MockStdout()
         p = dnf.cli.progress.MultiFileProgressMeter(fo, update_period=-1)
+        p.isatty = True
         p.start(1, 5)
         pload = FakePayload('foo', 5.0)
         now = 1379406823.9
@@ -107,6 +108,7 @@ class ProgressTest(tests.support.TestCase):
              mock.patch('dnf.cli.progress.time', lambda: now):
 
             p = dnf.cli.progress.MultiFileProgressMeter(fo)
+            p.isatty = True
             p.start(2, 30)
             pload1 = FakePayload('foo', 10.0)
             pload2 = FakePayload('bar', 20.0)


### PR DESCRIPTION
It solves the problem from Comment 2 when there is no output for download in
case of output redirection into file.

https://bugzilla.redhat.com/show_bug.cgi?id=1161950

Requires: https://github.com/rpm-software-management/ci-dnf-stack/pull/298