### PR TITLE
Add clarifications about metadata refresh rules

### DIFF
--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -581,7 +581,8 @@ transactions and act according to this information (assuming the
     results can be accomplished with ``dnf repoquery --userinstalled``, and the repoquery
     command is more powerful in formatting of the output.
 
-This command by default does not force a sync of expired metadata.
+This command by default does not force a sync of expired metadata, except for
+the redo, rollback, and undo subcommands.
 See also :ref:`\metadata_synchronization-label`
 and :ref:`\configuration_files_replacement_policy-label`.
 
@@ -1397,7 +1398,7 @@ Metadata Synchronization
 
 Correct operation of DNF depends on having access to up-to-date data from all enabled repositories but contacting remote mirrors on every operation considerably slows it down and costs bandwidth for both the client and the repository provider. The :ref:`metadata_expire <metadata_expire-label>` (see :manpage:`dnf.conf(5)`) repo config option is used by DNF to determine whether particular local copy of repository data is due to be re-synced. It is crucial that the repository providers set the option well, namely to a value where it is guaranteed that if particular metadata was available in time ``T`` on the server, then all packages it references will still be available for download from the server in time ``T + metadata_expire``.
 
-To further reduce the bandwidth load, some of the commands where having up-to-date metadata is not critical (e.g. the ``list`` command) do not look at whether a repository is expired and whenever any version of it is locally available, it will be used. Note that in all situations the user can force synchronization of all enabled repositories with the ``--refresh`` switch.
+To further reduce the bandwidth load, some of the commands where having up-to-date metadata is not critical (e.g. the ``list`` command) do not look at whether a repository is expired and whenever any version of it is locally available to the user's account, it will be used. For non-root use, see also the ``--cacheonly`` switch. Note that in all situations the user can force synchronization of all enabled repositories with the ``--refresh`` switch.
 
 .. _configuration_files_replacement_policy-label:
 


### PR DESCRIPTION
I've added a clarification that the history command does require metadata refreshes for specific subcommands (noted through code inspection), and a bit more detail to clarify and cross-reference what users can expect when running commands as non-root.
