### PR TITLE
Fix UnicodeDecodeError during checkSig() on non UTF-8 locale (RhBug:1397848)

### DIFF
--- a/dnf/rpm/miscutils.py
+++ b/dnf/rpm/miscutils.py
@@ -47,9 +47,12 @@ def checkSig(ts, package):
         # checks signature from an hdr
         string = '%|DSAHEADER?{%{DSAHEADER:pgpsig}}:{%|RSAHEADER?{%{RSAHEADER:pgpsig}}:' \
                  '{%|SIGGPG?{%{SIGGPG:pgpsig}}:{%|SIGPGP?{%{SIGPGP:pgpsig}}:{(none)}|}|}|}|'
-        siginfo = hdr.sprintf(string)
-        if siginfo == '(none)':
-            value = 4
+        try:
+            siginfo = hdr.sprintf(string)
+            if siginfo == '(none)':
+                value = 4
+        except UnicodeDecodeError:
+            pass
 
         del hdr
 


### PR DESCRIPTION
Workaround for non UTF-8 locales.