### PR TITLE
invalid comps file parsing error (RhBug:1537957)

### DIFF
--- a/dnf/comps.py
+++ b/dnf/comps.py
@@ -326,11 +326,12 @@ class Comps(object):
 
     def _add_from_xml_filename(self, fn):
         comps = libcomps.Comps()
-        ret = comps.fromxml_f(fn)
-        if ret == -1:
-            errors = comps.get_last_parse_errors()
+        try:
+            comps.fromxml_f(fn)
+        except libcomps.ParserError:
+            errors = comps.get_last_errors()
             raise CompsError(' '.join(errors))
-        self._i = self._i + comps
+        self._i += comps
 
     @property
     def categories(self):


### PR DESCRIPTION
libcomps fromxml_f() function never returns -1. It raises
the ParserError exception instead.

https://bugzilla.redhat.com/show_bug.cgi?id=1537957