### PR TITLE
spec: do not strongly require inhibit plugin

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -46,9 +46,13 @@ Requires:       python3-%{name} = %{version}-%{release}
 %else
 Requires:       python2-%{name} = %{version}-%{release}
 %endif
-# TODO: use rich deps once it is allowed in Fedora
+%if 0%{?rhel} && %{?rhel} <= 7
+Requires:       python-dbus
+%else
+# TODO: use rich deps once it is allowed
 #Recommends:     (python%{?with_python3:3}-dbus if NetworkManager)
 Recommends:     python%{?with_python3:3}-dbus
+%endif
 Requires(post):     systemd
 Requires(preun):    systemd
 Requires(postun):   systemd

--- a/dnf.spec
+++ b/dnf.spec
@@ -122,7 +122,11 @@ Requires:       python2-hawkey >= %{hawkey_version}
 Requires:       python-iniparse
 Requires:       python-libcomps >= %{libcomps_version}
 Requires:       python-librepo >= %{librepo_version}
+%if 0%{?rhel} && %{?rhel} <= 7
 Requires:       rpm-plugin-systemd-inhibit
+%else
+Recommends:     rpm-plugin-systemd-inhibit
+%endif
 Requires:       rpm-python >= %{rpm_version}
 # dnf-langpacks package is retired in F25
 # to have clean upgrade path for dnf-langpacks
@@ -151,7 +155,11 @@ Requires:       python3-hawkey >= %{hawkey_version}
 Requires:       python3-iniparse
 Requires:       python3-libcomps >= %{libcomps_version}
 Requires:       python3-librepo >= %{librepo_version}
+%if 0%{?rhel} && %{?rhel} <= 7
 Requires:       rpm-plugin-systemd-inhibit
+%else
+Recommends:     rpm-plugin-systemd-inhibit
+%endif
 Requires:       rpm-python3 >= %{rpm_version}
 # dnf-langpacks package is retired in F25
 # to have clean upgrade path for dnf-langpacks


### PR DESCRIPTION
We don't really depend on it, just useful in workstation/server cases,
but completely useless in containers.

Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>