### PR TITLE
Fix problems with --downloaddir options

### DIFF
--- a/dnf/package.py
+++ b/dnf/package.py
@@ -225,9 +225,9 @@ class Package(hawkey.Package):
                 if schemes:
                     s = dnf.pycomp.urlparse.urlparse(url)[0]
                     if s in schemes:
-                        return url + self.location
+                        return os.path.join(url, self.location.lstrip('/'))
                 else:
-                    return url + self.location
+                    return os.path.join(url, self.location.lstrip('/'))
             return None
 
         if not self.location:


### PR DESCRIPTION
It will copy all files even from local repository

It removes permissions change, because it will not work for repos where
pkg.location is not only filename but path + filename.