### PR TITLE
enable using --downloaddir for system-upgrade command

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -36,7 +36,7 @@
 As a Yum CLI compatibility layer, supplies /usr/bin/yum redirecting to DNF.
 
 Name:           dnf
-Version:        2.8.8
+Version:        2.8.9
 Release:        1%{?dist}
 Summary:        Package manager forked from Yum, using libsolv as a dependency resolver
 # For a breakdown of the licensing, see PACKAGE-LICENSING

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -819,7 +819,8 @@ class Cli(object):
             sys.exit(1)
         if opts.destdir is not None:
             self.base.conf.destdir = opts.destdir
-            if not self.base.conf.downloadonly and opts.command != 'download':
+            if not self.base.conf.downloadonly and opts.command not in (
+                    'download', 'system-upgrade'):
                 logger.critical(
                     _('--destdir must be used with --downloadonly or download command.')
                 )

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -169,8 +169,9 @@ Options
 
 ``--downloaddir=<path>``
     Redirect downloaded packages to provided directory. The option has to by used together with \-\
-    :ref:`-downloadonly <downloadonly-label>` command line option or with ``download`` command
-    (dnf-plugins-core).
+    :ref:`-downloadonly <downloadonly-label>` command line option or with
+    ``download`` command (dnf-plugins-core) or with ``system-upgrade`` command
+    (dnf-plugins-extras).
 
 .. _downloadonly-label:
 


### PR DESCRIPTION
version bump, this feature is required by dnf-plugins-extras
system-upgrade command for enabling the --downloaddir option

Required by https://github.com/rpm-software-management/dnf-plugins-extras/pull/118