### PR TITLE
Fix plugins not appearing for completion (RhBug:1448874)

### DIFF
--- a/dnf/cli/completion_helper.py
+++ b/dnf/cli/completion_helper.py
@@ -173,7 +173,7 @@ def main(args):
     base = dnf.cli.cli.BaseCli()
     cli = dnf.cli.Cli(base)
     if args[0] == "_cmds":
-        base.init_plugins([], cli)
+        base.init_plugins([], [], cli)
         print("\n".join(filter_list_by_kw(args[1], cli.cli_commands)))
         return
     cli.cli_commands.clear()


### PR DESCRIPTION
Extra parameter was added in aece5c2eb3ae87bd3e40b0b339fbf24f62ecdcd7.

https://bugzilla.redhat.com/show_bug.cgi?id=1448874

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>