### PR TITLE
[modularity] module enabling based on rpms

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -146,8 +146,8 @@ Recommends:     rpm-plugin-systemd-inhibit
 %endif
 BuildRequires:  python2-modulemd
 Requires:       python2-modulemd
-BuildRequires:  python2-smartcols
-Requires:       python2-smartcols
+BuildRequires:  python2-smartcols >= 0.3.0
+Requires:       python2-smartcols >= 0.3.0
 # dnf-langpacks package is retired in F25
 # to have clean upgrade path for dnf-langpacks
 Obsoletes:      python-dnf-langpacks < %{dnf_langpacks_ver}
@@ -185,8 +185,8 @@ Recommends:     rpm-plugin-systemd-inhibit
 %endif
 BuildRequires:  python3-modulemd
 Requires:       python3-modulemd
-BuildRequires:  python3-smartcols
-Requires:       python3-smartcols
+BuildRequires:  python3-smartcols >= 0.3.0
+Requires:       python3-smartcols >= 0.3.0
 # dnf-langpacks package is retired in F25
 # to have clean upgrade path for dnf-langpacks
 Obsoletes:      python3-dnf-langpacks < %{dnf_langpacks_ver}

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -194,7 +194,6 @@ class Base(object):
         self.repo_module_dict.read_all_module_confs()
         self.repo_module_dict.read_all_module_defaults()
         self._module_persistor = ModulePersistor()
-        self.use_module_includes()
 
     def use_module_includes(self):
         self.sack.reset_includes()
@@ -720,6 +719,7 @@ class Base(object):
             installed = self.sack.query().installed()
             self._group_persistor.update_group_env_installed(installed, goal)
         self._plugins.run_resolved()
+        self.repo_module_dict.enable_based_on_rpms()
         return got_transaction
 
     def do_transaction(self, display=()):

--- a/dnf/cli/commands/module.py
+++ b/dnf/cli/commands/module.py
@@ -87,7 +87,7 @@ class ModuleCommand(commands.Command):
 
         def run_on_module(self):
             for module_ns in self.opts.module_nsvp:
-                self.base.repo_module_dict.enable(module_ns)
+                self.base.repo_module_dict.enable(module_ns, True)
                 logger.info("'{}' is enabled".format(module_ns))
 
     class DisableSubCommand(SubCommand):
@@ -102,7 +102,7 @@ class ModuleCommand(commands.Command):
 
         def run_on_module(self):
             for module_n in self.opts.module_nsvp:
-                self.base.repo_module_dict.disable(module_n)
+                self.base.repo_module_dict.disable(module_n, True)
                 logger.info("'{}' is disabled".format(module_n))
 
     class InstallSubCommand(SubCommand):
@@ -164,7 +164,7 @@ class ModuleCommand(commands.Command):
 
         def run_on_module(self):
             for module_n in self.opts.module_nsvp:
-                stream, version = self.base.repo_module_dict.lock(module_n)
+                stream, version = self.base.repo_module_dict.lock(module_n, True)
                 logger.info("'{}' is locked (stream: {}, version: {})"
                             .format(module_n, stream, version))
 
@@ -180,7 +180,7 @@ class ModuleCommand(commands.Command):
 
         def run_on_module(self):
             for module_n in self.opts.module_nsvp:
-                self.base.repo_module_dict.unlock(module_n)
+                self.base.repo_module_dict.unlock(module_n, True)
                 logger.info("'{}' is unlocked".format(module_n))
 
     class ProfileInfoSubCommand(SubCommand):

--- a/dnf/module/__init__.py
+++ b/dnf/module/__init__.py
@@ -21,6 +21,7 @@ NOTHING_TO_SHOW = 2
 VERSION_LOCKED = 3
 INSTALLING_NEWER_VERSION = 4
 NOTHING_TO_INSTALL = 5
+NO_PROFILE_SPECIFIED = 6
 
 module_messages = {
     DIFFERENT_STREAM_INFO: _("Enabling different stream for '{}'"),
@@ -28,4 +29,5 @@ module_messages = {
     VERSION_LOCKED: _("'{}' is locked to version: {}"),
     INSTALLING_NEWER_VERSION: _("Installing newer version of '{}' than specified. Reason: {}"),
     NOTHING_TO_INSTALL: _("Nothing to install. Enabled modules: {}"),
+    NO_PROFILE_SPECIFIED: _("No profile specified for '{}', please specify profile"),
 }

--- a/dnf/module/exceptions.py
+++ b/dnf/module/exceptions.py
@@ -18,6 +18,7 @@
 #
 
 import dnf
+from dnf.module import module_messages, NO_PROFILE_SPECIFIED
 
 
 class LoadCacheException(dnf.exceptions.Error):
@@ -76,7 +77,7 @@ class NoStreamSpecifiedException(dnf.exceptions.Error):
 
 class NoProfileSpecifiedException(dnf.exceptions.Error):
     def __init__(self, module_spec):
-        value = "No profile specified for '{}', please specify profile".format(module_spec)
+        value = module_messages[NO_PROFILE_SPECIFIED].format(module_spec)
         super(NoProfileSpecifiedException, self).__init__(value)
 
 

--- a/dnf/module/repo_module.py
+++ b/dnf/module/repo_module.py
@@ -71,30 +71,21 @@ class RepoModule(OrderedDict):
 
             if not self.parent.base.conf.assumeno and \
                     self.parent.base.output.userconfirm():
-                self.conf.profiles = []
-                self.conf.version = -1
+                self.parent.base._module_persistor.set_data(self, version=-1, profiles=set())
                 self.enable(stream, True)
             else:
                 raise EnabledStreamException("{}:{}".format(self.name, stream))
 
-        self.conf.stream = stream
-        self.conf.enabled = True
-        self.write_conf_to_file()
-
-        self.parent.base.use_module_includes()
+        self.parent.base._module_persistor.set_data(self, stream=stream, enabled=True)
 
     def disable(self):
-        self.conf.enabled = False
-        self.write_conf_to_file()
+        self.parent.base._module_persistor.set_data(self, enabled=False)
 
     def lock(self, version):
-        self.conf.locked = True
-        self.conf.version = version
-        self.write_conf_to_file()
+        self.parent.base._module_persistor.set_data(self, locked=True, version=version)
 
     def unlock(self):
-        self.conf.locked = False
-        self.write_conf_to_file()
+        self.parent.base._module_persistor.set_data(self, locked=False)
 
     def write_conf_to_file(self):
         output_file = os.path.join(self.parent.get_modules_dir(), "%s.module" % self.conf.name)

--- a/dnf/module/repo_module.py
+++ b/dnf/module/repo_module.py
@@ -17,7 +17,7 @@
 import os
 from collections import OrderedDict
 
-from dnf.conf import ModuleConf
+from dnf.conf import ModuleConf, ModuleDefaultsConf
 from dnf.module import module_messages, DIFFERENT_STREAM_INFO
 from dnf.module.exceptions import NoStreamException, EnabledStreamException
 from dnf.module.repo_module_stream import RepoModuleStream
@@ -30,7 +30,7 @@ class RepoModule(OrderedDict):
         super(RepoModule, self).__init__()
 
         self._conf = None
-        self.defaults = None
+        self._defaults = None
         self.name = None
         self.parent = None
 
@@ -48,6 +48,20 @@ class RepoModule(OrderedDict):
     @conf.setter
     def conf(self, value):
         self._conf = value
+
+    @property
+    def defaults(self):
+        if self._defaults is None:
+            self._defaults = ModuleDefaultsConf(section=self.name, parser=ConfigParser())
+            self._defaults.name = self.name
+            self._defaults.stream = None
+            self._defaults.profiles = None
+
+        return self._defaults
+
+    @defaults.setter
+    def defaults(self, value):
+        self._defaults = value
 
     def add(self, repo_module_version):
         module_stream = self.setdefault(repo_module_version.stream, RepoModuleStream())

--- a/dnf/module/repo_module_dict.py
+++ b/dnf/module/repo_module_dict.py
@@ -189,20 +189,28 @@ class RepoModuleDict(OrderedDict):
                 if nevra in version.module_metadata.artifacts.rpms:
                     version.repo_module.enable(version.stream, True)
 
-    def enable(self, module_spec):
+    def enable(self, module_spec, save_immediately=False):
         subj = ModuleSubject(module_spec)
         module_version, module_form = subj.find_module_version(self)
 
         self[module_version.name].enable(module_version.stream, self.base.conf.assumeyes)
 
-    def disable(self, module_spec):
+        if save_immediately:
+            self.base._module_persistor.commit()
+            self.base._module_persistor.save()
+
+    def disable(self, module_spec, save_immediately=False):
         subj = ModuleSubject(module_spec)
         module_version, module_form = subj.find_module_version(self)
 
         repo_module = module_version.repo_module
         repo_module.disable()
 
-    def lock(self, module_spec):
+        if save_immediately:
+            self.base._module_persistor.commit()
+            self.base._module_persistor.save()
+
+    def lock(self, module_spec, save_immediately=False):
         subj = ModuleSubject(module_spec)
         module_version, module_form = subj.find_module_version(self)
 
@@ -212,9 +220,14 @@ class RepoModuleDict(OrderedDict):
             raise EnabledStreamException(module_spec)
 
         repo_module.lock(module_version.version)
+
+        if save_immediately:
+            self.base._module_persistor.commit()
+            self.base._module_persistor.save()
+
         return module_version.stream, module_version.version
 
-    def unlock(self, module_spec):
+    def unlock(self, module_spec, save_immediately=False):
         subj = ModuleSubject(module_spec)
         module_version, module_form = subj.find_module_version(self)
 
@@ -224,6 +237,11 @@ class RepoModuleDict(OrderedDict):
             raise EnabledStreamException(module_spec)
 
         repo_module.unlock()
+
+        if save_immediately:
+            self.base._module_persistor.commit()
+            self.base._module_persistor.save()
+
         return module_version.stream, module_version.version
 
     def install(self, module_specs):
@@ -245,7 +263,7 @@ class RepoModuleDict(OrderedDict):
 
             result |= module_version.install(profiles, default_profiles)
 
-        if not result and self.base._module_persistor:
+        if not result and versions and self.base._module_persistor:
             module_versions = ["{}:{}".format(module_version.name, module_version.stream)
                                for module_version, profiles, default_profiles in versions.values()]
             self.base._module_persistor.commit()

--- a/dnf/module/repo_module_version.py
+++ b/dnf/module/repo_module_version.py
@@ -33,6 +33,8 @@ class RepoModuleVersion(object):
     def __lt__(self, other):
         # for finding latest
         assert self.full_stream == other.full_stream
+        if self.repo_module.conf.locked:
+            return self.version < self.repo_module.conf.version
         return self.module_metadata.version < other.module_metadata.version
 
     def __repr__(self):

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -536,7 +536,17 @@ class ModuleTest(unittest.TestCase):
         self.assertNotIn(rmv, installed)
 
         # install
-        rmd.install(["base-runtime"])
+        try:
+            rmd.install(["base-runtime"])
+        except SystemExit:
+            # module profile wasn't, module was just enabled
+
+            repo_module = rmd["base-runtime"]
+            self.assertTrue(repo_module.conf.enabled)
+            self.assertEqual(repo_module.conf.name, "base-runtime")
+            self.assertEqual(repo_module.conf.stream, "f26")
+            self.assertEqual(repo_module.conf.profiles, [])
+            return
 
         # check module conf
         repo_module = rmd["base-runtime"]


### PR DESCRIPTION
* module list output fixed
* module enabling based on rpms
* do not enable module when transaction fails
* enable module runtime dependencies, when enabling module:stream
* accept no profile when installing module, but inform user about it
* install new rpms when updating profiles
* limit the width of module list command