### PR TITLE
Add '--nocaps' tsflag config value

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -465,6 +465,10 @@ class Base(object):
                         'justdb': rpm.RPMTRANS_FLAG_JUSTDB,
                         'nocontexts': rpm.RPMTRANS_FLAG_NOCONTEXTS,
                         'nocrypto': rpm.RPMTRANS_FLAG_NOFILEDIGEST}
+    if hasattr(rpm, 'RPMTRANS_FLAG_NOCAPS'):
+        # Introduced in rpm-4.14
+        _TS_FLAGS_TO_RPM['nocaps'] = rpm.RPMTRANS_FLAG_NOCAPS
+
     _TS_VSFLAGS_TO_RPM = {'nocrypto': rpm._RPMVSF_NOSIGNATURES |
                           rpm._RPMVSF_NODIGESTS}
 

--- a/doc/api_conf.rst
+++ b/doc/api_conf.rst
@@ -216,6 +216,7 @@ Configurable settings of the :class:`dnf.Base` object are stored into a :class:`
     nodocs                  RPMTRANS_FLAG_NODOCS
     justdb                  RPMTRANS_FLAG_JUSTDB
     nocontexts              RPMTRANS_FLAG_NOCONTEXTS
+    nocaps                  RPMTRANS_FLAG_NOCAPS
     nocrypto                RPMTRANS_FLAG_NOFILEDIGEST
     ==========              ===========================
 


### PR DESCRIPTION
Makes it possible to work around the trouble of installing packages with
filesystem capabilities in user namespaces. Introduced in RPM 4.14.