### PR TITLE
Enable import gpg_keys with tsflag test

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -2153,7 +2153,10 @@ class Base(object):
                     continue
 
                 # Import the key
-                result = self._ts.pgpImportPubkey(misc.procgpgkey(info.raw_key))
+                # If rpm.RPMTRANS_FLAG_TEST in self._ts, gpg keys cannot be imported successfully
+                # therefore the new instance of dnf.rpm.transaction.TransactionWrapper is used'
+                ts_import_instance = dnf.rpm.transaction.TransactionWrapper(self.conf.installroot)
+                result = ts_import_instance.pgpImportPubkey(misc.procgpgkey(info.raw_key))
                 if result != 0:
                     msg = _('Key import failed (code %d)') % result
                     raise dnf.exceptions.Error(_prov_key_data(msg))

--- a/doc/api_conf.rst
+++ b/doc/api_conf.rst
@@ -220,6 +220,9 @@ Configurable settings of the :class:`dnf.Base` object are stored into a :class:`
     ==========              ===========================
 
     The ``"nocrypto"`` option will also set the ``_RPMVSF_NOSIGNATURES`` and ``_RPMVSF_NODIGESTS`` VS flags.
+    The ``test`` option provides a transaction check without performing the transaction. It includes
+    download of packages, gpg keys check (including permanent import of additional keys if
+    necessary), and rpm check to prevent file conflicts.
 
   .. attribute:: username
 


### PR DESCRIPTION
This behavior is problematic for "dnf system-upgrade download", where tsflag
"test" is used. There is only one but not nice and fragile work around
"--nogpgcheck".