### PR TITLE
History command: improve usage of input arguments

### DIFF
--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -973,7 +973,7 @@ class HistoryCommand(Command):
                         else:
                             logger.info(msg)
 
-        return sorted(transaction_ids)
+        return sorted(transaction_ids, reverse=True)
 
     def run(self):
         vcmd = self.opts.transactions_action

--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -970,7 +970,7 @@ class HistoryCommand(Command):
                         else:
                             logger.info(msg)
 
-        return sorted(tids)
+        return sorted(tids, reverse=True)
 
     def run(self):
         vcmd = self.opts.tid_action

--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -972,7 +972,7 @@ class HistoryCommand(Command):
                         else:
                             logger.info(msg)
 
-        return sorted(trans_ids)
+        return sorted(trans_ids, reverse=True)
 
     def run(self):
         vcmd = self.opts.transactions_action

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -552,20 +552,20 @@ transactions and act according to this information (assuming the
 
 ``dnf history redo <transaction-spec>|<package-name-spec>``
     Repeat the specified transaction. Uses the last transaction (with highest ID)
-    if more than one transactions for giver <package-name-spec> is found. If it is not possible
-    to redo any operation due to the current state of RPMDB, do not redo any operation.
+    if more than one transaction for given <package-name-spec> is found. If it is not possible
+    to redo some operation due to the current state of RPMDB, it will not redo the transaction.
 
 ``dnf history rollback <transaction-spec>|<package-name-spec>``
     Undo all transactions performed after the specified transaction. Uses the last transaction
-    (with highest ID) if more than one transactions for giver <package-name-spec> is found.
-    If it is not possible to undo any transaction due to the current state of RPMDB, do not undo
+    (with highest ID) if more than one transaction for given <package-name-spec> is found.
+    If it is not possible to undo some transaction due to the current state of RPMDB, it will not undo
     any transaction.
 
 ``dnf history undo <transaction-spec>|<package-name-spec>``
     Perform the opposite operation to all operations performed in the specified transaction.
-    Uses the last transaction (with highest ID) if more than one transactions for giver
-    <package-name-spec> is found. If it is not possible to undo any operation due to
-    the current state of RPMDB, do not undo any operation.
+    Uses the last transaction (with highest ID) if more than one transaction for given
+    <package-name-spec> is found. If it is not possible to undo some operation due to
+    the current state of RPMDB, it will not undo the transaction.
 
 ``dnf history userinstalled``
     It will show all installonly packages, packages installed outside of DNF and packages not

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -550,18 +550,21 @@ transactions and act according to this information (assuming the
 
 .. _history_redo_command-label:
 
-``dnf history redo <transaction-spec>``
-    Repeat the specified transaction. If it is not possible to redo any
-    operation due to the current state of RPMDB, do not redo any operation.
+``dnf history redo <transaction-spec>|<package-name-spec>``
+    Repeat the specified transaction. Uses the last transaction (with highest ID)
+    if more than one transactions for giver <package-name-spec> is found. If it is not possible
+    to redo any operation due to the current state of RPMDB, do not redo any operation.
 
-``dnf history rollback <transaction-spec>``
-    Undo all transactions performed after the specified transaction. If it is
-    not possible to undo any transaction due to the current state of RPMDB,
-    do not undo any transaction.
+``dnf history rollback <transaction-spec>|<package-name-spec>``
+    Undo all transactions performed after the specified transaction. Uses the last transaction
+    (with highest ID) if more than one transactions for giver <package-name-spec> is found.
+    If it is not possible to undo any transaction due to the current state of RPMDB, do not undo
+    any transaction.
 
-``dnf history undo <transaction-spec>``
-    Perform the opposite operation to all operations performed in the
-    specified transaction. If it is not possible to undo any operation due to
+``dnf history undo <transaction-spec>|<package-name-spec>``
+    Perform the opposite operation to all operations performed in the specified transaction.
+    Uses the last transaction (with highest ID) if more than one transactions for giver
+    <package-name-spec> is found. If it is not possible to undo any operation due to
     the current state of RPMDB, do not undo any operation.
 
 ``dnf history userinstalled``

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -553,18 +553,18 @@ transactions and act according to this information (assuming the
 ``dnf history redo <transaction-spec>|<package-name-spec>``
     Repeat the specified transaction. Uses the last transaction (with highest ID)
     if more than one transaction for given <package-name-spec> is found. If it is not possible
-    to redo some operation due to the current state of RPMDB, it will not redo the transaction.
+    to redo some operations due to the current state of RPMDB, it will not redo the transaction.
 
 ``dnf history rollback <transaction-spec>|<package-name-spec>``
     Undo all transactions performed after the specified transaction. Uses the last transaction
     (with highest ID) if more than one transaction for given <package-name-spec> is found.
-    If it is not possible to undo some transaction due to the current state of RPMDB, it will not undo
+    If it is not possible to undo some transactions due to the current state of RPMDB, it will not undo
     any transaction.
 
 ``dnf history undo <transaction-spec>|<package-name-spec>``
     Perform the opposite operation to all operations performed in the specified transaction.
     Uses the last transaction (with highest ID) if more than one transaction for given
-    <package-name-spec> is found. If it is not possible to undo some operation due to
+    <package-name-spec> is found. If it is not possible to undo some operations due to
     the current state of RPMDB, it will not undo the transaction.
 
 ``dnf history userinstalled``


### PR DESCRIPTION
- Better manipulation of input arguments. (Fix RhBug:1478115)
- New error messages was added.
- Undo, redo and rollback history sub-commands will use last transaction (with highest transaction ID) if more than one transactions for given package name is found.