### PR TITLE
[modularity] usage of includes (test thoroughly)

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -195,22 +195,29 @@ class Base(object):
         self.repo_module_dict.read_all_module_confs()
         self.repo_module_dict.read_all_module_defaults()
         self._module_persistor = ModulePersistor()
+        self.use_module_includes()
 
     def use_module_includes(self):
+        def update_future_package_set(includes, repos):
+            include_repos.update(repos)
+
+            for nevra in includes:
+                subj = dnf.subject.Subject(nevra)
+                pkgs = subj.get_best_query(self.sack, forms=[hawkey.FORM_NEVRA])
+                include_pkgs.add(pkgs)
+
         self.sack.reset_includes()
         include_repos = set()
         include_pkgs = set()
         for repo_module in self.repo_module_dict.values():
-            if repo_module.conf and repo_module.conf.enabled:
+            if repo_module.conf.enabled:
                 includes, repos = self.repo_module_dict.get_includes(repo_module.name,
                                                                      repo_module.conf.stream)
-
-                include_repos.update(repos)
-
-                for nevra in includes:
-                    subj = dnf.subject.Subject(nevra)
-                    pkgs = subj.get_best_query(self.sack, forms=[hawkey.FORM_NEVRA])
-                    include_pkgs.add(pkgs)
+                update_future_package_set(includes, repos)
+            elif repo_module.defaults.stream:
+                includes, repos = self.repo_module_dict.get_includes(repo_module.name,
+                                                                     repo_module.defaults.stream)
+                update_future_package_set(includes, repos)
 
         for pkg in include_pkgs:
             self.sack.add_includes(pkg)

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1875,17 +1875,11 @@ class Base(object):
                 not self.repo_module_dict.list_module_version_installed():
             self._goal.upgrade_all()
         else:
-            self.repo_module_dict.upgrade_all()
+            module_query = self.repo_module_dict.upgrade_all()
 
             q = self.sack.query().upgrades()
-
-            filtered_rpms_name = []
-            for repo_module_version in self.repo_module_dict.list_module_version_installed():
-                for profile in repo_module_version.repo_module.conf.profiles:
-                    filtered_rpms_name.append(repo_module_version.rpms(profile))
-
-            for name in filtered_rpms_name:
-                q = q.filter(name__neq=name)
+            # HACK: self.repo_module_dict.upgrade_all() should return a query
+            q = q.union(module_query)
 
             # add obsoletes into transaction
             if self.conf.obsoletes:

--- a/dnf/cli/commands/module.py
+++ b/dnf/cli/commands/module.py
@@ -133,7 +133,7 @@ class ModuleCommand(commands.Command):
             demands.root_user = True
 
         def run_on_module(self):
-            module_specs = self.base.repo_module_dict.upgrade(self.opts.module_nsvp)
+            module_specs = self.base.repo_module_dict.upgrade(self.opts.module_nsvp, True)
             if module_specs:
                 raise NoModuleException(", ".join(module_specs))
 

--- a/dnf/cli/commands/upgrade.py
+++ b/dnf/cli/commands/upgrade.py
@@ -85,7 +85,7 @@ class UpgradeCommand(commands.Command):
     def _update_modules(self):
         group_specs_num = len(self.opts.grp_specs)
 
-        self.skipped_grp_specs = self.base.repo_module_dict.upgrade(self.opts.grp_specs)
+        self.skipped_grp_specs = self.base.repo_module_dict.upgrade(self.opts.grp_specs, True)
 
         return len(self.skipped_grp_specs) != group_specs_num
 

--- a/dnf/module/exceptions.py
+++ b/dnf/module/exceptions.py
@@ -57,6 +57,14 @@ class VersionLockedException(dnf.exceptions.Error):
         super(VersionLockedException, self).__init__(value)
 
 
+class CannotLockVersionException(dnf.exceptions.Error):
+    def __init__(self, module_spec, version, reason=None):
+        value = "Cannot lock '{}' to version: {}".format(module_spec, version)
+        if reason:
+            value = "{}. {}".format(value, reason)
+        super(CannotLockVersionException, self).__init__(value)
+
+
 class NoProfileException(dnf.exceptions.Error):
     def __init__(self, profile):
         value = "No such profile: {}".format(profile)

--- a/dnf/module/repo_module_dict.py
+++ b/dnf/module/repo_module_dict.py
@@ -153,7 +153,7 @@ class RepoModuleDict(OrderedDict):
             version_dependencies = self.get_module_dependency(name, stream)
 
         for dependency in version_dependencies:
-            repos.update(dependency.repo)
+            repos.add(dependency.repo)
             includes.update(dependency.nevra())
 
         return includes, repos
@@ -201,6 +201,8 @@ class RepoModuleDict(OrderedDict):
         if save_immediately:
             self.base._module_persistor.commit()
             self.base._module_persistor.save()
+
+        self.base.use_module_includes()
 
     def disable(self, module_spec, save_immediately=False):
         subj = ModuleSubject(module_spec)

--- a/dnf/module/repo_module_dict.py
+++ b/dnf/module/repo_module_dict.py
@@ -644,7 +644,7 @@ class RepoModuleDict(OrderedDict):
             column_info.hidden = True
 
         for repo_id, versions in sorted(versions_by_repo.items(), key=lambda key: key[0]):
-            for i in sorted(versions, key=lambda data: data.name):
+            for i in sorted(versions, key=lambda data: (data.name, data.stream, data.version)):
                 line = table.new_line()
                 conf = i.repo_module.conf
                 defaults_conf = i.repo_module.defaults

--- a/dnf/module/repo_module_dict.py
+++ b/dnf/module/repo_module_dict.py
@@ -319,8 +319,7 @@ class RepoModuleDict(OrderedDict):
 
                 if module_form.profile:
                     profiles = [module_form.profile]
-                elif module_version.repo_module.defaults.stream == module_version.stream and \
-                        module_version.repo_module.defaults.profiles:
+                elif module_version.repo_module.defaults.profiles:
                     default_profiles = module_version.repo_module.defaults.profiles
                     profiles = []
                 else:

--- a/dnf/module/repo_module_dict.py
+++ b/dnf/module/repo_module_dict.py
@@ -227,9 +227,13 @@ class RepoModuleDict(OrderedDict):
 
         if not repo_module.conf.enabled:
             raise EnabledStreamException(module_spec)
+        elif repo_module.conf.locked and \
+                (repo_module.conf.stream != module_version.stream or
+                 repo_module.conf.version != module_version.version):
+            raise VersionLockedException(module_spec, module_version.version)
 
         version_to_lock = module_version.version
-        if module_version.repo_module.conf.profiles:
+        if repo_module.conf.profiles:
             version_to_lock = module_version.repo_module.conf.version
         repo_module.lock(version_to_lock)
 
@@ -237,7 +241,7 @@ class RepoModuleDict(OrderedDict):
             self.base._module_persistor.commit()
             self.base._module_persistor.save()
 
-        return module_version.stream, module_version.version
+        return module_version.stream, version_to_lock
 
     def unlock(self, module_spec, save_immediately=False):
         subj = ModuleSubject(module_spec)

--- a/dnf/module/repo_module_dict.py
+++ b/dnf/module/repo_module_dict.py
@@ -27,7 +27,7 @@ from dnf.module import module_messages, NOTHING_TO_SHOW, \
     INSTALLING_NEWER_VERSION, NOTHING_TO_INSTALL, VERSION_LOCKED, NO_PROFILE_SPECIFIED
 from dnf.module.exceptions import NoStreamSpecifiedException, NoModuleException, \
     EnabledStreamException, ProfileNotInstalledException, NoProfileSpecifiedException, \
-    NoProfileToRemoveException, VersionLockedException
+    NoProfileToRemoveException, VersionLockedException, CannotLockVersionException
 from dnf.module.repo_module import RepoModule
 from dnf.module.subject import ModuleSubject
 from dnf.subject import Subject
@@ -236,6 +236,10 @@ class RepoModuleDict(OrderedDict):
         if repo_module.conf.profiles:
             version_to_lock = module_version.repo_module.conf.version
         repo_module.lock(version_to_lock)
+
+        if module_form.version and version_to_lock != module_form.version:
+            raise CannotLockVersionException(module_spec, module_form.version,
+                                             "Different version installed.")
 
         if save_immediately:
             self.base._module_persistor.commit()


### PR DESCRIPTION
 * consistent sorting in module list
 * usage of includes also with defaults (needed for autoenabling based on rpms)
 * do not allow to lock different version when already locked
 * fail when trying to lock different version than installed