### PR TITLE
pkg.(hdr_)chksum does not raise AttributeError any more

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -1,4 +1,4 @@
-%global hawkey_version 0.13.0
+%global hawkey_version 0.13.1
 %global librepo_version 1.7.19
 %global libcomps_version 0.1.8
 %global rpm_version 4.14.0
@@ -36,7 +36,7 @@
 As a Yum CLI compatibility layer, supplies /usr/bin/yum redirecting to DNF.
 
 Name:           dnf
-Version:        2.8.6
+Version:        2.8.7
 Release:        1%{?dist}
 Summary:        Package manager forked from Yum, using libsolv as a dependency resolver
 # For a breakdown of the licensing, see PACKAGE-LICENSING

--- a/dnf/db/history.py
+++ b/dnf/db/history.py
@@ -156,10 +156,7 @@ class SwdbInterface(object):
         return self.swdb.reason(str(pkg))
 
     def ipkg_to_pkg(self, ipkg):
-        try:
-            csum = ipkg.returnIdSum()
-        except AttributeError:
-            csum = ('', '')
+        csum = ipkg.returnIdSum()
         pkgtup = map(ucd, ipkg.pkgtup)
         (n, a, e, v, r) = pkgtup
         pkg = SwdbPkg.new(

--- a/dnf/package.py
+++ b/dnf/package.py
@@ -131,11 +131,10 @@ class Package(hawkey.Package):
 
     @property
     def _pkgid(self):
-        try:
-            (_, chksum) = self.hdr_chksum
-            return binascii.hexlify(chksum)
-        except AttributeError:
+        if self.hdr_chksum is None:
             return None
+        (_, chksum) = self.hdr_chksum
+        return binascii.hexlify(chksum)
 
     @property # yum compatibility attribute
     def idx(self):
@@ -254,6 +253,8 @@ class Package(hawkey.Package):
         """ Return the chksum type and chksum string how the legacy yum expects
             it.
         """
+        if self._chksum is None:
+            return (None, None)
         (chksum_type, chksum) = self._chksum
         return (hawkey.chksum_name(chksum_type), binascii.hexlify(chksum).decode())
 


### PR DESCRIPTION
pkg.hdr_chksum and pkg.chksum used to raise AttributeError
when accessing these attributes on package not present in the rpmdb.
Now these attributes return None.

Requires https://github.com/rpm-software-management/libdnf/pull/403