### PR TITLE
Decode result of strftime

### DIFF
--- a/dnf/util.py
+++ b/dnf/util.py
@@ -30,6 +30,7 @@ import dnf.const
 import dnf.pycomp
 import itertools
 import librepo
+import locale
 import logging
 import os
 import pwd
@@ -224,6 +225,8 @@ def mapall(fn, *seq):
 def normalize_time(timestamp):
     """Convert time into locale aware datetime string object."""
     t = time.strftime("%c", time.localtime(timestamp))
+    if not dnf.pycomp.PY3:
+        t = t.decode(locale.getlocale()[1])
     return t
 
 def on_ac_power():


### PR DESCRIPTION
On Python 2 the function returns a bytestring with locale dependent encoding. [Python documentation][0] suggest how to decode the value into unicode, so that should be applied here.

[0]: https://docs.python.org/2/library/time.html#time.strftime

I ran into this causing a failure in my tests for Pungi. It can be replicate with the following snippet (which does not crash, but still prints a traceback). I have `cs_CZ.UTF-8` as locale.

Ultimately the problem is `msg % args` snippet where `msg` is `unicode` but one element of `args` is a `str` that can not be decoded as ASCII.

```python
import logging
import dnf


logging.basicConfig(level=logging.DEBUG)

base = dnf.Base()
repo = dnf.repo.Repo('test', base.conf)
repo.baseurl = 'http://download.fedoraproject.org/pub/fedora/linux/releases/26/Everything/x86_64/os/'
repo.enable()
base.repos.add(repo)
base.fill_sack(load_system_repo=False, load_available_repos=True)
```

```
$ python replicate.py
DEBUG:dnf:repozitář: použití mezipaměti pro: test
DEBUG:dnf:not found deltainfo for: test
DEBUG:dnf:not found updateinfo for: test
Traceback (most recent call last):
  File "/usr/lib64/python2.7/logging/__init__.py", line 861, in emit
    msg = self.format(record)
  File "/usr/lib64/python2.7/logging/__init__.py", line 734, in format
    return fmt.format(record)
  File "/usr/lib64/python2.7/logging/__init__.py", line 465, in format
    record.message = record.getMessage()
  File "/usr/lib64/python2.7/logging/__init__.py", line 329, in getMessage
    msg = msg % self.args
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc4 in position 0: ordinal not in range(128)
Logged from file base.py, line 324
Traceback (most recent call last):
  File "/usr/lib64/python2.7/logging/__init__.py", line 861, in emit
    msg = self.format(record)
  File "/usr/lib64/python2.7/logging/__init__.py", line 734, in format
    return fmt.format(record)
  File "/usr/lib64/python2.7/logging/__init__.py", line 465, in format
    record.message = record.getMessage()
  File "/usr/lib64/python2.7/logging/__init__.py", line 329, in getMessage
    msg = msg % self.args
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 0: ordinal not in range(128)
Logged from file base.py, line 337
```