### PR TITLE
Keep all possibility of downgrade for solver

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1971,7 +1971,7 @@ class Base(object):
             msg = _('Packages for argument %s available, but not installed.') % pkg_spec
             raise dnf.exceptions.PackagesNotInstalledError(msg, pkg_spec, available_pkgs)
         for pkg_name in q_installed._name_dict().keys():
-            downgrade_pkgs = available_pkgs.downgrades().latest().filter(name=pkg_name)
+            downgrade_pkgs = available_pkgs.downgrades().filter(name=pkg_name)
             if not downgrade_pkgs:
                 msg = _("Package %s of lowest version already installed, cannot downgrade it.")
                 logger.warning(msg, pkg_name)

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -458,7 +458,9 @@ Downgrade Command
 -----------------
 
 ``dnf [options] downgrade <package-installed-specs>...``
-    Downgrades the specified packages to the highest of all known lower versions if possible. When version is given and is lower than version of installed package then it downgrades to target version.
+    Downgrades the specified packages to the highest installable package of all known lower versions
+    if possible. When version is given and is lower than version of installed package then it
+    downgrades to target version.
 
 .. _erase_command-label:
 


### PR DESCRIPTION
It allows to downgrade according to priority of repos, and skip broken best
candidates if they cannot be installed and use the first higher installable
version.