### PR TITLE
Provide pkg name hint for icase (RhBug:1339280) (RhBug:1138978)

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -358,6 +358,7 @@ class BaseCli(dnf.Base):
             except dnf.exceptions.PackageNotFoundError as err:
                 msg = _('No package %s available.')
                 logger.info(msg, self.output.term.bold(arg))
+                self._report_icase_hint(arg)
             except dnf.exceptions.PackagesNotInstalledError as err:
                 logger.info(_('Packages for argument %s available, but not installed.'),
                             self.output.term.bold(err.pkg_spec))
@@ -366,6 +367,13 @@ class BaseCli(dnf.Base):
         cnt = self._goal.req_length() - oldcount
         if cnt <= 0:
             raise dnf.exceptions.Error(_('Nothing to do.'))
+
+    def _report_icase_hint(self, pkg_spec):
+        subj = dnf.subject.Subject(pkg_spec, ignore_case=True)
+        q = subj.get_best_query(self.sack, with_nevra=True, with_provides=False,
+                                with_filenames=False)
+        if q:
+            logger.info(_("  * Maybe you meant: {}").format(q[0].name))
 
     def output_packages(self, basecmd, pkgnarrow='all', patterns=(), reponame=None):
         """Output selection *pkgnarrow* of packages matching *patterns* and *repoid*."""

--- a/dnf/cli/commands/install.py
+++ b/dnf/cli/commands/install.py
@@ -121,6 +121,7 @@ class InstallCommand(commands.Command):
                 except dnf.exceptions.MarkingError:
                     msg = _('No package %s available.')
                     logger.info(msg, self.base.output.term.bold(pkg_spec))
+                    self.base._report_icase_hint(pkg_spec)
                     errs.append(pkg_spec)
 
         if (len(errs) != 0 or len(err_pkgs) != 0) and self.base.conf.strict:

--- a/dnf/cli/commands/upgrade.py
+++ b/dnf/cli/commands/upgrade.py
@@ -83,6 +83,7 @@ class UpgradeCommand(commands.Command):
                 except dnf.exceptions.MarkingError as e:
                     logger.info(_('No match for argument: %s'),
                                  self.base.output.term.bold(pkg_spec))
+                    self.base._report_icase_hint(pkg_spec)
                 else:
                     done = True
 


### PR DESCRIPTION
It will be user friendly to see hint for pkg name if no package available but
in case insensitive mode, some packages available.

https://bugzilla.redhat.com/show_bug.cgi?id=1339280

https://bugzilla.redhat.com/show_bug.cgi?id=1138978