### PR TITLE
Not reinstall packages if install from repository-pkgs used

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1639,19 +1639,15 @@ class Base(object):
         elif self.conf.multilib_policy == "best":
             sltrs = subj._get_best_selectors(self.sack,
                                              forms=forms,
-                                             obsoletes=self.conf.obsoletes)
+                                             obsoletes=self.conf.obsoletes,
+                                             reponame=reponame,
+                                             reports=True)
             if not any((s.matches() for s in sltrs)):
                 raise dnf.exceptions.MarkingError(
                     _('no package matched'), pkg_spec)
             for sltr in sltrs:
                 if not sltr.matches():
                     continue
-                if reponame is not None:
-                    sltr = sltr.set(reponame=reponame)
-                already_inst = self._sltr_matches_installed(sltr)
-                if already_inst:
-                    for package in already_inst:
-                        _msg_installed(package)
                 self._goal.install(select=sltr, optional=(not strict))
             return 1
         return 0

--- a/dnf/subject.py
+++ b/dnf/subject.py
@@ -95,11 +95,8 @@ class Subject(object):
         @param forms:
         @return: dict with keys nevra and query
         """
-        kwargs = {}
         solution = {'nevra': None, 'query': sack.query().filter(empty=True)}
         if with_nevra:
-            if forms:
-                kwargs['form'] = forms
             for nevra in self.get_nevra_possibilities(forms=forms):
                 if nevra:
                     q = self._nevra_to_filters(sack.query(), nevra)
@@ -134,9 +131,6 @@ class Subject(object):
     def get_best_selector(self, sack, forms=None, obsoletes=True, reponame=None, reports=False):
         # :api
 
-        kwargs = {}
-        if forms:
-            kwargs['form'] = forms
         sltr = dnf.selector.Selector(sack)
         solution = self._get_nevra_solution(sack, forms=forms)
         if solution['query']:

--- a/doc/api_queries.rst
+++ b/doc/api_queries.rst
@@ -140,9 +140,14 @@
     searched for a match. `forms` is a list of pattern forms from `hawkey`_. Leaving the parameter
     to ``None`` results in using a reasonable default list of forms.
 
-  .. method:: get_best_selector(sack, forms=None)
+  .. method:: get_best_selector(sack, forms=None, obsoletes=True, reponame=None, reports=False)
 
-    Return a :class:`~dnf.selector.Selector` that will select a single best-matching package when used in a transaction operation. `sack` and `forms` have the same meaning as in :meth:`get_best_query`.
+    Return a :class:`~dnf.selector.Selector` that will select a single best-matching package when
+    used in a transaction operation. `sack` and `forms` have the same meaning as in
+    :meth:`get_best_query`. If ``obsoletes``, selector will also contain packages that obsoletes
+    requested packages (default is True). If ``reponame``, the selection of available packages is
+    limited to packages from that repo (default is False). If ``reports``, it will report if
+    packages where already installed (default is False).
 
   .. method:: get_nevra_possibilities(self, forms=None)
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -481,9 +481,9 @@ class RepoPkgsInstallSubCommandTest(support.ResultTestCase):
         support.command_run(cmd, ['third_party', 'install'])
 
         self.assertResult(self.cli.base, itertools.chain(
-            self.cli.base.sack.query().installed().filter(name__neq='hole'),
+            self.cli.base.sack.query().installed(),
             self.cli.base.sack.query().available().filter(reponame='third_party',
-                                                          arch='x86_64')))
+                                                          arch='x86_64', name__neq='hole')))
 
 class RepoPkgsMoveToSubCommandTest(support.ResultTestCase):
 

--- a/tests/test_subject.py
+++ b/tests/test_subject.py
@@ -49,8 +49,6 @@ class SubjectTest(support.TestCase):
     def test_best_selectors_ver(self):
         subj = dnf.subject.Subject('*-1-1')
         sltrs = subj._get_best_selectors(self.base.sack)
-        q = self.base.sack.query().filter(evr__eq='1-1')
-        self.assertEqual(len(sltrs), len(set(map(lambda p: p.name, q))))
         for sltr in sltrs:
             for pkg in sltr.matches():
                 self.assertEqual(pkg.evr, '1-1')


### PR DESCRIPTION
For commands like repository-pkgs it happen that in case that package with same
NEVRA and even from same repository is installed, the package is always
reinstalled.

This behavior is the same like with distrosync command.