### PR TITLE
Ensure command line parameter is utf-8 encodeable (RhBug 1525542)

### DIFF
--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -191,7 +191,8 @@ class InfoCommand(Command):
                              help=_("show only recently changed packages"))
         parser.add_argument('packages', nargs='*', metavar=_('PACKAGE'),
                             choices=cls.pkgnarrows, default=cls.DEFAULT_PKGNARROW,
-                            action=OptionParser.PkgNarrowCallback)
+                            action=OptionParser.PkgNarrowCallback,
+                            type=dnf.i18n.unicode_argument)
 
     def configure(self):
         demands = self.cli.demands
@@ -260,7 +261,8 @@ class CheckUpdateCommand(Command):
 
     @staticmethod
     def set_argparser(parser):
-        parser.add_argument('packages', nargs='*', metavar=_('PACKAGE'))
+        parser.add_argument('packages', nargs='*', metavar=_('PACKAGE'),
+                            type=dnf.i18n.unicode_argument)
 
     def configure(self):
         demands = self.cli.demands
@@ -759,7 +761,8 @@ class RepoPkgsCommand(Command):
                              help=_("show only recently changed packages"))
         parser.add_argument('pkg_specs', nargs='*', metavar=_('PACKAGE'),
                             choices=pkgnarrows, default=DEFAULT_PKGNARROW,
-                            action=OptionParser.PkgNarrowCallback)
+                            action=OptionParser.PkgNarrowCallback,
+                            type=dnf.i18n.unicode_argument)
 
     def configure(self):
         """Verify whether the command can run with given arguments."""

--- a/dnf/cli/commands/autoremove.py
+++ b/dnf/cli/commands/autoremove.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from dnf.cli import commands
 from dnf.cli.option_parser import OptionParser
-from dnf.i18n import _
+from dnf.i18n import _, unicode_argument
 
 import dnf.exceptions
 import hawkey
@@ -45,7 +45,8 @@ class AutoremoveCommand(commands.Command):
     def set_argparser(parser):
         parser.add_argument('packages', nargs='*', help=_('Package to remove'),
                             action=OptionParser.ParseSpecGroupFileCallback,
-                            metavar=_('PACKAGE'))
+                            metavar=_('PACKAGE'),
+                            type=unicode_argument)
 
     def configure(self):
         demands = self.cli.demands

--- a/dnf/cli/commands/distrosync.py
+++ b/dnf/cli/commands/distrosync.py
@@ -20,7 +20,7 @@
 
 from __future__ import absolute_import
 from dnf.cli import commands
-from dnf.i18n import _
+from dnf.i18n import _, unicode_argument
 
 
 class DistroSyncCommand(commands.Command):
@@ -33,7 +33,8 @@ class DistroSyncCommand(commands.Command):
 
     @staticmethod
     def set_argparser(parser):
-        parser.add_argument('package', nargs='*', help=_('Package to synchronize'))
+        parser.add_argument('package', nargs='*', help=_('Package to synchronize'),
+                            type=unicode_argument)
 
     def configure(self):
         demands = self.cli.demands

--- a/dnf/cli/commands/downgrade.py
+++ b/dnf/cli/commands/downgrade.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from dnf.cli import commands
 from dnf.cli.option_parser import OptionParser
-from dnf.i18n import _
+from dnf.i18n import _, unicode_argument
 
 
 class DowngradeCommand(commands.Command):
@@ -36,7 +36,8 @@ class DowngradeCommand(commands.Command):
     @staticmethod
     def set_argparser(parser):
         parser.add_argument('package', nargs='*', help=_('Package to downgrade'),
-                            action=OptionParser.ParseSpecGroupFileCallback)
+                            action=OptionParser.ParseSpecGroupFileCallback,
+                            type=unicode_argument)
 
     def configure(self):
         demands = self.cli.demands

--- a/dnf/cli/commands/install.py
+++ b/dnf/cli/commands/install.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from dnf.cli import commands
 from dnf.cli.option_parser import OptionParser
-from dnf.i18n import _
+from dnf.i18n import _, unicode_argument
 from itertools import chain
 
 import dnf.exceptions
@@ -46,8 +46,9 @@ class InstallCommand(commands.Command):
     @staticmethod
     def set_argparser(parser):
         parser.add_argument('package', nargs='+', metavar=_('PACKAGE'),
-                          action=OptionParser.ParseSpecGroupFileCallback,
-                          help=_('Package to install'))
+                            action=OptionParser.ParseSpecGroupFileCallback,
+                            help=_('Package to install'),
+                            type=unicode_argument)
 
     def configure(self):
         """Verify that conditions are met so that this command can run.

--- a/dnf/cli/commands/mark.py
+++ b/dnf/cli/commands/mark.py
@@ -20,7 +20,7 @@
 
 from __future__ import print_function
 from __future__ import unicode_literals
-from dnf.i18n import _
+from dnf.i18n import _, unicode_argument
 from dnf.cli import commands
 from hawkey import SwdbReason
 
@@ -40,7 +40,7 @@ class MarkCommand(commands.Command):
     def set_argparser(parser):
         parser.add_argument('mark', nargs=1, choices=['install', 'remove', 'group'],
                             metavar='[ install | remove | group ]')
-        parser.add_argument('package', nargs='+')
+        parser.add_argument('package', nargs='+', type=unicode_argument)
 
     def _mark_install(self, pkg):
         self.base.history.set_reason(pkg, SwdbReason.USER)

--- a/dnf/cli/commands/reinstall.py
+++ b/dnf/cli/commands/reinstall.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from dnf.cli import commands
 from dnf.cli.option_parser import OptionParser
-from dnf.i18n import _
+from dnf.i18n import _, unicode_argument
 
 import dnf.exceptions
 import logging
@@ -41,7 +41,8 @@ class ReinstallCommand(commands.Command):
     def set_argparser(parser):
         parser.add_argument('packages', nargs='+', help=_('Package to reinstall'),
                             action=OptionParser.ParseSpecGroupFileCallback,
-                            metavar=_('PACKAGE'))
+                            metavar=_('PACKAGE'),
+                            type=unicode_argument)
 
     def configure(self):
         """Verify that conditions are met so that this command can

--- a/dnf/cli/commands/remove.py
+++ b/dnf/cli/commands/remove.py
@@ -21,7 +21,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from dnf.cli import commands
-from dnf.i18n import _
+from dnf.i18n import _, unicode_argument
 from dnf.cli.option_parser import OptionParser
 
 import argparse
@@ -58,7 +58,8 @@ class RemoveCommand(commands.Command):
                                 'remove installonly packages over the limit'))
         parser.add_argument('packages', nargs='*', help=_('Package to remove'),
                             action=OptionParser.ParseSpecGroupFileCallback,
-                            metavar=_('PACKAGE'))
+                            metavar=_('PACKAGE'),
+                            type=unicode_argument)
 
     def configure(self):
         demands = self.cli.demands

--- a/dnf/cli/commands/upgrade.py
+++ b/dnf/cli/commands/upgrade.py
@@ -21,7 +21,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from dnf.cli import commands
-from dnf.i18n import _
+from dnf.i18n import _, unicode_argument
 from dnf.cli.option_parser import OptionParser
 
 import dnf.exceptions
@@ -41,7 +41,8 @@ class UpgradeCommand(commands.Command):
     def set_argparser(parser):
         parser.add_argument('packages', nargs='*', help=_('Package to upgrade'),
                             action=OptionParser.ParseSpecGroupFileCallback,
-                            metavar=_('PACKAGE'))
+                            metavar=_('PACKAGE'),
+                            type=unicode_argument)
 
     def configure(self):
         """Verify that conditions are met so that this command can run.

--- a/dnf/i18n.py
+++ b/dnf/i18n.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from dnf.pycomp import unicode
 
+from argparse import ArgumentTypeError
 import dnf
 import locale
 import os
@@ -115,6 +116,21 @@ def ucd_input(ucstring):
     """
     print(ucstring, end='')
     return dnf.pycomp.raw_input()
+
+
+def unicode_argument(val):
+    """
+    Type checking for ArgumentParser to ensure that command line
+    argument can be converted to unicode with utf-8 encoding.
+    """
+    if dnf.pycomp.PY3:
+        try:
+            val.encode('utf-8')
+        except UnicodeEncodeError:
+            raise ArgumentTypeError(str(sys.exc_info()[1]))
+        return val
+    else:
+        return val.decode(sys.getfilesystemencoding())
 
 
 def ucd(obj):


### PR DESCRIPTION
when creating Subject object, we expect that pattern
is in utf-8 encoding. Otherwise, UnicodeError is raised.

https://bugzilla.redhat.com/show_bug.cgi?id=1525542