### PR TITLE
command_ref.rst: fix "–userinstalled"

### DIFF
--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -577,9 +577,9 @@ transactions and act according to this information (assuming the
     It will show all installonly packages, packages installed outside of DNF and packages not
     installed as dependency. I.e. it lists packages that will stay on the system when
     :ref:`\autoremove_command-label` or :ref:`\remove_command-label` along with
-    `clean_requirements_on_remove` configuration option set to True is executed. Same results can be
-    accomplished with "dnf repoquery --userinstalled" but repoquery command is much more powerful in
-    formatting of an output.
+    `clean_requirements_on_remove` configuration option set to True is executed. Note the same
+    results can be accomplished with ``dnf repoquery --userinstalled``, and the repoquery
+    command is more powerful in formatting of the output.
 
 This command by default does not force a sync of expired metadata.
 See also :ref:`\metadata_synchronization-label`


### PR DESCRIPTION
I noticed this being rendered as "–userinstalled" on Fedora 27 with dnf-2.7.5-1.fc27.noarch.
It should be "--userinstalled" instead.

It's surprising as the same text is fine in Fedora 26 with dnf-2.7.5-1.fc26.noarch.
I think it is very simple to "work around" this though.

I found the sentence confusing as well.  I have attempted to reword as necessary to avoid my own confusion.
Something about using "but" in this context made it sound as if it was about to explain
why the "repoquery" command is _not_ as powerful.  When what it actually goes on to say
is the exact opposite.