### PR TITLE
Add dnf option --noclean (RhBug:1361424)

### DIFF
--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -262,6 +262,9 @@ class OptionParser(argparse.ArgumentParser):
                                  metavar='[repo,path]',
                                  help=_("label and path to additional repository,"
                                         " can be specified multiple times."))
+        main_parser.add_argument("--noautoremove", action="store_false",
+                                 default=None, dest='clean_requirements_on_remove',
+                                 help=_("disable removal of dependencies that are no longer used"))
         main_parser.add_argument("--nogpgcheck", action="store_false",
                                  default=None, dest='gpgcheck',
                                  help=_("disable gpg signature checking"))

--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -824,7 +824,7 @@ class MainConf(BaseConfig):
 
         config_args = ['plugins', 'version', 'config_file_path',
                        'debuglevel', 'errorlevel', 'installroot',
-                       'best', 'assumeyes', 'assumeno', 'gpgcheck',
+                       'best', 'assumeyes', 'assumeno', 'clean_requirements_on_remove', 'gpgcheck',
                        'showdupesfromrepos', 'plugins', 'ip_resolve',
                        'rpmverbosity', 'disable_excludes',
                        'color', 'downloadonly', 'exclude', 'excludepkgs', "skip_broken", 'tsflags']

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -227,6 +227,10 @@ Options
 ``--newpackage``
     Include newpackage relevant packages. Applicable for upgrade command.
 
+``--noautoremove``
+    disable removal of dependencies that are no longer used. It sets
+    :ref:`clean_requirements_on_remove <clean_requirements_on_remove-label>` conf option to ``False``.
+
 ``--nodocs``
     do not install documentations by using rpm flag 'RPMTRANS_FLAG_NODOCS'
 


### PR DESCRIPTION
The option sets clean_requirements_on_remove to false from commandline. The
cleaning is pretty strong behavior that is handy to be easily be switched off.

https://bugzilla.redhat.com/show_bug.cgi?id=1361424