### PR TITLE
Provide API for substitution of repo attribute (RhBug:1457507)

### DIFF
--- a/doc/api_repos.rst
+++ b/doc/api_repos.rst
@@ -59,7 +59,9 @@ Repository Configuration
     Initialize new :class:`.Repo` object and add it to the repodict. It requires ``repoid``
     (string), and :class:`dnf.conf.Conf` object. Optionally it can be speciffied baseurl (list), and
     additionally key/value pairs from `kwargs` to set additional attribute of the :class:`.Repo`
-    object. It returns the :class:`.Repo` object.
+    object. Variables in provided values (``baseurl`` or ``kwargs``) will be automatically
+    substituted using conf.substitutions (like ``$releasever``, ...). It returns the :class:`.Repo`
+    object.
 
 .. module:: dnf.repo
 


### PR DESCRIPTION
Also it fix problem with substitution of path from --repofrompath.

https://bugzilla.redhat.com/show_bug.cgi?id=1457507