### PR TITLE
Add eol command and alerting if system reached EOL (RhBug:1402668)

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -338,6 +338,20 @@ class Base(object):
         timer()
         self._goal = dnf.goal.Goal(self._sack)
         self._plugins.run_sack()
+
+        # if metadata have just been updated
+        if datetime.timedelta(seconds=int(age)).total_seconds() < 1:
+            logger.debug("Fetching EOL status from the pkgdb API")
+            fetchEolFromApi = True
+        else:
+            fetchEolFromApi = False
+        try:
+            if dnf.util.getEolStatus(self.conf.eol_url, fetchEolFromApi):
+                logger.info(_("\033[1mThis version of your system has reached its End of Life! " +
+                            "You are not receiving any new updates.\033[0m"))
+        except Exception:
+            logger.error(_("Unable to get End of Life status of your system."))
+
         return self._sack
 
     @property

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -50,6 +50,7 @@ import dnf.cli.commands.swap
 import dnf.cli.commands.updateinfo
 import dnf.cli.commands.upgrade
 import dnf.cli.commands.upgrademinimal
+import dnf.cli.commands.eol
 import dnf.cli.demand
 import dnf.cli.option_parser
 import dnf.conf
@@ -675,6 +676,7 @@ class Cli(object):
         self.register_command(dnf.cli.commands.RepoPkgsCommand)
         self.register_command(dnf.cli.commands.HelpCommand)
         self.register_command(dnf.cli.commands.HistoryCommand)
+        self.register_command(dnf.cli.commands.eol.EolCommand)
 
     def _configure_repos(self, opts):
         self.base.read_all_repos(opts)

--- a/dnf/cli/commands/eol.py
+++ b/dnf/cli/commands/eol.py
@@ -1,0 +1,40 @@
+# eol.py
+# EOL CLI command.
+#
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+from dnf.cli import commands
+from dnf.i18n import _
+import dnf.util
+
+import logging
+
+logger = logging.getLogger('dnf')
+
+
+class EolCommand(commands.Command):
+
+    aliases = ('eol',)
+    summary = _('get the lifecycle stage of your system')
+
+    def __init__(self, cli):
+        commands.Command.__init__(self, cli)
+
+    def run(self):
+        logger.info(_("Lifecycle stage of your system: %s"),
+                    dnf.util.getEolStatus(self.base.conf.eol_url, True, True))

--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -720,7 +720,8 @@ class MainConf(BaseConfig):
         self._add_option('best', BoolOption(False)) # :api
         self._add_option('install_weak_deps', BoolOption(True))
         self._add_option('bugtracker_url', Option(dnf.const.BUGTRACKER))
-
+        self._add_option('eol_url', 
+                         UrlOption('https://admin.fedoraproject.org/pkgdb/api/collections/'))
         self._add_option('color',
                          SelectionOption('auto',
                                          choices=('auto', 'never', 'always'),


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1402668

From now on, distributions will need to set the pkgdb API URL for dnf. This can be done in main section of /etc/dnf/dnf.conf like this: `eol_url=https://admin.fedoraproject.org/pkgdb/api/collections/`. VERSION_ID in /etc/os-release must also correspond to the version in the pkgdb API.