### PR TITLE
doc: clarify info command argument

### DIFF
--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -598,7 +598,7 @@ and :ref:`\configuration_files_replacement_policy-label`.
 Info Command
 ------------
 
-``dnf [options] info [<package-spec>...]``
+``dnf [options] info [<package-name-spec>...]``
     Is used to list description and summary information about installed and available packages.
 
 This command by default does not force a sync of expired metadata. See also :ref:`\metadata_synchronization-label`.


### PR DESCRIPTION
Similar to `list`, the `info` command does not consult provides.  Use
`<package-name-spec>` rather than `<package-spec>` in the command
synopsis to make this clearer.

The `list` command documentation was updated in 026c9d74 ("doc: man
page: better describe the input patterns.", 2013-02-26) to reflect this
distinction.