### PR TITLE
[modularity] exclude names, hotfixes, "default"

### DIFF
--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -1029,6 +1029,9 @@ class RepoConf(BaseConfig):
                          SelectionOption('priority', choices=('priority',),
                                          notimplemented=('roundrobin',)))
 
+        # modularity
+        self._add_option('hotfixes', BoolOption(default=False))
+
     def _configure_from_options(self, opts):
         """Configure repos from the opts. """
 

--- a/dnf/module/repo_module_version.py
+++ b/dnf/module/repo_module_version.py
@@ -53,6 +53,9 @@ class RepoModuleVersion(object):
         result = self._install_profiles(profiles, False)
         result |= self._install_profiles(default_profiles, True)
 
+        if not profiles and not default_profiles:
+            result |= self._install_profiles(["default"], True)
+
         profiles.extend(self.repo_module.conf.profiles)
         profiles.extend(default_profiles)
         self.base._module_persistor.set_data(self.repo_module, stream=self.stream,


### PR DESCRIPTION
Changes:
 * add 'default' profile as last resort default profile
 * add 'hotfixes' repo conf option
 * exclude non-modular rpm filtered by name of their (enabled) modular equivalent