### PR TITLE
[wip/modularity] fix locked version and profile removing error reporting

### DIFF
--- a/dnf/module/exceptions.py
+++ b/dnf/module/exceptions.py
@@ -90,3 +90,9 @@ class NoProfilesException(dnf.exceptions.Error):
     def __init__(self, module_spec):
         value = "No such profile: {}. No profiles available".format(module_spec)
         super(NoProfilesException, self).__init__(value)
+
+
+class NoProfileToRemoveException(dnf.exceptions.Error):
+    def __init__(self, module_spec):
+        value = "No profile to remove for '{}'".format(module_spec)
+        super(NoProfileToRemoveException, self).__init__(value)


### PR DESCRIPTION
 * problem when version is locked to stream:version
    * user tries to install something from different stream 
    * update same stream to newer version
    * tries to install different profile (same stream:version) (didn't work before)
* `dnf module list --installed` showed modules that had no profile installed
* dnf reported `Nothing to do` when there was no profile to remove, now dnf prints out correct error message