### PR TITLE
Fix: add_includes

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -1,4 +1,4 @@
-%global hawkey_version 0.9.3
+%global hawkey_version 0.9.4
 %global librepo_version 1.7.19
 %global libcomps_version 0.1.8
 %global rpm_version 4.13.0-0.rc1.29

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -148,11 +148,11 @@ class Base(object):
             if r.id in disabled:
                 continue
             if len(r.includepkgs) > 0:
-                pkgs = self.sack.query().filter(empty=True)
                 for incl in r.includepkgs:
                     subj = dnf.subject.Subject(incl)
-                    pkgs = pkgs.union(subj.get_best_query(self.sack))
-                self.sack.add_includes(pkgs, reponame=r.id)
+                    pkgs = subj.get_best_query(self.sack)
+                    self.sack.add_includes(pkgs.filter(reponame=r.id))
+                self.sack.set_use_includes(True, r.id)
             for excl in r.excludepkgs:
                 subj = dnf.subject.Subject(excl)
                 pkgs = subj.get_best_query(self.sack)
@@ -161,11 +161,11 @@ class Base(object):
         # repo specific settings
         if 'main' not in disabled:
             if len(self.conf.includepkgs) > 0:
-                pkgs = self.sack.query().filter(empty=True)
                 for incl in self.conf.includepkgs:
                     subj = dnf.subject.Subject(incl)
-                    pkgs = pkgs.union(subj.get_best_query(self.sack))
-                self.sack.add_includes(pkgs)
+                    pkgs = subj.get_best_query(self.sack)
+                    self.sack.add_includes(pkgs)
+                self.sack.set_use_includes(True)
             for excl in self.conf.excludepkgs:
                 subj = dnf.subject.Subject(excl)
                 pkgs = subj.get_best_query(self.sack)

--- a/dnf/sack.py
+++ b/dnf/sack.py
@@ -73,14 +73,6 @@ class Sack(hawkey.Sack):
         """Factory function returning a DNF Query."""
         return dnf.query.Query(self)
 
-    def add_includes(self, pkgq, reponame=None):
-        # exclude all but includes from repo
-        excl = self.query()
-        if reponame:
-            excl = excl.filter(reponame=reponame)
-        excl = excl.difference(pkgq)
-        self.add_excludes(excl)
-
     def _rpmdb_version(self, yumdb):
         pkgs = self.query().installed().run()
         main = SackVersion()


### PR DESCRIPTION
The "add_includes()" was wrongly emulated by the "add_excludes()".
In fact next call of "add_includes()" had could just adds more excluded packages.

The methods add_includes() and set_use_includes() from libdnf are used now.

Requires https://github.com/rpm-software-management/libdnf/pull/319 