### PR TITLE
Fix unassigned variable exception in base

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -67,6 +67,7 @@ DNF CONTRIBUTORS
     Christopher Meng <cickumqt@gmail.com>
     Daniel Mach <dmach@redhat.com>
     Dave Johansen <davejohansen@gmail.com>
+    Dylan Pindur <dylanpindur@gmail.com>
     Frank Dana <ferdnyc@gmail.com>
     George Machitidze <giomac@gmail.com>
     Haïkel Guémar <haikel.guemar@gmail.com>

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -2290,7 +2290,8 @@ class Base(object):
 
         try:
             msg = _('Package "{}" from local repository "{}" has incorrect checksum')
-            if pkg is not None and not _verification_of_packages(local_repository_pkgs, msg.format(pkg, pkg.reponame)):
+            if pkg is not None and not _verification_of_packages(local_repository_pkgs,
+                                                                 msg.format(pkg, pkg.reponame)):
                 error = True
         except Exception as e:
             logger.critical(str(e))

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -2279,6 +2279,7 @@ class Base(object):
 
         remote_pkgs = []
         local_repository_pkgs = []
+        pkg = None
         for pkg in install_pkgs:
             if pkg._is_local_pkg():
                 if pkg.reponame != hawkey.CMDLINE_REPO_NAME:
@@ -2289,7 +2290,7 @@ class Base(object):
 
         try:
             msg = _('Package "{}" from local repository "{}" has incorrect checksum')
-            if not _verification_of_packages(local_repository_pkgs, msg.format(pkg, pkg.reponame)):
+            if pkg is not None and not _verification_of_packages(local_repository_pkgs, msg.format(pkg, pkg.reponame)):
                 error = True
         except Exception as e:
             logger.critical(str(e))


### PR DESCRIPTION
If `install_pkgs` is empty `pkg` would never be assigned to and cause an exception when it is passed to `_verification_of_packages`. A DNF exception would then be raised indicating that some packages have an incorrect checksum.

I noticed this while using the DNF Ansible module. The bug prevented the module from removing packages.

Let me know if you need more details, or can suggest a nicer place to implement the fix.