### PR TITLE
Fix unicode comparison in dnf.rpm.miscutils.checkSig().

### DIFF
--- a/dnf/rpm/miscutils.py
+++ b/dnf/rpm/miscutils.py
@@ -15,10 +15,9 @@
 
 from __future__ import print_function, absolute_import
 from __future__ import unicode_literals
-import dnf.pycomp
+
 import rpm
 import os
-import locale
 
 
 def checkSig(ts, package):

--- a/dnf/rpm/miscutils.py
+++ b/dnf/rpm/miscutils.py
@@ -19,6 +19,8 @@ from __future__ import unicode_literals
 import rpm
 import os
 
+from dnf.i18n import ucd
+
 
 def checkSig(ts, package):
     """Takes a transaction set and a package, check it's sigs,
@@ -48,6 +50,7 @@ def checkSig(ts, package):
                  '{%|SIGGPG?{%{SIGGPG:pgpsig}}:{%|SIGPGP?{%{SIGPGP:pgpsig}}:{(none)}|}|}|}|'
         try:
             siginfo = hdr.sprintf(string)
+            siginfo = ucd(siginfo)
             if siginfo == '(none)':
                 value = 4
         except UnicodeDecodeError:


### PR DESCRIPTION
Fixes following warning:
/usr/lib/python2.7/site-packages/dnf/rpm/miscutils.py:52:
UnicodeWarning: Unicode equal comparison failed to convert
both arguments to Unicode - interpreting them as being unequal
  if siginfo == '(none)':