### PR TITLE
Solve problems in case of empty installroot (RhBug:1299482)

### DIFF
--- a/dnf/sack.py
+++ b/dnf/sack.py
@@ -105,5 +105,9 @@ def _build_sack(base):
 
 def _rpmdb_sack(base):
     sack = _build_sack(base)
-    sack.load_system_repo()
+    try:
+        # It can fail if rpmDB is not present
+        sack.load_system_repo(build_cache=False)
+    except IOError:
+        pass
     return sack


### PR DESCRIPTION
If dnf try to add to sack system repo, but there is no rpmDB it fails. The patch
should solve the problem with empty installroot and debug-info plugin.

https://bugzilla.redhat.com/show_bug.cgi?id=1299482