### PR TITLE
Refactor base in tests

### DIFF
--- a/dnf/db/history.py
+++ b/dnf/db/history.py
@@ -90,6 +90,8 @@ class SwdbInterface(object):
         self._group = GroupPersistor(self.swdb)
 
     def close(self):
+        if not self._swdb:
+            return
         return self.swdb.close()
 
     def add_package(self, pkg):

--- a/tests/automatic/__init__.py
+++ b/tests/automatic/__init__.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2014 Red Hat, Inc.
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2014-2018 Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of

--- a/tests/automatic/test_emitter.py
+++ b/tests/automatic/test_emitter.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2014 Red Hat, Inc.
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2014-2018 Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -17,9 +19,12 @@
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from tests.support import mock, mock_open
+
 import dnf.automatic.emitter
+
 import tests.support
+from tests.support import mock, mock_open
+
 
 MSG = """\
 downloaded on myhost:
@@ -46,4 +51,3 @@ class TestMotdEmitter(tests.support.TestCase):
                 emitter.commit()
             handle = m()
             handle.write.assert_called_once_with(MSG)
-

--- a/tests/automatic/test_main.py
+++ b/tests/automatic/test_main.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2014 Red Hat, Inc.
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2014-2018 Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -14,12 +16,17 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
 import dnf.automatic.main
+
 import tests.support
 
+
 FILE = tests.support.resource_path('etc/automatic.conf')
+
 
 class TestConfig(tests.support.TestCase):
     def test_load(self):

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2014 Red Hat, Inc.
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2014-2018 Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of

--- a/tests/cli/commands/__init__.py
+++ b/tests/cli/commands/__init__.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2014 Red Hat, Inc.
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2014-2018 Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of

--- a/tests/cli/commands/test_autoremove.py
+++ b/tests/cli/commands/test_autoremove.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2014-2016 Red Hat, Inc.
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2014-2018 Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -16,17 +18,19 @@
 #
 
 from __future__ import absolute_import
-from tests import support
-from dnf.cli.option_parser import OptionParser
+
 from hawkey import SwdbReason
 
 import dnf.cli.commands.autoremove as autoremove
+from dnf.cli.option_parser import OptionParser
+
+import tests.support
 
 
-class AutoRemoveCommandTest(support.ResultTestCase):
+class AutoRemoveCommandTest(tests.support.ResultTestCase):
 
     def test_run(self):
-        base = support.MockBase()
+        base = tests.support.MockBase()
         q = base.sack.query()
         pkgs = list(q.filter(name='librita')) + list(q.filter(name='pepper'))
         history = base.history

--- a/tests/cli/commands/test_autoremove.py
+++ b/tests/cli/commands/test_autoremove.py
@@ -29,21 +29,22 @@ import tests.support
 
 class AutoRemoveCommandTest(tests.support.ResultTestCase):
 
-    def test_run(self):
-        base = tests.support.MockBase()
-        q = base.sack.query()
-        pkgs = list(q.filter(name='librita')) + list(q.filter(name='pepper'))
-        history = base.history
-        for pkg in pkgs:
-            history.set_reason(pkg, SwdbReason.USER)
+    REPOS = []
+    CLI = "mock"
 
-        cli = base.mock_cli()
-        cmd = autoremove.AutoremoveCommand(cli)
+    def test_run(self):
+        q = self.base.sack.query()
+        pkgs = list(q.filter(name='librita')) + list(q.filter(name='pepper'))
+        for pkg in pkgs:
+            self.history.set_reason(pkg, SwdbReason.USER)
+
+        cmd = autoremove.AutoremoveCommand(self.cli)
         parser = OptionParser()
         parser.parse_main_args(['autoremove', '-y'])
         parser.parse_command_args(cmd, ['autoremove', '-y'])
         cmd.run()
-        inst, rem = self.installed_removed(base)
+
+        inst, rem = self.installed_removed(self.base)
         self.assertEmpty(inst)
         removed = ('librita-1-1.i686',
                    'librita-1-1.x86_64',

--- a/tests/cli/commands/test_clean.py
+++ b/tests/cli/commands/test_clean.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2014-2016 Red Hat, Inc.
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2014-2018 Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -17,30 +19,31 @@
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
+import os
 from io import StringIO
-from tests import support
-from tests.support import mock
 
 import dnf.cli.cli
-import dnf.cli.commands.clean as clean
-import os
+
 import tests.support
+from tests.support import mock
 
 
 def _run(cli, args):
-    with mock.patch('sys.stdout', new_callable=StringIO) as stdout, \
-         mock.patch('dnf.rpm.detect_releasever', return_value=69):
+    with mock.patch('sys.stdout', new_callable=StringIO), \
+            mock.patch('dnf.rpm.detect_releasever', return_value=69):
         cli.configure(['clean', '--config', '/dev/null'] + args)
         cli.run()
+
 
 class CleanTest(tests.support.TestCase):
     def setUp(self):
         conf = dnf.conf.Conf()
-        base = support.Base(conf)
-        base.repos.add(support.MockRepo('main', conf))
+        base = tests.support.Base(conf)
+        base.repos.add(tests.support.MockRepo('main', conf))
         base.conf.reposdir = '/dev/null'
         base.conf.plugins = False
-        base.output = support.MockOutput()
+        base.output = tests.support.MockOutput()
 
         repo = base.repos['main']
         repo.baseurl = ['http:///dnf-test']

--- a/tests/cli/commands/test_group.py
+++ b/tests/cli/commands/test_group.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2014-2016 Red Hat, Inc.
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2014-2018 Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -16,19 +18,20 @@
 #
 
 from __future__ import absolute_import
-from tests import support
-from dnf.comps import CompsQuery
-from dnf.cli.option_parser import OptionParser
 
 import dnf.cli.commands.group as group
 import dnf.comps
 import dnf.exceptions
+from dnf.comps import CompsQuery
+from dnf.cli.option_parser import OptionParser
+
+import tests.support
 
 
-class GroupCommandStaticTest(support.TestCase):
+class GroupCommandStaticTest(tests.support.TestCase):
 
     def test_canonical(self):
-        cmd = group.GroupCommand(support.mock.MagicMock())
+        cmd = group.GroupCommand(tests.support.mock.MagicMock())
 
         for args, out in [
                 (['grouplist', 'crack'], ['list', 'crack']),
@@ -43,17 +46,17 @@ class GroupCommandStaticTest(support.TestCase):
             self.assertEqual(cmd.opts.args, out[1:])
 
     def test_split_extcmds(self):
-        cmd = group.GroupCommand(support.mock.MagicMock())
+        cmd = group.GroupCommand(tests.support.mock.MagicMock())
         cmd.base.conf = dnf.conf.Conf()
-        support.command_run(cmd, ['install', 'crack'])
+        tests.support.command_run(cmd, ['install', 'crack'])
         cmd.base.env_group_install.assert_called_with(
             ['crack'], ('mandatory', 'default', 'conditional'),
             cmd.base.conf.strict)
 
 
-class GroupCommandTest(support.TestCase):
+class GroupCommandTest(tests.support.TestCase):
     def setUp(self):
-        base = support.MockBase("main")
+        base = tests.support.MockBase("main")
         base.read_mock_comps()
         base.init_sack()
         self.cmd = group.GroupCommand(base.mock_cli())
@@ -66,18 +69,18 @@ class GroupCommandTest(support.TestCase):
         self.assertEqual(env_avail[0].name, 'Sugar Desktop Environment')
 
     def test_configure(self):
-        support.command_configure(self.cmd, ['remove', 'crack'])
+        tests.support.command_configure(self.cmd, ['remove', 'crack'])
         demands = self.cmd.cli.demands
         self.assertTrue(demands.allow_erasing)
         self.assertFalse(demands.freshest_metadata)
 
 
-class CompsQueryTest(support.TestCase):
+class CompsQueryTest(tests.support.TestCase):
 
     def setUp(self):
-        self.base = support.MockBase()
+        self.base = tests.support.MockBase()
         self.history = self.base.history
-        self.comps = support.mock_comps(self.history, True)
+        self.comps = tests.support.mock_comps(self.history, True)
         self.prst = self.history.group
 
     def test_all(self):

--- a/tests/cli/commands/test_makecache.py
+++ b/tests/cli/commands/test_makecache.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2014-2016 Red Hat, Inc.
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2014-2018 Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -16,16 +18,17 @@
 #
 
 from __future__ import absolute_import
-from tests import support
-from tests.support import mock
+
 import dnf.cli.commands.makecache as makecache
 import dnf.pycomp
-import tempfile
+
+import tests.support
+from tests.support import mock
 
 
-class MakeCacheCommandTest(support.TestCase):
+class MakeCacheCommandTest(tests.support.TestCase):
     def setUp(self):
-        self.base = support.MockBase('main')
+        self.base = tests.support.MockBase('main')
         self.cli = self.base.mock_cli()
         for r in self.base.repos.values():
             r.basecachedir = self.base.conf.cachedir
@@ -33,13 +36,13 @@ class MakeCacheCommandTest(support.TestCase):
     @staticmethod
     @mock.patch('dnf.Base.fill_sack', new=mock.MagicMock())
     def _do_makecache(cmd):
-        return support.command_run(cmd, ['timer'])
+        return tests.support.command_run(cmd, ['timer'])
 
     def assert_last_info(self, logger, msg):
         self.assertEqual(logger.info.mock_calls[-1], mock.call(msg))
 
     @mock.patch('dnf.base.logger',
-                new_callable=support.mock_logger)
+                new_callable=tests.support.mock_logger)
     @mock.patch('dnf.cli.commands._', dnf.pycomp.NullTranslations().ugettext)
     @mock.patch('dnf.util.on_ac_power', return_value=True)
     def test_makecache_timer(self, _on_ac_power, logger):
@@ -49,14 +52,14 @@ class MakeCacheCommandTest(support.TestCase):
         self.assertFalse(self._do_makecache(cmd))
         self.assert_last_info(logger, u'Metadata timer caching disabled.')
 
-        self.base.conf.metadata_timer_sync = 5 # resync after 5 seconds
+        self.base.conf.metadata_timer_sync = 5  # resync after 5 seconds
         self.base._repo_persistor.since_last_makecache = mock.Mock(return_value=3)
         self.assertFalse(self._do_makecache(cmd))
         self.assert_last_info(logger, u'Metadata cache refreshed recently.')
 
         self.base._repo_persistor.since_last_makecache = mock.Mock(return_value=10)
         self.base._sack = 'nonempty'
-        r = support.MockRepo("glimpse", self.base.conf)
+        r = tests.support.MockRepo("glimpse", self.base.conf)
         self.base.repos.add(r)
 
         # regular case 1: metadata is already expired:
@@ -84,7 +87,7 @@ class MakeCacheCommandTest(support.TestCase):
         self.assertTrue(r._expired)
 
     @mock.patch('dnf.base.logger',
-                new_callable=support.mock_logger)
+                new_callable=tests.support.mock_logger)
     @mock.patch('dnf.cli.commands._', dnf.pycomp.NullTranslations().ugettext)
     @mock.patch('dnf.util.on_ac_power', return_value=False)
     def test_makecache_timer_battery(self, _on_ac_power, logger):

--- a/tests/cli/commands/test_makecache.py
+++ b/tests/cli/commands/test_makecache.py
@@ -26,10 +26,13 @@ import tests.support
 from tests.support import mock
 
 
-class MakeCacheCommandTest(tests.support.TestCase):
+class MakeCacheCommandTest(tests.support.DnfBaseTestCase):
+
+    REPOS = ['main']
+    CLI = "mock"
+
     def setUp(self):
-        self.base = tests.support.MockBase('main')
-        self.cli = self.base.mock_cli()
+        super(MakeCacheCommandTest, self).setUp()
         for r in self.base.repos.values():
             r.basecachedir = self.base.conf.cachedir
 

--- a/tests/cli/commands/test_remove.py
+++ b/tests/cli/commands/test_remove.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2014-2016 Red Hat, Inc.
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2014-2018 Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -17,20 +19,23 @@
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from tests import support
-from tests.support import mock
-from dnf.cli.option_parser import OptionParser
 
-import dnf.cli.commands.remove
 import logging
 
-class RemoveCommandTest(support.ResultTestCase):
+import dnf.cli.commands.remove
+from dnf.cli.option_parser import OptionParser
+
+import tests.support
+from tests.support import mock
+
+
+class RemoveCommandTest(tests.support.ResultTestCase):
     """Tests of ``dnf.cli.commands.EraseCommand`` class."""
 
     def setUp(self):
         """Prepare the test fixture."""
         super(RemoveCommandTest, self).setUp()
-        base = support.BaseCliStub()
+        base = tests.support.BaseCliStub()
         base.init_sack()
         self.cmd = dnf.cli.commands.remove.RemoveCommand(base.mock_cli())
 
@@ -47,8 +52,8 @@ class RemoveCommandTest(support.ResultTestCase):
         """Test whether it fails if the package cannot be found."""
         stdout = dnf.pycomp.StringIO()
 
-        with support.wiretap_logs('dnf', logging.INFO, stdout):
-            self.assertRaises(dnf.exceptions.Error, support.command_run, self.cmd,
+        with tests.support.wiretap_logs('dnf', logging.INFO, stdout):
+            self.assertRaises(dnf.exceptions.Error, tests.support.command_run, self.cmd,
                               ['non-existent'])
 
         self.assertEqual(stdout.getvalue(),

--- a/tests/cli/commands/test_repolist.py
+++ b/tests/cli/commands/test_repolist.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2014-2016 Red Hat, Inc.
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2014-2018 Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -19,7 +21,9 @@ from __future__ import absolute_import
 
 import dnf.cli.commands.repolist as repolist
 import dnf.repo
+
 import tests.support
+
 
 class TestRepolist(tests.support.TestCase):
 

--- a/tests/cli/commands/test_search.py
+++ b/tests/cli/commands/test_search.py
@@ -27,10 +27,14 @@ import tests.support
 from tests import mock
 
 
-class SearchCountedTest(tests.support.TestCase):
+class SearchCountedTest(tests.support.DnfBaseTestCase):
+
+    REPOS = ["main"]
+    CLI = "mock"
+
     def setUp(self):
-        base = tests.support.MockBase("main")
-        self.cmd = search.SearchCommand(base.mock_cli())
+        super(SearchCountedTest, self).setUp()
+        self.cmd = search.SearchCommand(self.cli)
 
     def test_search_counted(self):
         counter = dnf.match_counter.MatchCounter()
@@ -48,12 +52,16 @@ class SearchCountedTest(tests.support.TestCase):
         self.assertEqual(len(counter), 1)
 
 
-class SearchTest(tests.support.TestCase):
+class SearchTest(tests.support.DnfBaseTestCase):
+
+    REPOS = ["search"]
+    CLI = "mock"
+
     def setUp(self):
-        self.base = tests.support.MockBase("search")
+        super(SearchTest, self).setUp()
         self.base.output = mock.MagicMock()
         self.base.output.fmtSection = lambda str: str
-        self.cmd = search.SearchCommand(self.base.mock_cli())
+        self.cmd = search.SearchCommand(self.cli)
 
     def patched_search(self, *args):
         with tests.support.patch_std_streams() as (stdout, _):

--- a/tests/cli/commands/test_search.py
+++ b/tests/cli/commands/test_search.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2014  Red Hat, Inc.
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2014-2018 Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -16,16 +18,18 @@
 #
 
 from __future__ import absolute_import
-from tests import support
-from tests import mock
 
 import dnf.cli.commands.search as search
 import dnf.match_counter
 import dnf.pycomp
 
-class SearchCountedTest(support.TestCase):
+import tests.support
+from tests import mock
+
+
+class SearchCountedTest(tests.support.TestCase):
     def setUp(self):
-        base = support.MockBase("main")
+        base = tests.support.MockBase("main")
         self.cmd = search.SearchCommand(base.mock_cli())
 
     def test_search_counted(self):
@@ -43,16 +47,17 @@ class SearchCountedTest(support.TestCase):
         self.cmd._search_counted(counter, 'summary', '*invit*')
         self.assertEqual(len(counter), 1)
 
-class SearchTest(support.TestCase):
+
+class SearchTest(tests.support.TestCase):
     def setUp(self):
-        self.base = support.MockBase("search")
+        self.base = tests.support.MockBase("search")
         self.base.output = mock.MagicMock()
         self.base.output.fmtSection = lambda str: str
         self.cmd = search.SearchCommand(self.base.mock_cli())
 
     def patched_search(self, *args):
-        with support.patch_std_streams() as (stdout, _):
-            support.command_run(self.cmd, *args)
+        with tests.support.patch_std_streams() as (stdout, _):
+            tests.support.command_run(self.cmd, *args)
             call_args = self.base.output.matchcallback.call_args_list
             pkgs = [c[0][0] for c in call_args]
             return (stdout.getvalue(), pkgs)

--- a/tests/cli/commands/test_updateinfo.py
+++ b/tests/cli/commands/test_updateinfo.py
@@ -35,16 +35,18 @@ import tests.support
 from tests.support import mock
 
 
-class UpdateInfoCommandTest(tests.support.TestCase):
+class UpdateInfoCommandTest(tests.support.DnfBaseTestCase):
 
     """Test case validating updateinfo commands."""
+
+    REPOS = []
+    CLI = "mock"
 
     def setUp(self):
         """Prepare the test fixture."""
         super(UpdateInfoCommandTest, self).setUp()
         cachedir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, cachedir)
-        self.cli = tests.support.MockBase().mock_cli()
         self.cli.base.conf.cachedir = cachedir
         self.cli.base.add_test_dir_repo('rpm', self.cli.base.conf)
         self._stdout = dnf.pycomp.StringIO()

--- a/tests/cli/commands/test_updateinfo.py
+++ b/tests/cli/commands/test_updateinfo.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2014-2016 Red Hat, Inc.
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2014-2018 Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -20,14 +22,17 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import datetime
-import dnf.pycomp
-import dnf.cli.commands.updateinfo
-import hawkey
 import itertools
 import shutil
 import tempfile
-import tests.mock
+
+import hawkey
+
+import dnf.pycomp
+import dnf.cli.commands.updateinfo
+
 import tests.support
+from tests.support import mock
 
 
 class UpdateInfoCommandTest(tests.support.TestCase):
@@ -43,11 +48,11 @@ class UpdateInfoCommandTest(tests.support.TestCase):
         self.cli.base.conf.cachedir = cachedir
         self.cli.base.add_test_dir_repo('rpm', self.cli.base.conf)
         self._stdout = dnf.pycomp.StringIO()
-        self.addCleanup(tests.mock.patch.stopall)
-        tests.support.mock.patch(
+        self.addCleanup(mock.patch.stopall)
+        mock.patch(
             'dnf.cli.commands.updateinfo._',
             dnf.pycomp.NullTranslations().ugettext).start()
-        tests.support.mock.patch(
+        mock.patch(
             'dnf.cli.commands.updateinfo.print',
             self._stub_print, create=True).start()
 
@@ -179,18 +184,21 @@ class UpdateInfoCommandTest(tests.support.TestCase):
              for apkg in adv.packages))
         cmd = dnf.cli.commands.updateinfo.UpdateInfoCommand(self.cli)
         cmd.display_list(apkg_adv_insts, True, '')
-        self.assertEqual(self._stdout.getvalue(),
-                         'i DNF-2014-1 bugfix       tour-4-4.noarch\n'
-                         'i DNF-2014-2 enhancement  tour-5-0.noarch\n'
-                         '  DNF-2014-3 Unknown/Sec. tour-5-1.noarch\n',
-                         'incorrect output')
+        self.assertEqual(
+            self._stdout.getvalue(),
+            'i DNF-2014-1 bugfix       tour-4-4.noarch\n'
+            'i DNF-2014-2 enhancement  tour-5-0.noarch\n'
+            '  DNF-2014-3 Unknown/Sec. tour-5-1.noarch\n',
+            'incorrect output'
+        )
 
     def test_display_info_verbose(self):
         """Test verbose displaying."""
-        apkg_adv_insts = ((apkg, adv, False)
-                     for pkg in self.cli.base.sack.query().installed()
-                     for adv in pkg.get_advisories(hawkey.GT)
-                     for apkg in adv.packages)
+        apkg_adv_insts = (
+            (apkg, adv, False) for pkg in self.cli.base.sack.query().installed()
+            for adv in pkg.get_advisories(hawkey.GT)
+            for apkg in adv.packages
+        )
         self.cli.base.set_debuglevel(dnf.const.VERBOSE_LEVEL)
         cmd = dnf.cli.commands.updateinfo.UpdateInfoCommand(self.cli)
         cmd.display_info(apkg_adv_insts, False, '')

--- a/tests/cli/test_demand.py
+++ b/tests/cli/test_demand.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2014  Red Hat, Inc.
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2014-2018 Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -13,12 +15,15 @@
 # source code or documentation are not subject to the GNU General Public
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
+#
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import dnf.cli.demand
+
 import tests.support
+
 
 class DemandTest(tests.support.TestCase):
 

--- a/tests/cli/test_option_parser.py
+++ b/tests/cli/test_option_parser.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2012-2016 Red Hat, Inc.
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2012-2018 Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -17,14 +19,16 @@
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from dnf.cli.option_parser import OptionParser
-from tests import support
-from tests.support import mock
 
-import argparse
+from dnf.cli.option_parser import OptionParser
+
 import dnf.cli.commands
 import dnf.pycomp
 import dnf.util
+
+import tests.support
+from tests.support import mock
+
 
 def _parse(command, args):
     parser = OptionParser()
@@ -32,7 +36,8 @@ def _parse(command, args):
     opts = parser.parse_command_args(command, args)
     return parser, opts
 
-class OptionParserTest(support.TestCase):
+
+class OptionParserTest(tests.support.TestCase):
     def setUp(self):
         self.cli = mock.Mock()
         self.command = MyTestCommand(self.cli)
@@ -62,7 +67,7 @@ class MyTestCommand2(dnf.cli.commands.Command):
         dnf.cli.commands.Command.__init__(self, cli)
 
 
-class OptionParserAddCmdTest(support.TestCase):
+class OptionParserAddCmdTest(tests.support.TestCase):
 
     def setUp(self):
         self.cli_commands = {}

--- a/tests/cli/test_output.py
+++ b/tests/cli/test_output.py
@@ -79,7 +79,10 @@ class OutputFunctionsTest(tests.support.TestCase):
                          [('tour', 0, 1, 2, 3), ('', 4, 5, 6, 7)])
 
 
-class OutputTest(tests.support.TestCase):
+class OutputTest(tests.support.DnfBaseTestCase):
+
+    REPOS = ['updates']
+
     @staticmethod
     def _keyboard_interrupt(*ignored):
         raise KeyboardInterrupt
@@ -89,7 +92,7 @@ class OutputTest(tests.support.TestCase):
         raise EOFError
 
     def setUp(self):
-        self.base = tests.support.MockBase('updates')
+        super(OutputTest, self).setUp()
         self.output = dnf.cli.output.Output(self.base, self.base.conf)
 
     @mock.patch('dnf.cli.term._real_term_width', return_value=80)
@@ -228,14 +231,14 @@ Environment Group: Sugar Desktop Environment
 """
 
 
-class GroupOutputTest(tests.support.TestCase):
-    def setUp(self):
-        base = tests.support.MockBase('main')
-        base.read_mock_comps()
-        output = dnf.cli.output.Output(base, base.conf)
+class GroupOutputTest(tests.support.DnfBaseTestCase):
 
-        self.base = base
-        self.output = output
+    REPOS = ['main']
+    COMPS = True
+
+    def setUp(self):
+        super(GroupOutputTest, self).setUp()
+        self.output = dnf.cli.output.Output(self.base, self.base.conf)
 
     @mock.patch('dnf.cli.output._', dnf.pycomp.NullTranslations().ugettext)
     @mock.patch('dnf.cli.term._real_term_width', return_value=80)

--- a/tests/cli/test_output.py
+++ b/tests/cli/test_output.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2012-2016  Red Hat, Inc.
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2012-2018 Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -17,16 +19,18 @@
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from tests import support
-from tests.support import mock
+
 from hawkey import SwdbReason
 
 import dnf.cli.output
 import dnf.const
 import dnf.transaction
-import unittest
 
-INFOOUTPUT_OUTPUT="""\
+import tests.support
+from tests.support import mock
+
+
+INFOOUTPUT_OUTPUT = """\
 Name         : tour
 Epoch        : 1
 Version      : 5
@@ -41,7 +45,7 @@ License      : GPL+
 Description  : 
 """
 
-LIST_TRANSACTION_OUTPUT=u"""\
+LIST_TRANSACTION_OUTPUT = u"""\
 ================================================================================
  Package           Arch              Version           Repository          Size
 ================================================================================
@@ -55,10 +59,8 @@ Upgrade  1 Package
 """
 
 
-class OutputFunctionsTest(support.TestCase):
+class OutputFunctionsTest(tests.support.TestCase):
     def test_make_lists(self):
-        TSI = dnf.transaction.TransactionItem
-
         goal = mock.Mock(get_reason=lambda x: SwdbReason.USER)
         ts = dnf.transaction.Transaction()
         ts.add_install('pepper-3', [])
@@ -77,7 +79,7 @@ class OutputFunctionsTest(support.TestCase):
                          [('tour', 0, 1, 2, 3), ('', 4, 5, 6, 7)])
 
 
-class OutputTest(support.TestCase):
+class OutputTest(tests.support.TestCase):
     @staticmethod
     def _keyboard_interrupt(*ignored):
         raise KeyboardInterrupt
@@ -87,7 +89,7 @@ class OutputTest(support.TestCase):
         raise EOFError
 
     def setUp(self):
-        self.base = support.MockBase('updates')
+        self.base = tests.support.MockBase('updates')
         self.output = dnf.cli.output.Output(self.base, self.base.conf)
 
     @mock.patch('dnf.cli.term._real_term_width', return_value=80)
@@ -158,7 +160,7 @@ class OutputTest(support.TestCase):
         self.assertTrue(self.output.userconfirm())
 
     class _InputGenerator(object):
-        INPUT=['haha', 'dada', 'n']
+        INPUT = ['haha', 'dada', 'n']
 
         def __init__(self):
             self.called = 0
@@ -177,7 +179,7 @@ class OutputTest(support.TestCase):
     @mock.patch('dnf.cli.output._', dnf.pycomp.NullTranslations().ugettext)
     @mock.patch('dnf.cli.term._real_term_width', return_value=80)
     def test_infoOutput_with_none_description(self, _real_term_width):
-        pkg = support.MockPackage('tour-5-0.noarch')
+        pkg = tests.support.MockPackage('tour-5-0.noarch')
         pkg._from_system = False
         pkg._size = 0
         pkg._pkgid = None
@@ -225,9 +227,10 @@ Environment Group: Sugar Desktop Environment
    Base
 """
 
-class GroupOutputTest(unittest.TestCase):
+
+class GroupOutputTest(tests.support.TestCase):
     def setUp(self):
-        base = support.MockBase('main')
+        base = tests.support.MockBase('main')
         base.read_mock_comps()
         output = dnf.cli.output.Output(base, base.conf)
 
@@ -238,7 +241,7 @@ class GroupOutputTest(unittest.TestCase):
     @mock.patch('dnf.cli.term._real_term_width', return_value=80)
     def test_group_info(self, _real_term_width):
         group = self.base.comps.group_by_pattern('Peppers')
-        with support.patch_std_streams() as (stdout, stderr):
+        with tests.support.patch_std_streams() as (stdout, stderr):
             self.output.display_pkgs_in_groups(group)
         self.assertEqual(stdout.getvalue(), PKGS_IN_GROUPS_OUTPUT)
 
@@ -247,7 +250,7 @@ class GroupOutputTest(unittest.TestCase):
     def test_group_verbose_info(self, _real_term_width):
         group = self.base.comps.group_by_pattern('Peppers')
         self.base.set_debuglevel(dnf.const.VERBOSE_LEVEL)
-        with support.patch_std_streams() as (stdout, stderr):
+        with tests.support.patch_std_streams() as (stdout, stderr):
             self.output.display_pkgs_in_groups(group)
         self.assertEqual(stdout.getvalue(), PKGS_IN_GROUPS_VERBOSE_OUTPUT)
 
@@ -255,6 +258,6 @@ class GroupOutputTest(unittest.TestCase):
     @mock.patch('dnf.cli.term._real_term_width', return_value=80)
     def test_environment_info(self, _real_term_width):
         env = self.base.comps.environments[0]
-        with support.patch_std_streams() as (stdout, stderr):
+        with tests.support.patch_std_streams() as (stdout, stderr):
             self.output.display_groups_in_environment(env)
         self.assertEqual(stdout.getvalue(), GROUPS_IN_ENVIRONMENT_OUTPUT)

--- a/tests/cli/test_term.py
+++ b/tests/cli/test_term.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2014  Red Hat, Inc.
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2014-2018 Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -13,16 +15,21 @@
 # source code or documentation are not subject to the GNU General Public
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
+#
+
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from tests.support import mock
-import dnf.cli.term
+
 import io
-import unittest
+
+import dnf.cli.term
+
+import tests.support
+from tests.support import mock
 
 
-class TermTest(unittest.TestCase):
+class TermTest(tests.support.TestCase):
 
     """Tests of ```dnf.cli.term.Term``` class."""
 
@@ -35,7 +42,9 @@ class TermTest(unittest.TestCase):
         tty = mock.create_autospec(io.IOBase)
         tty.isatty.return_value = True
 
-        tigetstr = lambda name: '<cap_%(name)s>' % locals()
+        def tigetstr(name):
+            return '<cap_%(name)s>' % locals()
+
         with mock.patch('curses.tigetstr', autospec=True, side_effect=tigetstr):
             term = dnf.cli.term.Term(tty)
 

--- a/tests/conf/__init__.py
+++ b/tests/conf/__init__.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2014  Red Hat, Inc.
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2014-2018 Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -14,4 +16,3 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-

--- a/tests/conf/test_parser.py
+++ b/tests/conf/test_parser.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2014  Red Hat, Inc.
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2014-2018 Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -17,13 +19,15 @@
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
+
 from dnf.conf.parser import substitute
 
 import tests.support
 
+
 class SubstituteTest(tests.support.TestCase):
     def test_read(self):
-        substs = {'lies' : 'fact'}
+        substs = {'lies': 'fact'}
         # Test a single word without braces
         rawstr = '$Substitute some $lies.'
         result = '$Substitute some fact.'

--- a/tests/conf/test_read.py
+++ b/tests/conf/test_read.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2014  Red Hat, Inc.
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2014-2018 Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -18,11 +20,14 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import tests.support
 import dnf.conf
 import dnf.conf.read
 
+import tests.support
+
+
 FN = tests.support.resource_path('etc/repos.conf')
+
 
 class RepoReaderTest(tests.support.TestCase):
     def test_read(self):

--- a/tests/plugins/disabled-plugin.py
+++ b/tests/plugins/disabled-plugin.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2016  Red Hat, Inc.
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2016-2018 Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -16,7 +18,9 @@
 #
 
 from __future__ import unicode_literals
+
 import dnf.plugin
+
 
 class DisabledPlugin(dnf.plugin.Plugin):
 

--- a/tests/plugins/lucky.py
+++ b/tests/plugins/lucky.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2013-2016 Red Hat, Inc.
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2013-2018 Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -16,7 +18,9 @@
 #
 
 from __future__ import unicode_literals
+
 import dnf.plugin
+
 
 class LuckyPlugin(dnf.plugin.Plugin):
 

--- a/tests/support.py
+++ b/tests/support.py
@@ -77,10 +77,10 @@ TRACEBACK_RE = re.compile(
     r'(?:    .+\n)?)+'
     r'\S.*\n)')
 REASONS = {
-    'hole'      : 'group',
-    'pepper'    : 'group',
-    'right'     : 'dep',
-    'tour'      : 'group',
+    'hole': 'group',
+    'pepper': 'group',
+    'right': 'dep',
+    'tour': 'group',
     'trampoline': 'group',
 }
 RPMDB_CHECKSUM = '47655615e9eae2d339443fa00065d41900f99baf'
@@ -421,7 +421,7 @@ class MockQuery(dnf.query.Query):
 
 class MockTerminal(object):
     def __init__(self):
-        self.MODE = {'bold'   : '', 'normal' : ''}
+        self.MODE = {'bold': '', 'normal': ''}
         self.columns = 80
         self.real_columns = 80
         self.reinit = mock.Mock()
@@ -452,46 +452,48 @@ class FakeConf(dnf.conf.Conf):
     def __init__(self, **kwargs):
         super(FakeConf, self).__init__()
         self.substitutions['releasever'] = 'Fedora69'
-        for optname, val in [
-                ('assumeyes', None),
-                ('best', False),
-                ('cachedir', dnf.const.TMPDIR),
-                ('clean_requirements_on_remove', False),
-                ('color', 'never'),
-                ('color_update_installed', 'normal'),
-                ('color_update_remote', 'normal'),
-                ('color_list_available_downgrade', 'dim'),
-                ('color_list_available_install', 'normal'),
-                ('color_list_available_reinstall', 'bold'),
-                ('color_list_available_upgrade', 'bold'),
-                ('color_list_installed_extra', 'bold'),
-                ('color_list_installed_newer', 'bold'),
-                ('color_list_installed_older', 'bold'),
-                ('color_list_installed_reinstall', 'normal'),
-                ('color_update_local', 'bold'),
-                ('debug_solver', False),
-                ('debuglevel', 2),
-                ('defaultyes', False),
-                ('disable_excludes', []),
-                ('diskspacecheck', True),
-                ('exclude', []),
-                ('include', []),
-                ('install_weak_deps', True),
-                ('history_record', False),
-                ('installonly_limit', 0),
-                ('installonlypkgs', ['kernel']),
-                ('installroot', '/'),
-                ('ip_resolve', None),
-                ('multilib_policy', 'best'),
-                ('obsoletes', True),
-                ('persistdir', '/tmp/swdb/'),
-                ('transformdb', False),
-                ('protected_packages', ["dnf"]),
-                ('plugins', False),
-                ('showdupesfromrepos', False),
-                ('tsflags', []),
-                ('strict', True),
-                ] + list(kwargs.items()):
+        options = [
+            ('assumeyes', None),
+            ('best', False),
+            ('cachedir', dnf.const.TMPDIR),
+            ('clean_requirements_on_remove', False),
+            ('color', 'never'),
+            ('color_update_installed', 'normal'),
+            ('color_update_remote', 'normal'),
+            ('color_list_available_downgrade', 'dim'),
+            ('color_list_available_install', 'normal'),
+            ('color_list_available_reinstall', 'bold'),
+            ('color_list_available_upgrade', 'bold'),
+            ('color_list_installed_extra', 'bold'),
+            ('color_list_installed_newer', 'bold'),
+            ('color_list_installed_older', 'bold'),
+            ('color_list_installed_reinstall', 'normal'),
+            ('color_update_local', 'bold'),
+            ('debug_solver', False),
+            ('debuglevel', 2),
+            ('defaultyes', False),
+            ('disable_excludes', []),
+            ('diskspacecheck', True),
+            ('exclude', []),
+            ('include', []),
+            ('install_weak_deps', True),
+            ('history_record', False),
+            ('installonly_limit', 0),
+            ('installonlypkgs', ['kernel']),
+            ('installroot', '/'),
+            ('ip_resolve', None),
+            ('multilib_policy', 'best'),
+            ('obsoletes', True),
+            ('persistdir', '/tmp/swdb/'),
+            ('transformdb', False),
+            ('protected_packages', ["dnf"]),
+            ('plugins', False),
+            ('showdupesfromrepos', False),
+            ('tsflags', []),
+            ('strict', True),
+        ] + list(kwargs.items())
+
+        for optname, val in options:
             setattr(self, optname, dnf.conf.Value(val, dnf.conf.PRIO_DEFAULT))
 
     @property

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -149,9 +149,11 @@ class BuildTransactionTest(tests.support.TestCase):
         base = tests.support.MockBase("updates")
         base.upgrade("pepper")
         self.assertTrue(base.resolve())
-        base._ds_callback.assert_has_calls([mock.call.start(),
-                                            mock.call.pkg_added(mock.ANY, 'ud'),
-                                            mock.call.pkg_added(mock.ANY, 'u')])
+        base._ds_callback.assert_has_calls([
+            mock.call.start(),
+            mock.call.pkg_added(mock.ANY, 'ud'),
+            mock.call.pkg_added(mock.ANY, 'u')
+        ])
         self.assertLength(base.transaction, 1)
 
 

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -21,8 +21,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import unittest
-
 import dnf.cli.commands.check
 import dnf.pycomp
 
@@ -39,7 +37,7 @@ test-1-0.noarch is obsoleted by obs-3-0.noarch
 """
 
 
-class CheckDuplicatesTest(unittest.TestCase):
+class CheckDuplicatesTest(tests.support.TestCase):
     def test_duplicates(self):
         self.cmd = dnf.cli.commands.check.CheckCommand(
             tests.support.CliStub(tests.support.BaseCliStub()))

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -37,10 +37,14 @@ test-1-0.noarch is obsoleted by obs-3-0.noarch
 """
 
 
-class CheckDuplicatesTest(tests.support.TestCase):
+class CheckDuplicatesTest(tests.support.DnfBaseTestCase):
+
+    REPOS = []
+    BASE_CLI = True
+    CLI = "stub"
+
     def test_duplicates(self):
-        self.cmd = dnf.cli.commands.check.CheckCommand(
-            tests.support.CliStub(tests.support.BaseCliStub()))
+        self.cmd = dnf.cli.commands.check.CheckCommand(self.cli)
         tests.support.command_configure(self.cmd, ['--duplicates'])
         with tests.support.patch_std_streams() as (stdout, _):
             with self.assertRaises(dnf.exceptions.Error) as ctx:
@@ -50,8 +54,7 @@ class CheckDuplicatesTest(tests.support.TestCase):
         self.assertEqual(stdout.getvalue(), EXPECTED_DUPLICATES_FORMAT)
 
     def test_obsoleted(self):
-        self.cmd = dnf.cli.commands.check.CheckCommand(
-            tests.support.CliStub(tests.support.BaseCliStub()))
+        self.cmd = dnf.cli.commands.check.CheckCommand(self.cli)
         tests.support.command_configure(self.cmd, ['--obsoleted'])
         with tests.support.patch_std_streams() as (stdout, _):
             with self.assertRaises(dnf.exceptions.Error) as ctx:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -23,7 +23,6 @@ from __future__ import unicode_literals
 import itertools
 import logging
 import tempfile
-import unittest
 
 import dnf.cli.commands
 import dnf.cli.commands.group
@@ -222,7 +221,7 @@ class ReinstallCommandTest(tests.support.ResultTestCase):
         self.assertResult(base, base.sack.query().installed())
 
 
-class RepoPkgsCommandTest(unittest.TestCase):
+class RepoPkgsCommandTest(tests.support.TestCase):
 
     """Tests of ``dnf.cli.commands.RepoPkgsCommand`` class."""
 
@@ -241,7 +240,7 @@ class RepoPkgsCommandTest(unittest.TestCase):
         self.assertEqual(exit.exception.code, 1)
 
 
-class RepoPkgsCheckUpdateSubCommandTest(unittest.TestCase):
+class RepoPkgsCheckUpdateSubCommandTest(tests.support.TestCase):
 
     """Tests of ``dnf.cli.commands.RepoPkgsCommand.CheckUpdateSubCommand`` class."""
 
@@ -287,7 +286,7 @@ class RepoPkgsCheckUpdateSubCommandTest(unittest.TestCase):
         self.assertNotEqual(self.cli.demands.success_exit_status, 100)
 
 
-class RepoPkgsInfoSubCommandTest(unittest.TestCase):
+class RepoPkgsInfoSubCommandTest(tests.support.TestCase):
 
     """Tests of ``dnf.cli.commands.RepoPkgsCommand.InfoSubCommand`` class."""
 
@@ -480,10 +479,11 @@ class RepoPkgsInstallSubCommandTest(tests.support.ResultTestCase):
         cmd = dnf.cli.commands.RepoPkgsCommand(self.cli)
         tests.support.command_run(cmd, ['third_party', 'install'])
 
+        q = self.cli.base.sack.query()
         self.assertResult(self.cli.base, itertools.chain(
-            self.cli.base.sack.query().installed(),
-            self.cli.base.sack.query().available().filter(reponame='third_party',
-                                                          arch='x86_64', name__neq='hole')))
+            q.installed(),
+            q.available().filter(reponame='third_party', arch='x86_64', name__neq='hole'))
+        )
 
 
 class RepoPkgsMoveToSubCommandTest(tests.support.ResultTestCase):
@@ -536,7 +536,7 @@ class RepoPkgsReinstallOldSubCommandTest(tests.support.ResultTestCase):
         )
 
 
-class RepoPkgsReinstallSubCommandTest(unittest.TestCase):
+class RepoPkgsReinstallSubCommandTest(tests.support.TestCase):
 
     """Tests of ``dnf.cli.commands.RepoPkgsCommand.ReinstallSubCommand`` class."""
 
@@ -773,10 +773,11 @@ class RepoPkgsUpgradeSubCommandTest(tests.support.ResultTestCase):
         cmd = dnf.cli.commands.RepoPkgsCommand(self.cli)
         tests.support.command_run(cmd, ['third_party', 'upgrade'])
 
-        self.assertResult(self.cli.base, itertools.chain(
-            self.cli.base.sack.query().installed().filter(name__neq='hole'),
-            self.cli.base.sack.query().upgrades().filter(reponame='third_party',
-                                                         arch='x86_64')))
+        q = self.base.sack.query()
+        self.assertResult(self.base, itertools.chain(
+            q.installed().filter(name__neq='hole'),
+            q.upgrades().filter(reponame='third_party', arch='x86_64'))
+        )
 
 
 class UpgradeCommandTest(tests.support.ResultTestCase):

--- a/tests/test_comps.py
+++ b/tests/test_comps.py
@@ -169,19 +169,11 @@ class TestTransactionBunch(tests.support.TestCase):
         self.assertEmpty(t1.remove)
 
 
-class SolverTestMixin(object):
+class SolverGroupTest(tests.support.DnfBaseTestCase):
 
-    def setUp(self):
-        comps = dnf.comps.Comps()
-        comps._add_from_xml_filename(tests.support.COMPS_PATH)
-        self.comps = comps
-        self.base = tests.support.MockBase()
-        self.history = self.base.history
-        self.persistor = self.history.group
-        self.solver = dnf.comps.Solver(self.persistor, self.comps, tests.support.REASONS.get)
-
-
-class SolverGroupTest(SolverTestMixin, tests.support.TestCase):
+    REPOS = []
+    COMPS = True
+    COMPS_SOLVER = True
 
     def test_install(self):
         grp = self.comps.group_by_pattern('base')
@@ -260,7 +252,11 @@ class SolverGroupTest(SolverTestMixin, tests.support.TestCase):
         self.assertCountEqual(p_grp.get_full_list(), ('tour', 'pepper'))
 
 
-class SolverEnvironmentTest(SolverTestMixin, tests.support.TestCase):
+class SolverEnvironmentTest(tests.support.DnfBaseTestCase):
+
+    REPOS = []
+    COMPS = True
+    COMPS_SOLVER = True
 
     def _install(self, env, ex=True):
         exclude = ('lotus',) if ex else []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,7 +20,6 @@
 from __future__ import unicode_literals
 
 import argparse
-import unittest
 
 import dnf.conf
 import dnf.conf.read
@@ -31,7 +30,7 @@ import tests.support
 from tests.support import mock
 
 
-class OptionTest(unittest.TestCase):
+class OptionTest(tests.support.TestCase):
 
     class Cfg(BaseConfig):
         def __init__(self):
@@ -50,7 +49,7 @@ class OptionTest(unittest.TestCase):
         self.assertEqual(cfg.a_setting, "turn left")
 
 
-class CacheTest(unittest.TestCase):
+class CacheTest(tests.support.TestCase):
 
     @mock.patch('dnf.util.am_i_root', return_value=True)
     @mock.patch('dnf.const.SYSTEM_CACHEDIR', '/var/lib/spinning')
@@ -70,7 +69,7 @@ class CacheTest(unittest.TestCase):
         self.assertEqual(fn_getcachedir.call_count, 1)
 
 
-class ConfTest(unittest.TestCase):
+class ConfTest(tests.support.TestCase):
 
     def test_bugtracker(self):
         conf = Conf()

--- a/tests/test_distsync.py
+++ b/tests/test_distsync.py
@@ -22,15 +22,13 @@ from __future__ import unicode_literals
 
 import rpm
 
-import dnf.goal
-
 import tests.support
 
 
 class DistroSyncAll(tests.support.ResultTestCase):
-    def setUp(self):
-        self.base = tests.support.MockBase("distro")
-        self.sack = self.base.sack
+
+    REPOS = ["distro"]
+    INIT_SACK = True
 
     def test_distro_sync_all(self):
         self.base.distro_sync()
@@ -42,18 +40,17 @@ class DistroSyncAll(tests.support.ResultTestCase):
 
 
 class DistroSync(tests.support.ResultTestCase):
-    def setUp(self):
-        self._base = tests.support.BaseCliStub()
-        self._base._sack = tests.support.mock_sack('main', 'updates')
-        self._base._goal = dnf.goal.Goal(self._base.sack)
+
+    REPOS = ["main", "updates"]
+    BASE_CLI = True
 
     def test_distro_sync(self):
-        installed = self._get_installed(self._base)
+        installed = self._get_installed(self.base)
         original_pkg = list(filter(lambda p: p.name == "hole", installed))
-        self._base.distro_sync_userlist(('bla', 'hole'))
+        self.base.distro_sync_userlist(('bla', 'hole'))
         obsolete_pkg = list(filter(lambda p: p.name == "tour", installed))
 
-        installed2 = self._get_installed(self._base)
+        installed2 = self._get_installed(self.base)
         updated_pkg = list(filter(lambda p: p.name == "hole", installed2))
         self.assertLength(updated_pkg, 1)
         self.assertLength(original_pkg, 1)

--- a/tests/test_downgrade.py
+++ b/tests/test_downgrade.py
@@ -31,68 +31,70 @@ from tests.support import mock
 
 class DowngradeTest(tests.support.ResultTestCase):
 
+    REPOS = ["main"]
+    INIT_SACK = True
+
     @mock.patch('dnf.rpm.transaction.TransactionWrapper')
     def test_package_downgrade(self, ts):
-        base = tests.support.MockBase()
-
-        pkgs = base.add_remote_rpms([tests.support.TOUR_44_PKG_PATH])
-        cnt = base.package_downgrade(pkgs[0])
-        base._ts.setProbFilter.assert_called_with(
+        pkgs = self.base.add_remote_rpms([tests.support.TOUR_44_PKG_PATH])
+        cnt = self.base.package_downgrade(pkgs[0])
+        self.base._ts.setProbFilter.assert_called_with(
             rpm.RPMPROB_FILTER_OLDPACKAGE)
         self.assertGreater(cnt, 0)
-        (installed, removed) = self.installed_removed(base)
+        (installed, removed) = self.installed_removed(self.base)
         self.assertCountEqual(map(str, installed), ("tour-4-4.noarch", ))
         self.assertCountEqual(map(str, removed), ("tour-5-0.noarch", ))
 
     def test_downgrade(self):
-        base = tests.support.MockBase("main")
-        sack = base.sack
-        cnt = base.downgrade("tour")
+        cnt = self.base.downgrade("tour")
         self.assertGreater(cnt, 0)
 
-        new_pkg = sack.query().available().filter(name="tour")[0]
+        new_pkg = self.base.sack.query().available().filter(name="tour")[0]
         self.assertEqual(new_pkg.evr, "4.6-1")
-        new_set = tests.support.installed_but(sack, "tour") + [new_pkg]
-        self.assertResult(base, new_set)
+        new_set = tests.support.installed_but(self.base.sack, "tour") + [new_pkg]
+        self.assertResult(self.base, new_set)
 
     def test_downgrade2(self):
-        b = tests.support.MockBase("old_versions")
-        b.downgrade("tour")
-        installed, removed = self.installed_removed(b)
+        # override base with custom repos
+        self.base = tests.support.MockBase("old_versions")
+        self.base.downgrade("tour")
+        installed, removed = self.installed_removed(self.base)
         self.assertCountEqual(map(str, installed), ['tour-4.9-1.noarch'])
         self.assertCountEqual(map(str, removed), ['tour-5-0.noarch'])
 
 
-class DowngradeTest2(tests.support.TestCase):
+class DowngradeTest2(tests.support.DnfBaseTestCase):
+
+    REPOS = ["main"]
+    INIT_SACK = True
 
     def setUp(self):
-        self._base = tests.support.MockBase()
-        self._base._sack = tests.support.mock_sack('main')
-        self._base._goal = self._goal = mock.create_autospec(dnf.goal.Goal)
+        super(DowngradeTest2, self).setUp()
+        self.base._goal = mock.create_autospec(dnf.goal.Goal)
 
     def test_downgrade_pkgnevra(self):
         """ Downgrade should handle full NEVRAs. """
         tests.support.ObjectMatcher(dnf.package.Package, {'name': 'tour'})
         with self.assertRaises(dnf.exceptions.PackagesNotInstalledError):
-            self._base.downgrade('tour-0:5-0.noarch')
+            self.base.downgrade('tour-0:5-0.noarch')
 
     def test_downgrade_notinstalled(self):
         pkg = tests.support.ObjectMatcher(dnf.package.Package, {'name': 'lotus'})
 
         with self.assertRaises(dnf.exceptions.PackagesNotInstalledError) as context:
-            self._base.downgrade('lotus')
+            self.base.downgrade('lotus')
         self.assertEqual(context.exception.pkg_spec, 'lotus')
         self.assertEqual(tuple(context.exception.packages), (pkg,) * 2)
-        self.assertEqual(self._goal.mock_calls, [])
+        self.assertEqual(self.goal.mock_calls, [])
 
     def test_downgrade_notfound(self):
         with self.assertRaises(dnf.exceptions.PackageNotFoundError) as context:
-            self._base.downgrade('non-existent')
+            self.base.downgrade('non-existent')
         self.assertEqual(context.exception.pkg_spec, 'non-existent')
-        self.assertEqual(self._goal.mock_calls, [])
+        self.assertEqual(self.goal.mock_calls, [])
 
     def test_downgrade_nodowngrade(self):
-        downgraded_count = self._base.downgrade('pepper')
+        downgraded_count = self.base.downgrade('pepper')
 
-        self.assertEqual(self._goal.mock_calls, [])
+        self.assertEqual(self.goal.mock_calls, [])
         self.assertEqual(downgraded_count, 0)

--- a/tests/test_downgrade_to.py
+++ b/tests/test_downgrade_to.py
@@ -27,8 +27,7 @@ import tests.support
 
 class DowngradeTo(tests.support.ResultTestCase):
 
-    def setUp(self):
-        self.base = tests.support.MockBase('main', 'old_versions')
+    REPOS = ['main', 'old_versions']
 
     def test_downgrade_to_lowest(self):
         with tests.support.mock.patch('logging.Logger.warning'):

--- a/tests/test_drpm.py
+++ b/tests/test_drpm.py
@@ -72,11 +72,15 @@ class Proggress_3(dnf.cli.progress.MultiFileProgressMeter):
         self.rate = None
 
 
-class DrpmTest(tests.support.TestCase):
+class DrpmTest(tests.support.DnfBaseTestCase):
+
+    REPOS = []
+
     def setUp(self):
+        super(DrpmTest, self).setUp()
+
         cachedir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, cachedir)
-        self.base = tests.support.MockBase()
         self.base.conf.cachedir = tests.support.USER_RUNDIR
 
         # load the testing repo

--- a/tests/test_goal.py
+++ b/tests/test_goal.py
@@ -28,11 +28,10 @@ import dnf.selector
 import tests.support
 
 
-class GoalTest(tests.support.TestCase):
-    def setUp(self):
-        base = tests.support.MockBase('main')
-        self.sack = base.sack
-        self.goal = dnf.goal.Goal(self.sack)
+class GoalTest(tests.support.DnfBaseTestCase):
+
+    REPOS = ['main']
+    INIT_SACK = True
 
     def test_get_reason(self):
         sltr = dnf.selector.Selector(self.sack)
@@ -40,22 +39,20 @@ class GoalTest(tests.support.TestCase):
         grp_sltr = dnf.selector.Selector(self.sack)
         grp_sltr.set(name='lotus')
 
-        goal = self.goal
-        goal.install(select=sltr)
-        goal.install(select=grp_sltr)
-        goal.group_members.add('lotus')
-        goal.run()
-        installs = goal.list_installs()
+        self.goal.install(select=sltr)
+        self.goal.install(select=grp_sltr)
+        self.goal.group_members.add('lotus')
+        self.goal.run()
+        installs = self.goal.list_installs()
         mrkite = [pkg for pkg in installs if pkg.name == 'mrkite'][0]
         lotus = [pkg for pkg in installs if pkg.name == 'lotus'][0]
         trampoline = [pkg for pkg in installs if pkg.name == 'trampoline'][0]
-        self.assertEqual(goal.get_reason(lotus), SwdbReason.GROUP)
-        self.assertEqual(goal.get_reason(mrkite), SwdbReason.USER)
-        self.assertEqual(goal.get_reason(trampoline), SwdbReason.DEP)
+        self.assertEqual(self.goal.get_reason(lotus), SwdbReason.GROUP)
+        self.assertEqual(self.goal.get_reason(mrkite), SwdbReason.USER)
+        self.assertEqual(self.goal.get_reason(trampoline), SwdbReason.DEP)
 
     def test_group_reason(self):
-        goal = self.goal
         hole = self.sack.query().filter(name='hole')[0]
-        goal.group_members.add('hole')
-        self.assertEqual(SwdbReason.GROUP, goal.group_reason(hole, SwdbReason.GROUP))
-        self.assertEqual(SwdbReason.DEP, goal.group_reason(hole, SwdbReason.DEP))
+        self.goal.group_members.add('hole')
+        self.assertEqual(SwdbReason.GROUP, self.goal.group_reason(hole, SwdbReason.GROUP))
+        self.assertEqual(SwdbReason.DEP, self.goal.group_reason(hole, SwdbReason.DEP))

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -81,13 +81,34 @@ class NEVRAOperationsTest(tests.support.TestCase):
     def test_add_obsoleted_obsoleted(self):
         """Test add with an obsoleted NEVRA which was obsoleted before."""
         ops = dnf.history.NEVRAOperations()
-        ops.add('Install', 'tour-0:4.6-1.noarch', obsoleted_nevras=('lotus-0:3-16.x86_64', 'mrkite-0:2-0.x86_64'))
-        ops.add('Install', 'pepper-0:20-0.x86_64', obsoleted_nevras=('lotus-0:3-16.x86_64', 'librita-0:1-1.x86_64'))
+        ops.add(
+            'Install',
+            'tour-0:4.6-1.noarch',
+            obsoleted_nevras=('lotus-0:3-16.x86_64', 'mrkite-0:2-0.x86_64')
+        )
+        ops.add(
+            'Install',
+            'pepper-0:20-0.x86_64',
+            obsoleted_nevras=('lotus-0:3-16.x86_64', 'librita-0:1-1.x86_64')
+        )
 
         self.assertCountEqual(
             ops,
-            (('Install', 'tour-0:4.6-1.noarch', None, {'lotus-0:3-16.x86_64', 'mrkite-0:2-0.x86_64'}),
-             ('Install', 'pepper-0:20-0.x86_64', None, {'lotus-0:3-16.x86_64', 'librita-0:1-1.x86_64'})))
+            (
+                (
+                    'Install',
+                    'tour-0:4.6-1.noarch',
+                    None,
+                    {'lotus-0:3-16.x86_64', 'mrkite-0:2-0.x86_64'}
+                ),
+                (
+                    'Install',
+                    'pepper-0:20-0.x86_64',
+                    None,
+                    {'lotus-0:3-16.x86_64', 'librita-0:1-1.x86_64'}
+                )
+            )
+        )
 
     def test_add_obsoleted_removed(self):
         """Test add with an obsoleted NEVRA which was removed before."""
@@ -150,7 +171,9 @@ class NEVRAOperationsTest(tests.support.TestCase):
              ('Erase', 'tour-0:4.6-1.noarch', None, set())))
 
     def test_add_replaced_opposite(self):
-        """Test add with a replaced NEVRA which replaced a NEVRA before in the opposite direction."""
+        """
+        Test add with a replaced NEVRA which replaced a NEVRA before in the opposite direction.
+        """
         ops = dnf.history.NEVRAOperations()
         ops.add('Downgrade', 'tour-0:4.6-1.noarch', 'tour-0:4.9-1.noarch')
         ops.add('Update', 'tour-0:4.8-1.noarch', 'tour-0:4.6-1.noarch')
@@ -330,10 +353,13 @@ class NEVRAOperationsTest(tests.support.TestCase):
         """Test membership of an operation with different obsoleted NEVRAs."""
         ops = dnf.history.NEVRAOperations()
         ops.add('Update', 'tour-0:4.9-1.noarch', 'tour-0:4.8-1.noarch')
-
-        is_in = ('Update', 'tour-0:4.9-1.noarch', 'tour-0:4.8-1.noarch', ('pepper-0:20-0.x86_64',)) in ops
-
-        self.assertFalse(is_in)
+        op = (
+            'Update',
+            'tour-0:4.9-1.noarch',
+            'tour-0:4.8-1.noarch',
+            ('pepper-0:20-0.x86_64',)
+        )
+        self.assertFalse(op in ops)
 
     def test_membership_differentreplaced(self):
         """Test membership of an operation with different replaced NEVRA."""

--- a/tests/test_history_undo.py
+++ b/tests/test_history_undo.py
@@ -66,7 +66,12 @@ class BaseTest(tests.support.TestCase):
     def test_history_undo_operations_downgrade(self):
         """Test history_undo_operations with a downgrade."""
         operations = NEVRAOperations()
-        operations.add('Downgrade', 'pepper-20-0.x86_64', 'pepper-20-1.x86_64', ('lotus-3-16.x86_64',))
+        operations.add(
+            'Downgrade',
+            'pepper-20-0.x86_64',
+            'pepper-20-1.x86_64',
+            ('lotus-3-16.x86_64',)
+        )
 
         with self._base:
             self._base._history_undo_operations(operations, 0)
@@ -164,7 +169,12 @@ class BaseTest(tests.support.TestCase):
     def test_history_undo_operations_reinstall(self):
         """Test history_undo_operations with a reinstall."""
         operations = NEVRAOperations()
-        operations.add('Reinstall', 'pepper-20-0.x86_64', 'pepper-20-0.x86_64', ('hole-1-1.x86_64',))
+        operations.add(
+            'Reinstall',
+            'pepper-20-0.x86_64',
+            'pepper-20-0.x86_64',
+            ('hole-1-1.x86_64',)
+        )
 
         with self._base:
             self._base._history_undo_operations(operations, 0)
@@ -198,7 +208,12 @@ class BaseTest(tests.support.TestCase):
     def test_history_undo_operations_reinstall_notinstalled_obsoleted(self):
         """Test history_undo_operations with a not installed obsoleted of a reinstall."""
         operations = NEVRAOperations()
-        operations.add('Reinstall', 'pepper-20-0.x86_64', 'pepper-20-0.x86_64', ('lotus-3-16.x86_64',))
+        operations.add(
+            'Reinstall',
+            'pepper-20-0.x86_64',
+            'pepper-20-0.x86_64',
+            ('lotus-3-16.x86_64',)
+        )
 
         with self._base:
             self._base._history_undo_operations(operations, 0)

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -20,8 +20,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import unittest
 import sys
+import unittest
 
 import dnf.i18n
 from dnf.pycomp import PY3
@@ -31,8 +31,8 @@ import tests.support
 from tests.support import mock
 
 
-UC_TEXT          = 'Šířka'  # means 'Width' in Czech
-UC_TEXT_OSERROR  = 'Soubor již existuje'  # 'File already exists'
+UC_TEXT = 'Šířka'  # means 'Width' in Czech
+UC_TEXT_OSERROR = 'Soubor již existuje'  # 'File already exists'
 STR_TEXT_OSERROR = 'Soubor již existuje'
 
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -53,8 +53,7 @@ class CommonTest(tests.support.ResultTestCase):
 
     """
 
-    def setUp(self):
-        self.base = tests.support.MockBase('main', 'third_party', 'broken_deps')
+    REPOS = ['main', 'third_party', 'broken_deps']
 
     def test_install_arch_glob(self):
         """Test that the pkg specification can contain an architecture glob."""
@@ -211,8 +210,10 @@ class MultilibAllTest(tests.support.ResultTestCase):
 
     """
 
+    REPOS = ['main', 'third_party', 'broken_deps']
+
     def setUp(self):
-        self.base = tests.support.MockBase('main', 'third_party', 'broken_deps')
+        super(MultilibAllTest, self).setUp()
         self.base.conf.multilib_policy = "all"
         assert self.base.conf.best is False
 
@@ -344,8 +345,10 @@ class MultilibBestTest(tests.support.ResultTestCase):
 
     """
 
+    REPOS = ['main', 'third_party', 'broken_deps']
+
     def setUp(self):
-        self.base = tests.support.MockBase('main', 'third_party', 'broken_deps')
+        super(MultilibBestTest, self).setUp()
         self.installed = self.base.sack.query().installed().run()
         self.assertEqual(self.base.conf.multilib_policy, "best")
         assert self.base.conf.best is False
@@ -478,8 +481,10 @@ class BestTrueTest(tests.support.ResultTestCase):
 
     """
 
+    REPOS = ['broken_deps']
+
     def setUp(self):
-        self.base = tests.support.MockBase('broken_deps')
+        super(BestTrueTest, self).setUp()
         self.base.conf.best = True
 
     def test_install_name_choice(self):

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -47,8 +47,7 @@ class List(tests.support.TestCase):
     def test_list_installed_reponame(self):
         """Test whether only packages installed from the repository are listed."""
         base = tests.support.MockBase()
-        expected = base.sack.query().installed().filter(name={'pepper',
-                                                              'librita'})
+        expected = self.base.sack.query().installed().filter(name={'pepper', 'librita'})
         history = base.history
         for pkg in expected:
             tests.support.mockSwdbPkg(history, pkg, repo='main')

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -36,10 +36,12 @@ TOUR_WRONG_MD5 = binascii.unhexlify("ffe9ded8ea25137c964a638f12e9987c")
 TOUR_SIZE = 2317
 
 
-class PackageTest(tests.support.TestCase):
+class PackageTest(tests.support.DnfBaseTestCase):
+
+    REPOS = ['main']
+
     def setUp(self):
-        base = tests.support.MockBase("main")
-        self.sack = base.sack
+        super(PackageTest, self).setUp()
         self.pkg = self.sack.query().available().filter(name="pepper")[1]
 
     def test_from_cmdline(self):

--- a/tests/test_persistor.py
+++ b/tests/test_persistor.py
@@ -34,17 +34,17 @@ IDS = set(['one', 'two', 'three'])
 
 class RepoPersistorTest(tests.support.TestCase):
     def setUp(self):
-        self.persistdir = tempfile.mkdtemp(prefix="dnf-repoprst-test-")
-        self.prst = dnf.persistor.RepoPersistor(self.persistdir)
+        self.persistdir = tempfile.mkdtemp(prefix="dnf-persistor-test-")
+        self.persistor = dnf.persistor.RepoPersistor(self.persistdir)
 
     def tearDown(self):
         dnf.util.rm_rf(self.persistdir)
 
     def test_expired_repos(self):
-        self.assertLength(self.prst.get_expired_repos(), 0)
-        self.prst.expired_to_add = IDS
-        self.prst.save()
-        self.assertEqual(self.prst.get_expired_repos(), IDS)
+        self.assertLength(self.persistor.get_expired_repos(), 0)
+        self.persistor.expired_to_add = IDS
+        self.persistor.save()
+        self.assertEqual(self.persistor.get_expired_repos(), IDS)
 
-        prst = dnf.persistor.RepoPersistor(self.persistdir)
-        self.assertEqual(prst.get_expired_repos(), IDS)
+        persistor = dnf.persistor.RepoPersistor(self.persistdir)
+        self.assertEqual(persistor.get_expired_repos(), IDS)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -67,6 +67,7 @@ class PluginTest(tests.support.TestCase):
         conf = lucky.read_config(base.conf)
         self.assertTrue(conf.getboolean('main', 'enabled'))
         self.assertEqual(conf.get('main', 'wanted'), '/to/be/haunted')
+        base.close()
 
     def test_disabled(self):
         base = tests.support.MockBase()
@@ -76,6 +77,7 @@ class PluginTest(tests.support.TestCase):
                               for p in self.plugins.plugins]))
         self.assertLength(self.plugins.plugin_cls, 1)
         self.assertEqual(self.plugins.plugin_cls[0].name, 'lucky')
+        base.close()
 
 
 class PluginSkipsTest(tests.support.TestCase):

--- a/tests/test_provides.py
+++ b/tests/test_provides.py
@@ -23,9 +23,9 @@ from __future__ import unicode_literals
 import tests.support
 
 
-class ProvidesTest(tests.support.TestCase):
-    def setUp(self):
-        self.base = tests.support.MockBase("main")
+class ProvidesTest(tests.support.DnfBaseTestCase):
+
+    REPOS = ['main']
 
     def test_file(self):
         self.assertLength(self.base.provides("*ais*smile")[0], 1)

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -27,52 +27,49 @@ import tests.support
 
 
 class QueriesTest(tests.support.TestCase):
+
+    def setUp(self):
+        self.sack = tests.support.mock_sack('main', 'updates')
+
     def test_duplicities(self):
-        sack = tests.support.mock_sack()
-        pepper = sack.query().installed().filter(name="pepper")
+        pepper = self.sack.query().installed().filter(name="pepper")
         # make sure 'pepper' package exists:
         self.assertEqual(len(pepper), 1)
         # we shouldn't see it more than once with a tricky query below:
-        res = sack.query().installed().filter(name=["pep*", "*per"])
+        res = self.sack.query().installed().filter(name=["pep*", "*per"])
         res_set = set(res)
         self.assertEqual(len(res), len(res_set))
 
     def test_by_file(self):
         # check sanity first:
-        sack = tests.support.mock_sack()
-        q = sack.query().filter(file__eq="/raised/smile")
+        q = self.sack.query().filter(file__eq="/raised/smile")
         self.assertEqual(len(q.run()), 1)
         q[0]
 
     def test_by_repo(self):
-        sack = tests.support.mock_sack("updates", "main")
-        pkgs = sack.query().filter(reponame__eq="updates")
+        pkgs = self.sack.query().filter(reponame__eq="updates")
         self.assertEqual(len(pkgs), tests.support.UPDATES_NSOLVABLES)
-        pkgs = sack.query().filter(reponame__eq="main")
+        pkgs = self.sack.query().filter(reponame__eq="main")
         self.assertEqual(len(pkgs), tests.support.MAIN_NSOLVABLES)
 
     def test_duplicated(self):
-        sack = tests.support.mock_sack()
-        pkgs = sack.query().duplicated()
+        pkgs = self.sack.query().duplicated()
         self.assertEqual(len(pkgs), 3)
 
     def test_extras(self):
-        sack = tests.support.mock_sack("main")
-        pkgs = sack.query().extras()
+        pkgs = self.sack.query().extras()
         self.assertEqual(len(pkgs), tests.support.TOTAL_RPMDB_COUNT - 2)
 
     def test_installed_exact(self):
-        sack = tests.support.mock_sack()
-        pkgs = sack.query().installed()._nevra("tour-4.9-0.noarch")
+        pkgs = self.sack.query().installed()._nevra("tour-4.9-0.noarch")
         self.assertEqual(len(pkgs), 0)
-        pkgs = sack.query().installed()._nevra("tour-5-0.x86_64")
+        pkgs = self.sack.query().installed()._nevra("tour-5-0.x86_64")
         self.assertEqual(len(pkgs), 0)
-        pkgs = sack.query().installed()._nevra("tour-5-0.noarch")
+        pkgs = self.sack.query().installed()._nevra("tour-5-0.noarch")
         self.assertEqual(len(pkgs), 1)
 
     def test_latest(self):
-        sack = tests.support.mock_sack("old_versions")
-        tours = sack.query().filter(name="tour")
+        tours = self.sack.query().filter(name="tour")
         all_tours = sorted(tours.run(), reverse=True)
         head2 = all_tours[0:2]
         tail2 = all_tours[2:]
@@ -83,9 +80,9 @@ class QueriesTest(tests.support.TestCase):
 
 
 class SubjectTest(tests.support.TestCase):
+
     def setUp(self):
-        self.base = tests.support.MockBase("main", "updates")
-        self.sack = self.base.sack
+        self.sack = tests.support.mock_sack('main', 'updates')
 
     def test_wrong_name(self):
         subj = dnf.subject.Subject("call-his-wife-in")
@@ -122,9 +119,12 @@ class SubjectTest(tests.support.TestCase):
 
 
 class DictsTest(tests.support.TestCase):
+
+    def setUp(self):
+        self.sack = tests.support.mock_sack('main', 'updates')
+
     def test_per_nevra_dict(self):
-        sack = tests.support.mock_sack("main")
-        pkgs = sack.query().filter(name="lotus")
+        pkgs = self.sack.query().filter(name="lotus")
         dct = dnf.query._per_nevra_dict(pkgs)
         self.assertCountEqual(dct.keys(),
                               ["lotus-3-16.x86_64", "lotus-3-16.i686"])

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -28,8 +28,11 @@ import tests.support
 
 
 class Remove(tests.support.ResultTestCase):
+
+    REPOS = []
+
     def setUp(self):
-        self.base = tests.support.MockBase()
+        super(Remove, self).setUp()
         self.allow_erasing = True
 
     def test_not_installed(self):
@@ -72,9 +75,8 @@ class Remove(tests.support.ResultTestCase):
     def test_reponame(self):
         """Test whether only packages from the repository are uninstalled."""
         pkg_subj = dnf.subject.Subject('librita.x86_64')
-        history = self.base.history
         for pkg in pkg_subj.get_best_query(self.base.sack).installed():
-            tests.support.mockSwdbPkg(history, pkg, repo='main')
+            tests.support.mockSwdbPkg(self.history, pkg, repo='main')
 
         self.base.remove('librita', 'main')
         self.assertResult(self.base, itertools.chain(

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -25,7 +25,6 @@ import io
 import os
 import re
 import tempfile
-import unittest
 
 import librepo
 
@@ -46,7 +45,7 @@ TOUR_CHKSUM = """\
 ce77c1e5694b037b6687cf0ab812ca60431ec0b65116abbb7b82684f0b092d62"""
 
 
-class RepoFunctionsTest(unittest.TestCase):
+class RepoFunctionsTest(tests.support.TestCase):
     def test_cachedir_re(self):
         pairs = [
             ('fedora-fe3d2f0c91e9b65c', 'fedora'),
@@ -505,7 +504,7 @@ class DownloadPayloadsTest(RepoTestMixin, tests.support.TestCase):
         self.assertFile(path)
 
 
-class MDPayloadTest(unittest.TestCase):
+class MDPayloadTest(tests.support.TestCase):
     def test_null_progress(self):
         """MDPayload always has some progress attribute."""
         pload = dnf.repo.MDPayload(None)
@@ -513,7 +512,7 @@ class MDPayloadTest(unittest.TestCase):
         self.assertIsNotNone(pload.progress)
 
 
-class SavingTest(unittest.TestCase):
+class SavingTest(tests.support.TestCase):
     def test_update_saving(self):
         progress = dnf.callback.NullDownloadProgress()
 

--- a/tests/test_repoquery.py
+++ b/tests/test_repoquery.py
@@ -21,7 +21,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import unittest
 
 import dnf.cli.commands.repoquery
 import dnf.exceptions
@@ -72,7 +71,7 @@ class PkgStub(object):
         self.files = ['/tmp/foobar', '/var/foobar']
 
 
-class ArgParseTest(unittest.TestCase):
+class ArgParseTest(tests.support.TestCase):
     def setUp(self):
         self.cmd = dnf.cli.commands.repoquery.RepoQueryCommand(
             tests.support.CliStub(tests.support.BaseCliStub()))
@@ -102,7 +101,7 @@ class ArgParseTest(unittest.TestCase):
         self.assertIsNone(self.cmd.opts.file)
 
 
-class FilelistFormatTest(unittest.TestCase):
+class FilelistFormatTest(tests.support.TestCase):
     def test_filelist(self):
         self.cmd = dnf.cli.commands.repoquery.RepoQueryCommand(
             tests.support.CliStub(tests.support.BaseCliStub()))
@@ -112,7 +111,7 @@ class FilelistFormatTest(unittest.TestCase):
                          EXPECTED_FILELIST_FORMAT)
 
 
-class SourceRPMFormatTest(unittest.TestCase):
+class SourceRPMFormatTest(tests.support.TestCase):
     def test_info(self):
         self.cmd = dnf.cli.commands.repoquery.RepoQueryCommand(
             tests.support.CliStub(tests.support.BaseCliStub()))
@@ -122,7 +121,7 @@ class SourceRPMFormatTest(unittest.TestCase):
                          EXPECTED_SOURCERPM_FORMAT)
 
 
-class OutputTest(unittest.TestCase):
+class OutputTest(tests.support.TestCase):
     def test_output(self):
         pkg = PkgStub()
         fmt = dnf.cli.commands.repoquery.rpm2py_format(
@@ -137,7 +136,7 @@ class OutputTest(unittest.TestCase):
                          "'PkgStub' object has no attribute 'notfound'")
 
 
-class Rpm2PyFormatTest(unittest.TestCase):
+class Rpm2PyFormatTest(tests.support.TestCase):
     def test_rpm2py_format(self):
         fmt = dnf.cli.commands.repoquery.rpm2py_format('%{name}')
         self.assertEqual(fmt, '{0.name}')

--- a/tests/test_subject.py
+++ b/tests/test_subject.py
@@ -25,9 +25,12 @@ import dnf.exceptions
 import tests.support
 
 
-class SubjectTest(tests.support.TestCase):
+class SubjectTest(tests.support.DnfBaseTestCase):
+
+    REPOS = ['main', 'third_party']
+
     def setUp(self):
-        self.base = tests.support.MockBase('main', 'third_party')
+        super(SubjectTest, self).setUp()
         pkg = self.base.sack.query().filter(name='lotus', arch='x86_64')[0]
         self.base.sack.add_excludes([pkg])
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -133,9 +133,11 @@ class Update(tests.support.ResultTestCase):
         self.assertCountEqual(
             removed,
             base.sack.query().installed().filter(name='pepper'))
-        assert dnf.subject.Subject('*e*').get_best_query(base.sack).upgrades().filter(name__neq='pepper', reponame__neq='broken_deps'), \
-            ('in another repo, there must be another update matching the '
-             'pattern, otherwise the test makes no sense')
+
+        q = dnf.subject.Subject('*e*').get_best_query(base.sack).upgrades()
+        q = q.filter(name__neq='pepper', reponame__neq='broken_deps')
+        assert q, 'in another repo, there must be another update matching the ' \
+            'pattern, otherwise the test makes no sense'
 
     def test_upgrade_reponame_not_in_repo(self):
         """Test whether no packages are upgraded if bad repo is selected."""
@@ -147,9 +149,10 @@ class Update(tests.support.ResultTestCase):
         self.assertLength(installed, 0)
         self.assertLength(removed, 0)
         self.assertResult(base, base.sack.query().installed())
-        assert dnf.subject.Subject('hole').get_best_query(base.sack).upgrades().filter(reponame__neq='broken_deps'), \
-            ('in another repo, there must be an update matching the '
-             'pattern, otherwise the test makes no sense')
+        q = dnf.subject.Subject('hole').get_best_query(base.sack).upgrades()
+        q = q.filter(reponame__neq='broken_deps')
+        assert q, 'in another repo, there must be an update matching the ' \
+            'pattern, otherwise the test makes no sense'
 
 
 class SkipBroken(tests.support.ResultTestCase):

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -32,133 +32,132 @@ from tests.support import mock
 
 
 class Update(tests.support.ResultTestCase):
+
+    REPOS = ['main', 'updates']
+    INIT_SACK = True
+
     def test_update(self):
         """ Simple update. """
-        base = tests.support.MockBase("updates")
-        base.upgrade("pepper")
-        new_versions = base.sack.query().upgrades().filter(name="pepper")
-        other_installed = base.sack.query().installed().filter(name__neq="pepper")
+        self.base.upgrade("pepper")
+        new_versions = self.sack.query().upgrades().filter(name="pepper")
+        other_installed = self.sack.query().installed().filter(name__neq="pepper")
         expected = other_installed.run() + new_versions.run()
-        self.assertResult(base, expected)
+        self.assertResult(self.base, expected)
 
     def test_update_not_found(self):
-        base = tests.support.MockBase()
-        base._sack = tests.support.mock_sack('updates')
-        base._goal = goal = mock.create_autospec(dnf.goal.Goal)
+        self.base._sack = tests.support.mock_sack('updates')
+        self.base._goal = goal = mock.create_autospec(dnf.goal.Goal)
 
         with self.assertRaises(dnf.exceptions.MarkingError) as context:
-            base.upgrade('non-existent')
+            self.base.upgrade('non-existent')
         self.assertEqual(context.exception.pkg_spec, 'non-existent')
         self.assertEqual(goal.mock_calls, [])
 
     @mock.patch('dnf.base.logger.warning')
     def test_update_not_installed(self, logger):
         """ Updating an uninstalled package is a not valid operation. """
-        base = tests.support.MockBase("main")
-        base._goal = goal = mock.create_autospec(dnf.goal.Goal)
+        self.base._goal = goal = mock.create_autospec(dnf.goal.Goal)
         # no "mrkite" installed:
         with self.assertRaises(dnf.exceptions.MarkingError) as context:
-            base.upgrade("mrkite")
+            self.base.upgrade("mrkite")
         self.assertEqual(logger.mock_calls, [
             mock.call(u'Package %s available, but not installed.', u'mrkite')])
         self.assertEqual(context.exception.pkg_spec, 'mrkite')
         self.assertEqual(goal.mock_calls, [])
 
     def test_package_upgrade_fail(self):
-        base = tests.support.MockBase("main")
-        p = base.sack.query().available().filter(name="mrkite")[0]
+        p = self.sack.query().available().filter(name="mrkite")[0]
         with self.assertRaises(dnf.exceptions.MarkingError) as context:
-            base.package_upgrade(p)
+            self.base.package_upgrade(p)
         self.assertEqual(context.exception.pkg_spec, 'mrkite')
-        base.resolve()
-        self.assertEmpty(base._goal.list_upgrades())
+        self.base.resolve()
+        self.assertEmpty(self.base._goal.list_upgrades())
 
-        p = base.sack.query().available().filter(nevra="librita-1-1.x86_64")[0]
-        self.assertEqual(0, base.package_upgrade(p))
-        base.resolve()
-        self.assertEmpty(base._goal.list_upgrades())
+        p = self.sack.query().available().filter(nevra="librita-1-1.x86_64")[0]
+        self.assertEqual(0, self.base.package_upgrade(p))
+        self.base.resolve()
+        self.assertEmpty(self.base._goal.list_upgrades())
 
     def test_update_all(self):
         """ Update all you can. """
-        base = tests.support.MockBase("main", "updates")
-        sack = base.sack
-        base.upgrade_all()
-        expected = tests.support.installed_but(sack, "pepper", "hole", "tour") + \
-            list(sack.query().available()._nevra("pepper-20-1.x86_64")) + \
-            list(sack.query().available()._nevra("hole-2-1.x86_64"))
-        self.assertResult(base, expected)
+        self.base.upgrade_all()
+        expected = tests.support.installed_but(self.sack, "pepper", "hole", "tour") + \
+            list(self.sack.query().available()._nevra("pepper-20-1.x86_64")) + \
+            list(self.sack.query().available()._nevra("hole-2-1.x86_64"))
+        self.assertResult(self.base, expected)
 
     def test_upgrade_all_reponame(self):
         """Test whether only packages in selected repo are upgraded."""
-        base = tests.support.MockBase('updates', 'third_party')
-        base.init_sack()
+        # override base with custom repos
+        self.base = tests.support.MockBase('updates', 'third_party')
 
-        base.upgrade_all('third_party')
+        self.base.upgrade_all('third_party')
 
-        self.assertResult(base, itertools.chain(
-            base.sack.query().installed().filter(name__neq='hole'),
-            base.sack.query().upgrades().filter(reponame='third_party')))
+        self.assertResult(self.base, itertools.chain(
+            self.sack.query().installed().filter(name__neq='hole'),
+            self.sack.query().upgrades().filter(reponame='third_party')))
 
     def test_upgrade_to_package(self):
-        base = tests.support.MockBase()
-        pkgs = base.add_remote_rpms([tests.support.TOUR_51_PKG_PATH])
-        cnt = base.package_upgrade(pkgs[0])
+        # override base with new object with no repos
+        self.base = tests.support.MockBase()
+        pkgs = self.base.add_remote_rpms([tests.support.TOUR_51_PKG_PATH])
+        cnt = self.base.package_upgrade(pkgs[0])
         self.assertEqual(cnt, 1)
-        new_pkg = base.sack.query().available().filter(name="tour")[0]
-        new_set = tests.support.installed_but(base.sack, "tour") + [new_pkg]
-        self.assertResult(base, new_set)
+        new_pkg = self.sack.query().available().filter(name="tour")[0]
+        new_set = tests.support.installed_but(self.sack, "tour") + [new_pkg]
+        self.assertResult(self.base, new_set)
 
     def test_update_arches(self):
-        base = tests.support.MockBase("main", "updates")
-        base.upgrade("hole")
-        installed, removed = self.installed_removed(base)
+        self.base.upgrade("hole")
+        installed, removed = self.installed_removed(self.base)
         self.assertCountEqual(map(str, installed), ['hole-2-1.x86_64'])
         self.assertCountEqual(map(str, removed),
                               ['hole-1-1.x86_64', 'tour-5-0.noarch'])
 
     def test_upgrade_reponame(self):
         """Test whether only packages in selected repo are upgraded."""
-        base = tests.support.MockBase('updates', 'broken_deps')
-        base.logger = mock.Mock()
+        # override base with custom repos
+        self.base = tests.support.MockBase('updates', 'broken_deps')
 
-        base.upgrade('*e*', 'broken_deps')
+        self.base.upgrade('*e*', 'broken_deps')
 
-        installed, removed = self.installed_removed(base)
+        installed, removed = self.installed_removed(self.base)
         # Sack contains two upgrades with the same version. Because of that
         # test whether the installed package is one of those packages.
         self.assertLength(installed, 1)
         self.assertIn(
             dnf.util.first(installed),
-            base.sack.query().upgrades().filter(name='pepper'))
+            self.sack.query().upgrades().filter(name='pepper'))
         self.assertCountEqual(
             removed,
-            base.sack.query().installed().filter(name='pepper'))
+            self.sack.query().installed().filter(name='pepper'))
 
-        q = dnf.subject.Subject('*e*').get_best_query(base.sack).upgrades()
+        q = dnf.subject.Subject('*e*').get_best_query(self.sack).upgrades()
         q = q.filter(name__neq='pepper', reponame__neq='broken_deps')
         assert q, 'in another repo, there must be another update matching the ' \
             'pattern, otherwise the test makes no sense'
 
     def test_upgrade_reponame_not_in_repo(self):
         """Test whether no packages are upgraded if bad repo is selected."""
-        base = tests.support.MockBase('updates', 'broken_deps')
+        # override base with custom repos
+        self.base = tests.support.MockBase('updates', 'broken_deps')
 
-        base.upgrade('hole', 'broken_deps')
+        self.base.upgrade('hole', 'broken_deps')
         # ensure that no package was upgraded
-        installed, removed = self.installed_removed(base)
+        installed, removed = self.installed_removed(self.base)
         self.assertLength(installed, 0)
         self.assertLength(removed, 0)
-        self.assertResult(base, base.sack.query().installed())
-        q = dnf.subject.Subject('hole').get_best_query(base.sack).upgrades()
+        self.assertResult(self.base, self.sack.query().installed())
+        q = dnf.subject.Subject('hole').get_best_query(self.sack).upgrades()
         q = q.filter(reponame__neq='broken_deps')
         assert q, 'in another repo, there must be an update matching the ' \
             'pattern, otherwise the test makes no sense'
 
 
 class SkipBroken(tests.support.ResultTestCase):
-    def setUp(self):
-        self.base = tests.support.MockBase("broken_deps")
-        self.sack = self.base.sack
+
+    REPOS = ['broken_deps']
+    INIT_SACK = True
 
     def test_upgrade_all(self):
         """ upgrade() without parameters upgrade everything it can that has its
@@ -171,6 +170,10 @@ class SkipBroken(tests.support.ResultTestCase):
 
 
 class CostUpdate(tests.test_repo.RepoTestMixin, tests.support.ResultTestCase):
+
+    REPOS = []
+    INIT_SACK = True
+
     def test_cost(self):
         """Test the repo costs are respected."""
         r1 = self.build_repo('r1')
@@ -178,12 +181,10 @@ class CostUpdate(tests.test_repo.RepoTestMixin, tests.support.ResultTestCase):
         r1.cost = 500
         r2.cost = 700
 
-        base = tests.support.MockBase()
-        base.init_sack()
-        base.repos.add(r1)
-        base.repos.add(r2)
-        base._add_repo_to_sack(r1)
-        base._add_repo_to_sack(r2)
-        base.upgrade("tour")
-        (installed, _) = self.installed_removed(base)
+        self.base.repos.add(r1)
+        self.base.repos.add(r2)
+        self.base._add_repo_to_sack(r1)
+        self.base._add_repo_to_sack(r2)
+        self.base.upgrade("tour")
+        (installed, _) = self.installed_removed(self.base)
         self.assertEqual('r1', dnf.util.first(installed).reponame)

--- a/tests/test_upgrade_to.py
+++ b/tests/test_upgrade_to.py
@@ -28,33 +28,28 @@ import tests.support
 
 
 class UpgradeTo(tests.support.ResultTestCase):
+
+    REPOS = ['main', 'updates', 'third_party']
+
     def test_upgrade_to(self):
-        base = tests.support.MockBase("main", "updates")
-        sack = base.sack
-        base.upgrade("pepper-20-1.x86_64")
-        new_set = tests.support.installed_but(sack, "pepper").run()
-        q = sack.query().available()._nevra("pepper-20-1.x86_64")
+        self.base.upgrade("pepper-20-1.x86_64")
+        new_set = tests.support.installed_but(self.sack, "pepper").run()
+        q = self.sack.query().available()._nevra("pepper-20-1.x86_64")
         new_set.extend(q)
-        self.assertResult(base, new_set)
+        self.assertResult(self.base, new_set)
 
     def test_upgrade_to_reponame(self):
         """Test whether only packages in selected repo are used."""
-        base = tests.support.MockBase('updates', 'third_party')
-        base.init_sack()
-
-        base.upgrade('hole-1-2.x86_64', 'updates')
+        self.base.upgrade('hole-1-2.x86_64', 'updates')
 
         subject = dnf.subject.Subject('hole-1-2.x86_64')
-        self.assertResult(base, itertools.chain(
-            base.sack.query().installed().filter(name__neq='hole'),
-            subject.get_best_query(base.sack).filter(reponame='updates'))
+        self.assertResult(self.base, itertools.chain(
+            self.sack.query().installed().filter(name__neq='hole'),
+            subject.get_best_query(self.sack).filter(reponame='updates'))
         )
 
     def test_upgrade_to_reponame_not_in_repo(self):
         """Test whether no packages are upgraded if bad repo is selected."""
-        base = tests.support.MockBase('main', 'updates')
-        base.init_sack()
+        self.base.upgrade('hole-1-2.x86_64', 'main')
 
-        base.upgrade('hole-1-2.x86_64', 'main')
-
-        self.assertResult(base, base.sack.query().installed())
+        self.assertResult(self.base, self.sack.query().installed())

--- a/tests/test_upgrade_to.py
+++ b/tests/test_upgrade_to.py
@@ -44,9 +44,11 @@ class UpgradeTo(tests.support.ResultTestCase):
 
         base.upgrade('hole-1-2.x86_64', 'updates')
 
+        subject = dnf.subject.Subject('hole-1-2.x86_64')
         self.assertResult(base, itertools.chain(
             base.sack.query().installed().filter(name__neq='hole'),
-            dnf.subject.Subject('hole-1-2.x86_64').get_best_query(base.sack).filter(reponame='updates')))
+            subject.get_best_query(base.sack).filter(reponame='updates'))
+        )
 
     def test_upgrade_to_reponame_not_in_repo(self):
         """Test whether no packages are upgraded if bad repo is selected."""


### PR DESCRIPTION
The DNF 'base' object was improperly handled in tests.
Unused references to 'base' remained in memory -> swdb connections weren't closed.
The patch consolidates work with the base object to get it created in setUp() and closed in tearDown().