### PR TITLE
Remove short abbreviations of commands

### DIFF
--- a/dnf/cli/commands/distrosync.py
+++ b/dnf/cli/commands/distrosync.py
@@ -28,8 +28,7 @@ class DistroSyncCommand(commands.Command):
     distro-synch command.
     """
 
-    aliases = ('distro-sync', 'distrosync', 'distribution-synchronization', 'dup', 'dsync',
-               'dist-upgrade')
+    aliases = ('distro-sync', 'distrosync', 'distribution-synchronization')
     summary = _('synchronize installed packages to the latest available versions')
 
     @staticmethod

--- a/dnf/cli/commands/downgrade.py
+++ b/dnf/cli/commands/downgrade.py
@@ -30,7 +30,7 @@ class DowngradeCommand(commands.Command):
     downgrade command.
     """
 
-    aliases = ('downgrade', 'dg')
+    aliases = ('downgrade',)
     summary = _("Downgrade a package")
 
     @staticmethod

--- a/dnf/cli/commands/install.py
+++ b/dnf/cli/commands/install.py
@@ -40,7 +40,7 @@ class InstallCommand(commands.Command):
                    'install-na': hawkey.FORM_NA,
                    'install-nevra': hawkey.FORM_NEVRA}
 
-    aliases = ('install', 'localinstall', 'in') + tuple(nevra_forms.keys())
+    aliases = ('install', 'localinstall') + tuple(nevra_forms.keys())
     summary = _('install a package or packages on your system')
 
     @staticmethod

--- a/dnf/cli/commands/makecache.py
+++ b/dnf/cli/commands/makecache.py
@@ -33,7 +33,7 @@ logger = logging.getLogger("dnf")
 
 
 class MakeCacheCommand(commands.Command):
-    aliases = ('makecache', 'mc', 'refresh', 'ref')
+    aliases = ('makecache',)
     summary = _('generate the metadata cache')
 
     @staticmethod

--- a/dnf/cli/commands/reinstall.py
+++ b/dnf/cli/commands/reinstall.py
@@ -34,7 +34,7 @@ class ReinstallCommand(commands.Command):
     """A class containing methods needed by the cli to execute the reinstall command.
     """
 
-    aliases = ('reinstall', 'rei', 'ri')
+    aliases = ('reinstall',)
     summary = _('reinstall a package')
 
     @staticmethod

--- a/dnf/cli/commands/remove.py
+++ b/dnf/cli/commands/remove.py
@@ -42,7 +42,7 @@ class RemoveCommand(commands.Command):
                    'erase-na': hawkey.FORM_NA,
                    'erase-nevra': hawkey.FORM_NEVRA}
 
-    aliases = ('remove', 'erase', 'rm') + tuple(nevra_forms.keys())
+    aliases = ('remove', 'erase',) + tuple(nevra_forms.keys())
     summary = _('remove a package or packages from your system')
 
     @staticmethod

--- a/dnf/cli/commands/search.py
+++ b/dnf/cli/commands/search.py
@@ -39,7 +39,7 @@ class SearchCommand(commands.Command):
     search command.
     """
 
-    aliases = ('search', 'se')
+    aliases = ('search',)
     summary = _('search package details for the given string')
 
     @staticmethod

--- a/dnf/cli/commands/shell.py
+++ b/dnf/cli/commands/shell.py
@@ -48,7 +48,7 @@ class ShellDemandSheet(object):
 
 class ShellCommand(commands.Command, cmd.Cmd):
 
-    aliases = ('shell', 'sh')
+    aliases = ('shell',)
     summary = _('run an interactive DNF shell')
 
     MAPPING = {'repo': 'repo',

--- a/dnf/cli/commands/upgrade.py
+++ b/dnf/cli/commands/upgrade.py
@@ -34,7 +34,7 @@ class UpgradeCommand(commands.Command):
     """A class containing methods needed by the cli to execute the
     update command.
     """
-    aliases = ('upgrade', 'update', 'upgrade-to', 'update-to', 'up')
+    aliases = ('upgrade', 'update', 'upgrade-to', 'update-to')
     summary = _('upgrade a package or packages on your system')
 
     @staticmethod

--- a/dnf/cli/commands/upgrademinimal.py
+++ b/dnf/cli/commands/upgrademinimal.py
@@ -27,7 +27,7 @@ class UpgradeMinimalCommand(UpgradeCommand):
     command.
     """
 
-    aliases = ('upgrade-minimal', 'update-minimal', 'up-min', 'u-m', 'um')
+    aliases = ('upgrade-minimal', 'update-minimal')
     summary = _("upgrade, but only 'newest' package match which fixes a problem"
                 " that affects your system")
 


### PR DESCRIPTION
The proper solution here is to improve bash-completion. Aliases makes
bash-completion more difficult to use.

It reverts - 6a3c783bc35536a353dd389356dc4fde3f95e3d4