### PR TITLE
Fix command clean

### DIFF
--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -411,7 +411,9 @@ Clean Command
 -------------
 Performs cleanup of temporary files kept for repositories. This includes any
 such data left behind from disabled or removed repositories as well as for
-different distribution release versions.
+different distribution release versions by default.
+However, command can be limited to enabled repositories using option ``--enabled``.
+Option ``--enabled`` is automaticaly activated if list of enabled repositories is changed from commandline (``--repo``. ``--enablerepo``, ``--disablerepo``).
 
 ``dnf clean dbcache``
     Removes cache files generated from the repository metadata. This forces DNF


### PR DESCRIPTION
First commit fixes "Bug 1330211 - RFE: dnf clean does not respect enablerepo/disablerepo anymore"

Added option "--enabled".
Command "clean" cleans temporary files for all repositories by default.
Only enabled repositories are cleaned by using option "--enabled".
Option "--enabled" will be automaticaly activated if list of enabled repositories
is changed from commandline ("--repo". "--enablerepo", "--disablerepo").