### PR TITLE
cleanup code not executed in case of exception

### DIFF
--- a/dnf/crypto.py
+++ b/dnf/crypto.py
@@ -91,11 +91,13 @@ def log_key_import(keyinfo):
 def pubring_dir(pubring_dir):
     orig = os.environ.get(GPG_HOME_ENV, None)
     os.environ[GPG_HOME_ENV] = pubring_dir
-    yield
-    if orig is None:
-        del os.environ[GPG_HOME_ENV]
-    else:
-        os.environ[GPG_HOME_ENV] = orig
+    try:
+        yield
+    finally:
+        if orig is None:
+            del os.environ[GPG_HOME_ENV]
+        else:
+            os.environ[GPG_HOME_ENV] = orig
 
 
 def rawkey2infos(key_fo):


### PR DESCRIPTION
when there is exeption raised in with block - for example:

with dnf.crypto.pubring_dir(self._pubring_dir):
    x = 1/0
    return self._handle_load_core(handle)

the clean-up code is not executed and environment is left
in changed state.