### PR TITLE
Connection initiation callback for md download (RhBug:1048344)

### DIFF
--- a/dnf/callback.py
+++ b/dnf/callback.py
@@ -88,6 +88,19 @@ class DownloadProgress(object):
 
         pass
 
+    def start_transfer(self, payload, total_mirrors, tried_mirrors):
+        """Start of a single new transfer. Since internally data may be
+        downloaded from several mirrors, this provides detailed overview about
+        start of single transfers together with information about related mirrors.
+
+        :api, `payload` is the payload related to this call, `total_mirrors` is
+        maximal amount of mirrors that will be tried to connect,
+        `tried_mirrors` is count of mirrors which already failed to connect.
+
+        """
+
+        pass
+
     def start(self, total_files, total_size, total_drpms=0):
         """Start new progress metering. :api
 

--- a/dnf/cli/progress.py
+++ b/dnf/cli/progress.py
@@ -19,6 +19,7 @@ from dnf.cli.format import format_number, format_time
 from dnf.cli.term import _term_width
 from dnf.pycomp import unicode
 from time import time
+from dnf.i18n import _
 
 import sys
 import dnf.callback
@@ -69,6 +70,12 @@ class MultiFileProgressMeter(dnf.callback.DownloadProgress):
         self.last_time = 0
         self.last_size = 0
         self.rate = None
+
+    def start_transfer(self, payload, total_mirrors, tried_mirrors):
+        text = unicode(payload)
+        msg = _("Initiating transfer, tried %d / %d mirrors.\r") % (tried_mirrors, total_mirrors)
+        left = _term_width() - len(msg)
+        self.message('%-*.*s%s' % (left, left, text, msg))
 
     def progress(self, payload, done):
         now = time()


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1048344

(dnf part of 1048344 fix)
Adds start_transfer callback to dnf.callback.DownloadProgress, which
signalizes start of a single new transfer. Since internally data may be
downloaded from several mirrors, this provides detailed overview about
start of single transfers together with information about
related mirrors, concretely information about maximal number of mirrors to try
and count of mirrors that failed to connect yet.

In MultiFileProgressMeter produces output as follows, before progressbar is shown (on its place).:
Fedora 25 - x86_64 - Updates                                                  Initiating new transfer, tried 1 / 63 mirrors.

(!) This is dependent on https://github.com/rpm-software-management/librepo/pull/113 not compatible with older versions of librepo.