### PR TITLE
Spelling fix

### DIFF
--- a/dnf/cli/main.py
+++ b/dnf/cli/main.py
@@ -127,7 +127,7 @@ def cli_run(cli, base):
                 msg = _("(try to add '%s' to command line to replace conflicting "
                         "packages") % "--allowerasing"
                 if cli.base.conf.strict:
-                    msg += _(" or '%s' to skip uninstalable packages)") % "--skip-broken"
+                    msg += _(" or '%s' to skip uninstallable packages)") % "--skip-broken"
                 else:
                     msg += ")"
                 logger.info(msg)


### PR DESCRIPTION
Requires updating po/*.po as well. Not included in the patch, as I'm not sure how they're handled with zanata etc.