### PR TITLE
Revert parallel download for dnf

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -1,5 +1,5 @@
 %global hawkey_version 0.9.4
-%global librepo_version 1.8.0
+%global librepo_version 1.7.19
 %global libcomps_version 0.1.8
 %global rpm_version 4.13.0-0.rc1.29
 %global min_plugins_core 2.1.3

--- a/dnf/cli/progress.py
+++ b/dnf/cli/progress.py
@@ -49,7 +49,6 @@ class MultiFileProgressMeter(dnf.callback.DownloadProgress):
         self.unknown_progres = 0
         self.total_drpm = 0
         self.isatty = sys.stdout.isatty()
-        self.multi_download_id = None
 
     def message(self, msg):
         dnf.util._terminal_messenger('write_flush', msg, self.fo)
@@ -77,24 +76,18 @@ class MultiFileProgressMeter(dnf.callback.DownloadProgress):
         total = int(payload.download_size)
         done = int(done)
 
-        if text not in self.active:
-            self.active.append(text)
-
-        if self.multi_download_id is not None:
-            text = self.multi_download_id
-
         # update done_size
         if text not in self.state:
             self.state[text] = now, 0
+            self.active.append(text)
         start, old = self.state[text]
         self.state[text] = start, done
         self.done_size += done - old
 
-        if total > self.total_size:
-            self.total_size = total
-
         # update screen if enough time has elapsed
         if now - self.last_time > self.update_period:
+            if total > self.total_size:
+                self.total_size = total
             self._update(now)
 
     def _update(self, now):
@@ -156,30 +149,20 @@ class MultiFileProgressMeter(dnf.callback.DownloadProgress):
         text = unicode(payload)
         size = int(payload.download_size)
 
-        if self.multi_download_id is not None:
-            text = self.multi_download_id
-
         # update state
         if status == dnf.callback.STATUS_MIRROR:
             pass
         elif status == dnf.callback.STATUS_DRPM:
             self.done_drpm += 1
         elif text in self.state:
-            if self.multi_download_id is not None:
-                start, done = self.state[text]
-                size = 0
-            else:
-                start, done = self.state.pop(text)
-                size -= done
-            if unicode(payload) in self.active:
-                self.active.remove(unicode(payload))
+            start, done = self.state.pop(text)
+            self.active.remove(text)
+            size -= done
             self.done_files += 1
             self.done_size += size
         elif status == dnf.callback.STATUS_ALREADY_EXISTS:
             self.done_files += 1
             self.done_size += size
-
-        text = unicode(payload)
 
         if status:
             # the error message, no trimming

--- a/tests/support.py
+++ b/tests/support.py
@@ -232,10 +232,6 @@ class _BaseStubMixin(object):
         # class and a Base reference.
         self._sack = TestSack(REPO_DIR, self)
         self._sack.load_system_repo()
-
-        self.download_metadata([r for r in self.repos.iter_enabled()
-                                if r.__class__ is dnf.repo.Repo and not r.load()])
-
         for repo in self.repos.iter_enabled():
             if repo.__class__ is dnf.repo.Repo:
                 self._add_repo_to_sack(repo)

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -173,7 +173,6 @@ class CostUpdate(tests.test_repo.RepoTestMixin, support.ResultTestCase):
         base.init_sack()
         base.repos.add(r1)
         base.repos.add(r2)
-        base.download_metadata([r1, r2])
         base._add_repo_to_sack(r1)
         base._add_repo_to_sack(r2)
         base.upgrade("tour")


### PR DESCRIPTION
According to persistent problems with parallel download and limited time to fix
it it will be better to temporary revert it, before every problem will be
solved. The problems are also a blocker for periodic dnf releases.

Reverts commit: ae8474c68fa25b0bc980817c2ee2c426c6cb01c9
Reverts commit: a27e8aaef2cd8cde8e5e29976bbc0cb29be37c12
Reverts commit: 840bddb909d82f0e71d5ac534676ca929bdb8946