### PR TITLE
Enable cross-architecture installs using qemu

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -79,6 +79,7 @@ DNF CONTRIBUTORS
     Michael Dunphy <mdunphy@uwaterloo.ca>
     Michael Scherer <misc@redhat.com>
     Neal Gompa <ngompa13@gmail.com>
+    Nathaniel McCallum <npmccallum@redhat.com>
     Olivier Andrieu <olivier.andrieu@esterel-technologies.com>
     Padraig Brady <P@draigBrady.com>
     Pavel Grunt <pgrunt@redhat.com>

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -450,6 +450,9 @@ class Base(object):
         if not self.conf.diskspacecheck:
             self._rpm_probfilter.add(rpm.RPMPROB_FILTER_DISKSPACE)
 
+        if self.conf.ignorearch:
+            self._rpm_probfilter.add(rpm.RPMPROB_FILTER_IGNOREARCH)
+
         probfilter = reduce(operator.or_, self._rpm_probfilter, 0)
         self._priv_ts.setProbFilter(probfilter)
         return self._priv_ts

--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -23,6 +23,7 @@ from dnf.i18n import _
 
 import argparse
 import dnf.exceptions
+import dnf.rpm
 import dnf.yum.misc
 import logging
 import os.path
@@ -149,6 +150,11 @@ class OptionParser(argparse.ArgumentParser):
                 narrow = values.pop(0)
             setattr(namespace, dest_action, narrow)
             setattr(namespace, self.dest, values)
+
+    class ForceArchAction(argparse.Action):
+        def __call__(self, parser, namespace, values, opt_str):
+            namespace.ignorearch = True
+            namespace.arch = values
 
     def _main_parser(self):
         """ Standard options known to all dnf subcommands. """
@@ -308,6 +314,11 @@ class OptionParser(argparse.ArgumentParser):
             dest="severity", action="append", help=_(
                 "Include security relevant packages matching the severity, "
                 "in updates"))
+        main_parser.add_argument("--forcearch", metavar="ARCH",
+                                 dest=argparse.SUPPRESS,
+                                 action=self.ForceArchAction,
+                                 choices=sorted(dnf.rpm._BASEARCH_MAP.keys()),
+                                 help=_("Force the use of an architecture"))
         return main_parser
 
     def _command_parser(self, command):

--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -32,6 +32,7 @@ import dnf.const
 import dnf.exceptions
 import dnf.pycomp
 import dnf.util
+import hawkey
 import iniparse
 import logging
 import os
@@ -620,6 +621,8 @@ class MainConf(BaseConfig):
         # pylint: disable=R0915
         super(MainConf, self).__init__(section, parser)
         self.substitutions = dnf.conf.substitutions.Substitutions()
+        self.arch = hawkey.detect_arch()
+
         # setup different cache and log for non-priviledged users
         if dnf.util.am_i_root():
             cachedir = dnf.const.SYSTEM_CACHEDIR
@@ -821,13 +824,13 @@ class MainConf(BaseConfig):
 
     def _configure_from_options(self, opts):
         """Configure parts of CLI from the opts """
-
         config_args = ['plugins', 'version', 'config_file_path',
                        'debuglevel', 'errorlevel', 'installroot',
                        'best', 'assumeyes', 'assumeno', 'gpgcheck',
                        'showdupesfromrepos', 'plugins', 'ip_resolve',
-                       'rpmverbosity', 'disable_excludes',
-                       'color', 'downloadonly', 'exclude', 'excludepkgs', "skip_broken", 'tsflags']
+                       'rpmverbosity', 'disable_excludes', 'color',
+                       'downloadonly', 'exclude', 'excludepkgs', 'skip_broken',
+                       'tsflags', 'arch', 'basearch']
 
         for name in config_args:
             value = getattr(opts, name, None)
@@ -835,6 +838,8 @@ class MainConf(BaseConfig):
                 confopt = self._get_option(name)
                 if confopt:
                     confopt._set(value, dnf.conf.PRIO_COMMANDLINE)
+                elif hasattr(self, name):
+                    setattr(self, name, value)
                 else:
                     logger.warning(_('Unknown configuration option: %s = %s'),
                                    ucd(name), ucd(value))
@@ -846,6 +851,8 @@ class MainConf(BaseConfig):
                 opt = self._get_option(name)
                 if opt:
                     opt._set(val, dnf.conf.PRIO_COMMANDLINE)
+                elif hasattr(self, name):
+                    setattr(self, name, val)
                 else:
                     msg = "Main config did not have a %s attr. before setopt"
                     logger.warning(msg, name)
@@ -884,6 +891,38 @@ class MainConf(BaseConfig):
             return
         self.substitutions['releasever'] = val
 
+    @property
+    def arch(self):
+        # :api
+        return self.substitutions.get('arch')
+
+    @arch.setter
+    def arch(self, val):
+        # :api
+
+        if val is None:
+            self.substitutions.pop('arch', None)
+            return
+
+        assert(val in dnf.rpm._BASEARCH_MAP.keys())
+        self.substitutions['arch'] = val
+        self.basearch = dnf.rpm.basearch(val)
+
+    @property
+    def basearch(self):
+        # :api
+        return self.substitutions.get('basearch')
+
+    @basearch.setter
+    def basearch(self, val):
+        # :api
+
+        if val is None:
+            self.substitutions.pop('basearch', None)
+            return
+
+        assert(val in dnf.rpm._BASEARCH_MAP.values())
+        self.substitutions['basearch'] = val
 
     def read(self, filename=None, priority=PRIO_DEFAULT):
         # :api

--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -774,6 +774,7 @@ class MainConf(BaseConfig):
 
         # runtime only options
         self._add_option('downloadonly', BoolOption(False, runtimeonly=True))
+        self._add_option('ignorearch', BoolOption(False))
 
     @property
     def get_reposdir(self):
@@ -830,7 +831,7 @@ class MainConf(BaseConfig):
                        'showdupesfromrepos', 'plugins', 'ip_resolve',
                        'rpmverbosity', 'disable_excludes', 'color',
                        'downloadonly', 'exclude', 'excludepkgs', 'skip_broken',
-                       'tsflags', 'arch', 'basearch']
+                       'tsflags', 'arch', 'basearch', 'ignorearch']
 
         for name in config_args:
             value = getattr(opts, name, None)

--- a/dnf/conf/substitutions.py
+++ b/dnf/conf/substitutions.py
@@ -20,7 +20,6 @@
 
 import dnf
 import dnf.exceptions
-import hawkey
 import os
 
 
@@ -28,9 +27,6 @@ class Substitutions(dict):
 
     def __init__(self):
         super(Substitutions, self).__init__()
-        arch = hawkey.detect_arch()
-        self['arch'] = arch
-        self['basearch'] = dnf.rpm.basearch(arch)
         self._update_from_env()
 
     def _update_from_env(self):

--- a/doc/api_conf.rst
+++ b/doc/api_conf.rst
@@ -241,6 +241,10 @@ Configurable settings of the :class:`dnf.Base` object are stored into a :class:`
 
     The architecture used for installing packages. By default this is auto-detected.
 
+  .. attribute:: ignorearch
+
+    If set to ``True``, RPM will allow attempts to install packages incompatible with the CPU's architecture. Defaults to ``False``.
+
   .. method:: prepend_installroot(option)
 
     Prefix config option named `option` with :attr:`installroot`.

--- a/doc/api_conf.rst
+++ b/doc/api_conf.rst
@@ -233,6 +233,14 @@ Configurable settings of the :class:`dnf.Base` object are stored into a :class:`
 
     The password to use for connecting to repo with basic HTTP authentication. Defaults to ``None``.
 
+  .. attribute:: basearch
+
+    The base architecture used for installing packages. By default this is auto-detected.
+
+  .. attribute:: arch
+
+    The architecture used for installing packages. By default this is auto-detected.
+
   .. method:: prepend_installroot(option)
 
     Prefix config option named `option` with :attr:`installroot`.

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -313,6 +313,11 @@ Options
 ``-y, --assumeyes``
     Automatically answer yes for all questions
 
+``--forcearch=<arch>``
+    Force the use of an architecture. Any architecture can be specified.
+    However, use of an architecture not supported natively by your CPU will
+    require emulation of some kind. This is usually through QEMU.
+
 List options are comma-separated. Command-line options override respective settings from configuration files.
 
 ========


### PR DESCRIPTION
These patches make it possible to use dnf within a series of commands to create a cross-architecture root. Basically, you install qemu-user-static into the root first, using the host architecture. Then you install the target packages you want using --setopt=arch=$ARCH. If you have set up this process properly, all scriptlets will be run using the emulator. This makes it possible to construct cross-architecture chroots and containers using dnf.