### PR TITLE
Better handling of output columns when used noninteractively (RhBug 1512956)

### DIFF
--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -1139,7 +1139,6 @@ class Output(object):
             columns = self.calcColumns(data, indent="  ", columns=columns,
                                        remainder_column=2)
             (n_wid, a_wid, v_wid, r_wid, s_wid) = columns
-            assert s_wid == 5
 
             out = [u"%s\n%s\n%s\n" % ('=' * self.term.columns,
                                       self.fmtColumns(((P_('Package', 'Packages', 1), -n_wid),

--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -241,7 +241,7 @@ class Output(object):
 
         # i'm not able to get real terminal width so i'm probably
         # running in non interactive terminal (pipe to grep, redirect to file...)
-        # just return maximal lengths of each data column.
+        # avoid splitting lines to enable filtering output
         if not total_width:
             full_columns = []
             for col in data:
@@ -250,7 +250,11 @@ class Output(object):
                 else:
                     full_columns.append(0)
             full_columns[0] += len(indent)
-            return full_columns
+            # if possible, try to keep default width (usually 80 columns)
+            default_width = self.term.columns
+            if sum(full_columns) > default_width:
+                return full_columns
+            total_width = default_width
 
         #  We start allocating 1 char to everything but the last column, and a
         # space between each (again, except for the last column). Because

--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -223,21 +223,34 @@ class Output(object):
            extra spaces that may remain after other allocation has
            taken place
         :param total_width: the total width of the output.
-           self.term.columns is used by default
+           self.term.real_columns is used by default
         :param indent: string that will be prefixed to a line of
            output to create e.g. an indent
         :return: a list of the widths of the columns that the fields
            in data should be placed into for output
         """
-        if total_width is None:
-            total_width = self.term.columns
-
         cols = len(data)
         # Convert the data to ascending list of tuples, (field_length, pkgs)
         pdata = data
         data = [None] * cols # Don't modify the passed in data
         for d in range(0, cols):
             data[d] = sorted(pdata[d].items())
+
+        if total_width is None:
+            total_width = self.term.real_columns
+
+        # i'm not able to get real terminal width so i'm probably
+        # running in non interactive terminal (pipe to grep, redirect to file...)
+        # just return maximal lengths of each data column.
+        if not total_width:
+            full_columns = []
+            for col in data:
+                if col:
+                    full_columns.append(col[-1][0])
+                else:
+                    full_columns.append(0)
+            full_columns[0] += len(indent)
+            return full_columns
 
         #  We start allocating 1 char to everything but the last column, and a
         # space between each (again, except for the last column). Because
@@ -1309,7 +1322,7 @@ Transaction Summary
         if remote_size <= 0:
             return
 
-        width = dnf.cli.term._term_width()
+        width = self.term.columns
         logger.info("-" * width)
         dl_time = max(0.01, time.time() - download_start_timestamp)
         msg = ' %5sB/s | %5sB %9s     ' % (

--- a/tests/cli/test_output.py
+++ b/tests/cli/test_output.py
@@ -90,16 +90,16 @@ class OutputTest(support.TestCase):
         self.base = support.MockBase('updates')
         self.output = dnf.cli.output.Output(self.base, self.base.conf)
 
-    @mock.patch('dnf.cli.term._term_width', return_value=80)
-    def test_col_widths(self, _term_width):
+    @mock.patch('dnf.cli.term._real_term_width', return_value=80)
+    def test_col_widths(self, _real_term_width):
         rows = (('pep', 'per', 'row',
                  '', 'lon', 'e'))
         self.assertCountEqual(self.output._col_widths(rows), (-38, -37, -1))
 
     @mock.patch('dnf.cli.output._', dnf.pycomp.NullTranslations().ugettext)
     @mock.patch('dnf.cli.output.P_', dnf.pycomp.NullTranslations().ungettext)
-    @mock.patch('dnf.cli.term._term_width', return_value=80)
-    def test_list_transaction(self, _term_width):
+    @mock.patch('dnf.cli.term._real_term_width', return_value=80)
+    def test_list_transaction(self, _real_term_width):
         sack = self.base.sack
         q = sack.query().filter(name='pepper')
         i = q.installed()[0]
@@ -175,8 +175,8 @@ class OutputTest(support.TestCase):
         self.assertEqual(input_fnc.called, 3)
 
     @mock.patch('dnf.cli.output._', dnf.pycomp.NullTranslations().ugettext)
-    @mock.patch('dnf.cli.term._term_width', lambda: 80)
-    def test_infoOutput_with_none_description(self):
+    @mock.patch('dnf.cli.term._real_term_width', return_value=80)
+    def test_infoOutput_with_none_description(self, _real_term_width):
         pkg = support.MockPackage('tour-5-0.noarch')
         pkg._from_system = False
         pkg._size = 0
@@ -235,16 +235,16 @@ class GroupOutputTest(unittest.TestCase):
         self.output = output
 
     @mock.patch('dnf.cli.output._', dnf.pycomp.NullTranslations().ugettext)
-    @mock.patch('dnf.cli.term._term_width', return_value=80)
-    def test_group_info(self, _term_width):
+    @mock.patch('dnf.cli.term._real_term_width', return_value=80)
+    def test_group_info(self, _real_term_width):
         group = self.base.comps.group_by_pattern('Peppers')
         with support.patch_std_streams() as (stdout, stderr):
             self.output.display_pkgs_in_groups(group)
         self.assertEqual(stdout.getvalue(), PKGS_IN_GROUPS_OUTPUT)
 
     @mock.patch('dnf.cli.output._', dnf.pycomp.NullTranslations().ugettext)
-    @mock.patch('dnf.cli.term._term_width', return_value=80)
-    def test_group_verbose_info(self, _term_width):
+    @mock.patch('dnf.cli.term._real_term_width', return_value=80)
+    def test_group_verbose_info(self, _real_term_width):
         group = self.base.comps.group_by_pattern('Peppers')
         self.base.set_debuglevel(dnf.const.VERBOSE_LEVEL)
         with support.patch_std_streams() as (stdout, stderr):
@@ -252,8 +252,8 @@ class GroupOutputTest(unittest.TestCase):
         self.assertEqual(stdout.getvalue(), PKGS_IN_GROUPS_VERBOSE_OUTPUT)
 
     @mock.patch('dnf.cli.output._', dnf.pycomp.NullTranslations().ugettext)
-    @mock.patch('dnf.cli.term._term_width', return_value=80)
-    def test_environment_info(self, _term_width):
+    @mock.patch('dnf.cli.term._real_term_width', return_value=80)
+    def test_environment_info(self, _real_term_width):
         env = self.base.comps.environments[0]
         with support.patch_std_streams() as (stdout, stderr):
             self.output.display_groups_in_environment(env)

--- a/tests/support.py
+++ b/tests/support.py
@@ -401,6 +401,7 @@ class MockTerminal(object):
     def __init__(self):
         self.MODE = {'bold'   : '', 'normal' : ''}
         self.columns = 80
+        self.real_columns = 80
         self.reinit = mock.Mock()
 
     def bold(self, s):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -234,7 +234,8 @@ class RepoPkgsCheckUpdateSubCommandTest(unittest.TestCase):
 
     """Tests of ``dnf.cli.commands.RepoPkgsCommand.CheckUpdateSubCommand`` class."""
 
-    def test(self):
+    @mock.patch('dnf.cli.term._real_term_width', return_value=80)
+    def test(self, _real_term_width):
         """ Test whether only upgrades in the repository are listed. """
         history = self.cli.base.history
         for pkg in self.cli.base.sack.query().installed().filter(name='tour'):


### PR DESCRIPTION
When not used in interactive terminal width of output colums is set to
maximal required size in order to avoid splitting output columns
into multiple lines.

https://bugzilla.redhat.com/show_bug.cgi?id=1512956