### PR TITLE
Add --comment option and show it at history info (RhBug:1439196)

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -797,6 +797,10 @@ class Base(object):
             # write out our config and repo data to additional history info
             self._store_config_in_history()
 
+            if self.conf.comment:
+                # write out user provided comment to history info
+                self._store_comment_in_history(self.conf.comment)
+
         if self.conf.reset_nice:
             onice = os.nice(0)
             if onice:
@@ -2212,6 +2216,9 @@ class Base(object):
             myrepos += repo.dump()
             myrepos += '\n'
         self.history.write_addon_data('config-repos', myrepos)
+
+    def _store_comment_in_history(self, comment):
+        self.history.write_addon_data('transaction-comment', comment)
 
     def urlopen(self, url, repo=None, mode='w+b', **kwargs):
         # :api

--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -291,6 +291,8 @@ class OptionParser(argparse.ArgumentParser):
         main_parser.add_argument("--downloadonly", dest="downloadonly",
                                  action="store_true", default=False,
                                  help=_("only download packages"))
+        main_parser.add_argument("--comment", dest="comment", default=None,
+                                 help=_("add a comment to transaction"))
         # Updateinfo options...
         main_parser.add_argument("--bugfix", action="store_true",
                                  help=_("Include bugfix relevant packages, "

--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -1683,11 +1683,15 @@ Transaction Summary
             addon_info = self.history.return_addon_data(old.tid)
 
             # for the ones we create by default - don't display them as there
-            default_addons = set(['config-main', 'config-repos'])
+            default_addons = set(['config-main', 'config-repos', 'transaction-comment'])
             non_default = set(addon_info).difference(default_addons)
             if len(non_default) > 0:
                 print(_("Additional non-default information stored: %d") % \
                           len(non_default))
+
+            comment = self.history.return_addon_data(old.tid, item='transaction-comment')
+            if comment:
+                print(_("Comment        :"), comment)
 
         if old.trans_with:
             # This is _possible_, but not common

--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -772,6 +772,7 @@ class MainConf(BaseConfig):
         self._add_option('upgrade_group_objects_upgrade',
                          BoolOption(True))  # :api
         self._add_option('destdir', PathOption(None))
+        self._add_option('comment', Option())
         # runtime only options
         self._add_option('downloadonly', BoolOption(False, runtimeonly=True))
         self._add_option('ignorearch', BoolOption(False))
@@ -831,7 +832,7 @@ class MainConf(BaseConfig):
                        'showdupesfromrepos', 'plugins', 'ip_resolve',
                        'rpmverbosity', 'disable_excludes', 'color',
                        'downloadonly', 'exclude', 'excludepkgs', 'skip_broken',
-                       'tsflags', 'arch', 'basearch', 'ignorearch', 'cacheonly']
+                       'tsflags', 'arch', 'basearch', 'ignorearch', 'cacheonly', 'comment']
 
         for name in config_args:
             value = getattr(opts, name, None)

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -134,6 +134,9 @@ Options
 
     DNF uses a separate cache for each user under which it executes. The cache for the root user is called the system cache. This switch allows a regular user read-only access to the system cache which usually is more fresh than the user's and thus he does not have to wait for metadata sync.
 
+``--comment=<comment>``
+    add a comment to transaction history
+
 ``-c <config file>, --config=<config file>``
     config file location
 


### PR DESCRIPTION
This adds a --comment cli option when executing a transaction. Provided information is stored and displayed when history info for the specific transaction is requested

RhBug: 1439196