### PR TITLE
Allow reset append conf option from command line (RhBug:1512663)

### DIFF
--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -178,6 +178,9 @@ class ListAppendOption(ListOption):
 
     def _set(self, value, priority=PRIO_RUNTIME):
         """Append option's value"""
+        if value == '':
+            return super(ListAppendOption, self)._set(Value([], priority), priority)
+
         new = self._make_value(value, priority)
         if new.value is not None:
             if self._is_default():

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -313,7 +313,11 @@ Options
     upgrade command.
 
 ``--setopt=<option>=<value>``
-    override a config option from the config file. To override config options from repo files, use ``repoid.option`` for the ``<option>``.
+    override a config option from the config file. To override config options from repo files, use
+    ``repoid.option`` for the ``<option>``. Conf options like ``excludepkgs``, ``includepkgs``,
+    ``installonlypkgs``, and ``tsflags`` work as append option, therefore they are not overridden
+    but the value is appended. If there is no value like ``--setopt=tsflags=`` it remove all values
+    in append options.
 
 ``--skip-broken``
     Resolve depsolve problems by removing packages that are causing problems from the transaction.


### PR DESCRIPTION
It changes behavior for conf options excludepkgs, includepkgs, installonlypkgs,
and tsflags.

https://bugzilla.redhat.com/show_bug.cgi?id=1512663