### PR TITLE
Add Requires: sqlite in dnf.spec for bash-completion script

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -41,6 +41,8 @@ BuildRequires:  gettext
 BuildRequires:  %{_bindir}/sphinx-build
 BuildRequires:  systemd
 BuildRequires:  bash-completion
+# %{_bindir}/sqlite3 is needed for bash-completion script
+Recommends: (%{_bindir}/sqlite3 if bash-completion)
 %if %{with python3}
 Requires:       python3-%{name} = %{version}-%{release}
 %else


### PR DESCRIPTION
As per details given in bug 1479330, I think freshly installed system contains only sqlite-libs package but not /usr/bin/sqlite3 which comes from sqlite package. This PR will fix dnf.spec to pull that package as a dependency.