### PR TITLE
Make get_effective_login more robust

### DIFF
--- a/dnf/util.py
+++ b/dnf/util.py
@@ -145,7 +145,10 @@ def file_timestamp(fn):
     return os.stat(fn).st_mtime
 
 def get_effective_login():
-    return pwd.getpwuid(os.geteuid())[0]
+    try:
+        return pwd.getpwuid(os.geteuid())[0]
+    except KeyError:
+        return "UID: %s" % os.geteuid()
 
 def get_in(dct, keys, not_found):
     """Like dict.get() for nested dicts."""


### PR DESCRIPTION
On a Fedora 27 container running on Openshift, dnf install fail
with the following traceback:

    Traceback (most recent call last):
      File "/usr/bin/dnf", line 58, in <module>
        main.user_main(sys.argv[1:], exit_code=True)
      File "/usr/lib/python3.6/site-packages/dnf/cli/main.py", line 179, in user_main
        errcode = main(args)
      File "/usr/lib/python3.6/site-packages/dnf/cli/main.py", line 64, in main
        return _main(base, args, cli_class, option_parser_class)
      File "/usr/lib/python3.6/site-packages/dnf/cli/main.py", line 99, in _main
        return cli_run(cli, base)
      File "/usr/lib/python3.6/site-packages/dnf/cli/main.py", line 123, in cli_run
        ret = resolving(cli, base)
      File "/usr/lib/python3.6/site-packages/dnf/cli/main.py", line 154, in resolving
        base.do_transaction(display=displays)
      File "/usr/lib/python3.6/site-packages/dnf/cli/cli.py", line 238, in do_transaction
        super(BaseCli, self).do_transaction(display)
      File "/usr/lib/python3.6/site-packages/dnf/base.py", line 743, in do_transaction
        self._run_transaction(cb=cb)
      File "/usr/lib/python3.6/site-packages/dnf/base.py", line 859, in _run_transaction
        login = dnf.util.get_effective_login()
      File "/usr/lib/python3.6/site-packages/dnf/util.py", line 148, in get_effective_login
        return pwd.getpwuid(os.geteuid())[0]
    KeyError: 'getpwuid(): uid not found: 1010270000'