### PR TITLE
Report downloads of metalink or repomd.xml

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -1,5 +1,5 @@
 %global hawkey_version 0.13.1
-%global librepo_version 1.7.19
+%global librepo_version 1.9.0
 %global libcomps_version 0.1.8
 %global rpm_version 4.14.0
 %if 0%{?rhel} == 7
@@ -36,7 +36,7 @@
 As a Yum CLI compatibility layer, supplies /usr/bin/yum redirecting to DNF.
 
 Name:           dnf
-Version:        2.8.7
+Version:        2.8.8
 Release:        1%{?dist}
 Summary:        Package manager forked from Yum, using libsolv as a dependency resolver
 # For a breakdown of the licensing, see PACKAGE-LICENSING

--- a/dnf/cli/progress.py
+++ b/dnf/cli/progress.py
@@ -49,7 +49,16 @@ class MultiFileProgressMeter(dnf.callback.DownloadProgress):
         self.unknown_progres = 0
         self.total_drpm = 0
         self.isatty = sys.stdout.isatty()
+        self.done_drpm = 0
+        self.done_files = 0
+        self.done_size = 0
+        self.active = []
         self.state = {}
+        self.last_time = 0
+        self.last_size = 0
+        self.rate = None
+        self.total_files = 0
+        self.total_size = 0
 
     def message(self, msg):
         dnf.util._terminal_messenger('write_flush', msg, self.fo)
@@ -63,8 +72,8 @@ class MultiFileProgressMeter(dnf.callback.DownloadProgress):
         self.done_drpm = 0
         self.done_files = 0
         self.done_size = 0
-        self.state = {}
         self.active = []
+        self.state = {}
 
         # rate averaging
         self.last_time = 0

--- a/dnf/cli/progress.py
+++ b/dnf/cli/progress.py
@@ -49,6 +49,7 @@ class MultiFileProgressMeter(dnf.callback.DownloadProgress):
         self.unknown_progres = 0
         self.total_drpm = 0
         self.isatty = sys.stdout.isatty()
+        self.state = {}
 
     def message(self, msg):
         dnf.util._terminal_messenger('write_flush', msg, self.fo)
@@ -148,6 +149,7 @@ class MultiFileProgressMeter(dnf.callback.DownloadProgress):
         start = now = time()
         text = unicode(payload)
         size = int(payload.download_size)
+        done = 0
 
         # update state
         if status == dnf.callback.STATUS_MIRROR:

--- a/dnf/repo.py
+++ b/dnf/repo.py
@@ -444,6 +444,12 @@ class RemoteRPMPayload(PackagePayload):
 
 class MDPayload(dnf.callback.Payload):
 
+    def __init__(self, progress):
+        super(MDPayload, self).__init__(progress)
+        self._text = ""
+        self._download_size = 0
+        self.fm_running = False
+
     def __str__(self):
         if dnf.pycomp.PY3:
             return self._text
@@ -489,7 +495,6 @@ class MDPayload(dnf.callback.Payload):
 
     def start(self, text):
         self._text = text
-        self._download_size = 0
         self.progress.start(1, 0)
 
     def end(self):

--- a/dnf/repo.py
+++ b/dnf/repo.py
@@ -448,7 +448,7 @@ class MDPayload(dnf.callback.Payload):
         super(MDPayload, self).__init__(progress)
         self._text = ""
         self._download_size = 0
-        self.fm_running = False
+        self.fastest_mirror_running = False
 
     def __str__(self):
         if dnf.pycomp.PY3:
@@ -467,8 +467,8 @@ class MDPayload(dnf.callback.Payload):
         if stage == librepo.FMSTAGE_DETECTION:
             # pinging mirrors, this might take a while
             msg = _('determining the fastest mirror (%d hosts).. ') % data
-            self.fm_running = True
-        elif stage == librepo.FMSTAGE_STATUS and self.fm_running:
+            self.fastest_mirror_running = True
+        elif stage == librepo.FMSTAGE_STATUS and self.fastest_mirror_running:
             # done.. report but ignore any errors
             msg = 'error: %s\n' % data if data else 'done.\n'
         else:
@@ -735,7 +735,7 @@ class Repo(dnf.conf.RepoConf):
 
         # setup download progress
         h.progresscb = self._md_pload._progress_cb
-        self._md_pload.fm_running = False
+        self._md_pload.fastest_mirror_running = False
         h.fastestmirrorcb = self._md_pload._fastestmirror_cb
 
         # apply repo options

--- a/dnf/util.py
+++ b/dnf/util.py
@@ -92,7 +92,11 @@ def _urlopen(url, conf=None, repo=None, mode='w+b', **kwargs):
     else:
         handle = _non_repo_handle(conf)
     try:
+        if repo and handle.progresscb:
+            repo._md_pload.start(repo.name or repo.id or 'unknown')
         librepo.download_url(url, fo.fileno(), handle)
+        if repo and handle.progresscb:
+            repo._md_pload.end()
     except librepo.LibrepoException as e:
         raise IOError(e.args[1])
     fo.seek(0)


### PR DESCRIPTION
Previously downloads were performed silently.

Requires: https://github.com/rpm-software-management/librepo/pull/125
Requires: https://github.com/rpm-software-management/ci-dnf-stack/pull/364

The PR is alternative solution to https://github.com/rpm-software-management/dnf/pull/906