### PR TITLE
Enhance --duplicates for remove command (RhBug:1465292)

### DIFF
--- a/dnf/transaction.py
+++ b/dnf/transaction.py
@@ -202,6 +202,9 @@ class Transaction(object):
                 # note: in rpm 4.12 there should not be set
                 # rpm.RPMPROB_FILTER_REPLACEPKG to work
                 ts.addReinstall(tsi.installed._header, tsi)
+                if tsi.obsoleted:
+                    for pkg in tsi.obsoleted:
+                        ts.addErase(pkg.idx)
             elif tsi.op_type == UPGRADE:
                 hdr = tsi.installed._header
                 ts.addInstall(hdr, tsi, 'u')


### PR DESCRIPTION
From duplicates it tries to reinstall the newest package (it also installs
missing dependencies of that package), removes other, and also us able to remove
protected packages if the newest is available.

Also the transaction doesn't have a power to remove dependent packages (no
allowerasing for the transaction by default).

https://bugzilla.redhat.com/show_bug.cgi?id=1465292