### PR TITLE
WIP: Detect ostree

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -737,9 +737,13 @@ class Cli(object):
         demands = self.demands
         repos = self.base.repos
 
-        if demands.root_user:
+        if demands.root_user or demands.root_writable:
             if not os.getegid() == 0:
                 raise dnf.exceptions.Error(_('This command has to be run under the root user.'))
+        # Are we processing a write command but without /usr writable?
+        if demands.root_writable and self.base.conf.installroot == '/':
+            if not os.access('/usr', os.W_OK):
+                raise dnf.exceptions.Error(_('/usr is not writable'))
 
         if not demands.cacheonly:
             if demands.freshest_metadata:

--- a/dnf/cli/commands/install.py
+++ b/dnf/cli/commands/install.py
@@ -58,7 +58,7 @@ class InstallCommand(commands.Command):
         demands.sack_activation = True
         demands.available_repos = True
         demands.resolving = True
-        demands.root_user = True
+        demands.root_writable = True
         commands._checkGPGKey(self.base, self.cli)
         if not self.opts.filenames:
             commands._checkEnabledRepo(self.base)

--- a/dnf/cli/demand.py
+++ b/dnf/cli/demand.py
@@ -48,6 +48,7 @@ class DemandSheet(object):
     available_repos = _BoolDefault(False)
     resolving = _BoolDefault(False)
     root_user = _BoolDefault(False)
+    root_writable = _BoolDefault(False)  # Like root_user, but will mutate
     sack_activation = _BoolDefault(False)
     success_exit_status = 0
 


### PR DESCRIPTION
This is a proposal, interested in feedback.  Currently `dnf` gets
pulled into Fedora Atomic Workstation due to dependencies, but
`rpm-ostree` is the hybrid image/package system that does host updates.

That said there's a whole big issue here we have:
https://github.com/projectatomic/rpm-ostree/issues/405

Basically we're talking about trying to redirect individual commands,
for example having `yum install foo` redirect you to `yum-img layer`
or something (where the latter would be `rpm-ostree install`).

There's a lot of things we could do if we tried to build this bridge;
for example rpm-ostree doesn't implement `search`, and I would be totally
fine delegating that to `dnf`.  (A lot of this is ideally shared in
libdnf but that's its own big topic)

Anyways this is a WIP proposal patch for feedback.

(BTW one interesting side note; if `ostree admin unlock` is used,
 then `dnf` returns to fully writable, just in the overlayfs on `/usr`
 mostly)