### PR TITLE
Add pre_confirg() hook for plugins (RhBug:1212341)

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -24,7 +24,7 @@
 %global _docdir_fmt %{name}
 
 Name:           dnf
-Version:        2.6.4
+Version:        2.7.0
 Release:        1%{?dist}
 Summary:        Package manager forked from Yum, using libsolv as a dependency resolver
 # For a breakdown of the licensing, see PACKAGE-LICENSING

--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -187,6 +187,7 @@ def main(args):
                 logger.debug('Sleep for %s seconds', sleeper)
                 time.sleep(sleeper)
 
+            base.pre_configure_plugins()
             base.read_all_repos()
             base.fill_sack()
             upgrade(base, conf.commands.upgrade_type)

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -236,6 +236,11 @@ class Base(object):
             self._plugins._load(self.conf, disabled_glob, enable_plugins)
         self._plugins._run_init(self, cli)
 
+    def pre_configure_plugins(self):
+        # :api
+        """Run plugins pre_configure() method."""
+        self._plugins._run_pre_config()
+
     def configure_plugins(self):
         # :api
         """Run plugins configure() method."""

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -872,6 +872,8 @@ class Cli(object):
         if opts.obsoletes:
             self.base.conf.obsoletes = True
 
+        self.base.pre_configure_plugins()
+
         # with cachedir in place we can configure stuff depending on it:
         self.base._activate_persistor()
 

--- a/dnf/plugin.py
+++ b/dnf/plugin.py
@@ -61,6 +61,10 @@ class Plugin(object):
         self.base = base
         self.cli = cli
 
+    def pre_config(self):
+        # :api
+        pass
+
     def config(self):
         # :api
         pass
@@ -119,6 +123,8 @@ class Plugins(object):
         if len(self.plugin_cls) > 0:
             names = sorted(plugin.name for plugin in self.plugin_cls)
             logger.debug('Loaded plugins: %s', ', '.join(names))
+
+    _run_pre_config = _caller('pre_config')
 
     _run_config = _caller('config')
 

--- a/doc/api_base.rst
+++ b/doc/api_base.rst
@@ -62,6 +62,12 @@
      Initialize plugins. If you want to disable some plugins pass the list of their name patterns to
      `disabled_glob`. When run from interactive script then also pass your :class:`dnf.cli.Cli` instance.
 
+  .. method:: pre_configure_plugins()
+
+     Configure plugins by running their pre_configure() method. It makes possible to change
+     variables before repo files and rpmDB are loaded. It also makes possible to create internal
+     repositories that will be affected by ``--disablerepo`` and ``--enablerepo``.
+
   .. method:: configure_plugins()
 
      Configure plugins by running their configure() method.


### PR DESCRIPTION
The hook should allow to change base configurations before repo parsing
including substitutions.

https://bugzilla.redhat.com/show_bug.cgi?id=1212341