### PR TITLE
variable cachedir referenced before assignment (RhBug 1511050)

### DIFF
--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -631,7 +631,8 @@ class MainConf(BaseConfig):
             try:
                 cachedir = logdir = misc.getCacheDir()
             except (IOError, OSError) as e:
-                logger.critical(_('Could not set cachedir: %s'), ucd(e))
+                msg = _('Could not set cachedir: {}').format(ucd(e))
+                raise dnf.exceptions.Error(msg)
 
         self._add_option('debuglevel',
                          IntOption(2, range_min=0, range_max=10)) # :api


### PR DESCRIPTION
we do not have writable directory, so exit with an error.
https://bugzilla.redhat.com/show_bug.cgi?id=1511050
