### PR TITLE
Check conf.releasever instead of releasever

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -907,7 +907,7 @@ class Cli(object):
         conf.releasever = releasever
         subst = conf.substitutions
         subst.update_from_etc(conf.installroot)
-        if releasever is None:
+        if conf.releasever is None:
             logger.warning(_("Unable to detect release version (use '--releasever' to specify "
                              "release version)"))
 


### PR DESCRIPTION
The substitutions may actually set the conf.releasever correctly,
and so the check should use that instead of the passed-in function
parameter.