### PR TITLE
Use geteuid() instead of getegid() to see if we're root

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -738,7 +738,7 @@ class Cli(object):
         repos = self.base.repos
 
         if demands.root_user:
-            if not os.getegid() == 0:
+            if not os.geteuid() == 0:
                 raise dnf.exceptions.Error(_('This command has to be run under the root user.'))
 
         if demands.cacheonly or self.base.conf.cacheonly:


### PR DESCRIPTION
On upgrading from Fedora 24 to 27, the following has started happening:

```
# dnf update
Error: This command has to be run under the root user.
```

This is caused by PR 746, which moved the dnf privilege check from a core plugin called "noroot" (where allegedly it didn't work) into dnf itself. But the old code and the replacement aren't quite the same. The old code checked os.geteuid()==0:

https://github.com/rpm-software-management/dnf-plugins-core/commit/51b736021d4c86437761714cf25dd3bf91d9e9e3#diff-63dc9087c660611bdf3fcb1a1257247a

But the new code instead checks os.getegid()==0:

https://github.com/rpm-software-management/dnf/commit/d5820006274a42f7292a933152fbae89c315cd03

So if you're running with your primary gid set to 0, you pass the new check, but it's not sufficient for dnf to function. It proceeds to refresh the metadata, download new packages (into /tmp because it can't actually write the main cachedir), then fails when it attempts to install them because gid 0 is not enough to update the system.

OTOH if you're running as uid 0, but have a non-zero primary gid, the check fails and dnf refuses to run, even though uid 0 is sufficient to do anything it needs to and the primary gid is immaterial.

I can't see any mention of the change (the PR claims it's just moving the code from one place to another) nor justification for it, so I assume it's just a typo that slipped in during the move...
