### PR TITLE
Change behavior of --downloaddir option (RhBug:1279001)

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1013,7 +1013,7 @@ class Base(object):
         with lock:
             drpm = dnf.drpm.DeltaInfo(self.sack.query().installed(),
                                       progress, self.conf.deltarpm_percentage)
-            remote_pkgs = self._select_remote_pkgs(pkglist)
+            remote_pkgs, local_repository_pkgs = self._select_remote_pkgs(pkglist)
             self._add_tempfiles([pkg.localPkg() for pkg in remote_pkgs])
 
             payloads = [dnf.repo._pkg2payload(pkg, progress, drpm.delta_factory,
@@ -1084,8 +1084,7 @@ class Base(object):
             logger.info(msg, full / 1024 ** 2, real / 1024 ** 2, percent)
 
         if self.conf.destdir:
-            dnf.util.ensure_dir(self.conf.destdir)
-            for pkg in pkglist:
+            for pkg in local_repository_pkgs:
                 location = os.path.join(pkg.repo.pkgdir, os.path.basename(pkg.location))
                 shutil.copy(location, self.conf.destdir)
 
@@ -2294,7 +2293,7 @@ class Base(object):
                       '"--cacheonly" option'))
             remote_pkgs = []
 
-        return remote_pkgs
+        return remote_pkgs, local_repository_pkgs
 
 
 def _msg_installed(pkg):

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -883,6 +883,10 @@ class Cli(object):
 
         self.command.configure()
 
+        if self.base.conf.destdir:
+            dnf.util.ensure_dir(self.base.conf.destdir)
+            self.base.repos.all().pkgdir = self.base.conf.destdir
+
         if self.base.conf.color != 'auto':
             self.base.output.term.reinit(color=self.base.conf.color)
 


### PR DESCRIPTION
It will use --downloaddir as a cache dir for packages.

https://bugzilla.redhat.com/show_bug.cgi?id=1279001