### PR TITLE
Fix "includepkgs" crash for non loaded repos (RhBug:1499564)

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -344,6 +344,8 @@ class Base(object):
                         logger.info(_("Last metadata expiration check: %s ago on %s."),
                                     datetime.timedelta(seconds=int(age)),
                                     dnf.util.normalize_time(mts))
+            else:
+                self.repos.all().disable()
         conf = self.conf
         self._sack._configure(conf.installonlypkgs, conf.installonly_limit)
         self._setup_excludes_includes()


### PR DESCRIPTION
If load_available_repos is False then repos are not added to sack and
sack.set_use_includes(True, r.id) raises ValueError exception.
Solution is to disable not loaded repos at all.