### PR TITLE
Fix the loading of config for dnf-automatic command_email (RhBug:1470116)

### DIFF
--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -108,6 +108,8 @@ class AutomaticConfig(object):
         self.commands._populate(parser, 'commands', filename, dnf.conf.PRIO_AUTOMATICCONFIG)
         self.email._populate(parser, 'email', filename, dnf.conf.PRIO_AUTOMATICCONFIG)
         self.emitters._populate(parser, 'emitters', filename, dnf.conf.PRIO_AUTOMATICCONFIG)
+        self.command_email._populate(parser, 'command_email', filename,
+                                     dnf.conf.PRIO_AUTOMATICCONFIG)
         self._parser = parser
 
     def update_baseconf(self, baseconf):

--- a/etc/dnf/automatic.conf
+++ b/etc/dnf/automatic.conf
@@ -59,7 +59,7 @@ email_host = localhost
 # stdin_format = "{body}"
 
 
-[email_command]
+[command_email]
 # The shell command to use to send email. This is a Python format string,
 # as used in str.format(). The format function will pass shell-quoted arguments
 # called body, subject, email_from, email_to.


### PR DESCRIPTION
dnf-automatic doesn't load configuration for "command_email".