### PR TITLE
Compare transactions by IDs, not timestamps

### DIFF
--- a/dnf/yum/history.py
+++ b/dnf/yum/history.py
@@ -353,13 +353,7 @@ class YumHistoryTransaction(object):
     def __lt__(self, other):
         if other is None:
             return False
-        if self.beg_timestamp == other.beg_timestamp:
-            if self.end_timestamp == other.end_timestamp:
-                return self.tid > other.tid
-            else:
-                return self.end_timestamp < other.end_timestamp
-        else:
-            return self.beg_timestamp > other.beg_timestamp
+        return self.tid < other.tid
 
     def _getTransWith(self):
         if self._loaded_TW is None:
@@ -713,7 +707,7 @@ class YumMergedHistoryTransaction(YumHistoryTransaction):
         self._merged_tids.add(obj.tid)
         self._merged_objs.append(obj)
         # Oldest first...
-        self._merged_objs.sort(reverse=True)
+        self._merged_objs.sort()
 
         if self.beg_timestamp > obj.beg_timestamp:
             self.beg_timestamp    = obj.beg_timestamp

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -615,13 +615,8 @@ class ComparisonTests(TestCase):
     def test_transaction(self):
         a = dnf.yum.history.YumHistoryTransaction(None, [1, 5, 0, 5, 0, 0, 0])
         b = dnf.yum.history.YumHistoryTransaction(None, [9, 5, 0, 5, 0, 0, 0])
-        self.assertGreater(a, b)
-        self.assertLess(b, a)
-
-        a2 = dnf.yum.history.YumHistoryTransaction(None, [0, 1, 0, 0, 0, 0, 0])
-        b2 = dnf.yum.history.YumHistoryTransaction(None, [0, 9, 0, 0, 0, 0, 0])
-        self.assertGreater(a2, b2)
-        self.assertLess(b2, a2)
+        self.assertLess(a, b)
+        self.assertGreater(b, a)
 
     def test_rpmdb_problem(self):
         a = dnf.yum.history.YumHistoryRpmdbProblem(None, 1, 5, None)


### PR DESCRIPTION
Make Transaction method `__lt__` work in an expectable way.
True if t1.tid < t2.tid, false when t1.tid > t2.tid.
This fixes the behavior of sort method (lowest/oldest first without
    using reverse flag).

Fixes random behavior in CI tests:
    https://github.com/rpm-software-management/ci-dnf-stack/pull/248