### PR TITLE
Fail group install when package cannot be installed (#1461539)

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1509,10 +1509,10 @@ class Base(object):
             self._goal.upgrade(select=sltr)
             return remove_query
 
-        def trans_install(query, remove_query, comps_pkg):
+        def trans_install(query, remove_query, comps_pkg, strict):
             if self.conf.multilib_policy == "all":
                 if not comps_pkg.requires:
-                    self._install_multiarch(query, strict=False)
+                    self._install_multiarch(query, strict=strict)
                 else:
                     # it installs only one arch for conditional packages
                     installed_query = query.installed().apply()
@@ -1521,7 +1521,7 @@ class Base(object):
                             _msg_installed(pkg)
                     sltr = dnf.selector.Selector(self.sack)
                     sltr.set(provides="({} if {})".format(comps_pkg.name, comps_pkg.requires))
-                    self._goal.install(select=sltr, optional=True)
+                    self._goal.install(select=sltr, optional=not strict)
 
             else:
                 sltr = dnf.selector.Selector(self.sack)
@@ -1529,7 +1529,7 @@ class Base(object):
                     sltr.set(provides="({} if {})".format(comps_pkg.name, comps_pkg.requires))
                 else:
                     sltr.set(pkg=query)
-                self._goal.install(select=sltr, optional=True)
+                self._goal.install(select=sltr, optional=not strict)
             return remove_query
 
         def trans_remove(query, remove_query, comps_pkg):
@@ -1537,7 +1537,8 @@ class Base(object):
             return remove_query
 
         remove_query = self.sack.query().filterm(empty=True)
-        attr_fn = ((trans.install, trans_install),
+        attr_fn = ((trans.install, functools.partial(trans_install, strict=True)),
+                   (trans.install_opt, functools.partial(trans_install, strict=False)),
                    (trans.upgrade, trans_upgrade),
                    (trans.remove, trans_remove))
 
@@ -1608,6 +1609,10 @@ class Base(object):
         """Installs packages of selected group
         :param exclude: list of package name glob patterns
             that will be excluded from install set
+        :param strict: boolean indicating whether group packages that
+            exist but are non-installable due to e.g. dependency
+            issues should be skipped (False) or cause transaction to
+            fail to resolve (True)
         """
         def _pattern_to_pkgname(pattern):
             if dnf.util.is_glob_pattern(pattern):
@@ -1629,8 +1634,12 @@ class Base(object):
                                           strict)
         if not trans:
             return 0
+        if strict:
+            instlog = trans.install
+        else:
+            instlog = trans.install_opt
         logger.debug(_("Adding packages from group '%s': %s"),
-                     grp_id, trans.install)
+                     grp_id, instlog)
         return self._add_comps_trans(trans)
 
     def env_group_install(self, patterns, types, strict=True, exclude=None, exclude_groups=None):

--- a/tests/repos/broken_group.repo
+++ b/tests/repos/broken_group.repo
@@ -1,0 +1,4 @@
+=Ver: 2.0
+#
+=Pkg: brokendeps 20 2 x86_64
+=Req: nosuchpackage >= 1.2-0

--- a/tests/repos/main_comps.xml
+++ b/tests/repos/main_comps.xml
@@ -44,7 +44,9 @@
     <name>Broken Group</name>
     <packagelist>
       <packagereq type="mandatory">meaning-of-life</packagereq>
-      <packagereq>lotus</packagereq>
+      <packagereq type="mandatory">lotus</packagereq>
+      <packagereq type="default" requires="no-such-package">librita</packagereq>
+      <packagereq type="optional">brokendeps</packagereq>
     </packagelist>
   </group>
   <category>


### PR DESCRIPTION
This should finally make DNF's behaviour when installing comps
groups the same as yum's used to be, which has been a request
for several years now. See:

https://bugzilla.redhat.com/show_bug.cgi?id=1292892
https://bugzilla.redhat.com/show_bug.cgi?id=1337731
https://bugzilla.redhat.com/show_bug.cgi?id=1427365
https://bugzilla.redhat.com/show_bug.cgi?id=1461539

And commits:

91f9ce98dbb630800017f44180d636af395435cd
1e1901822748b754d038dd396655c997281a7201

We have been around the houses on this multiple times. @mikem23
actually got things right way way back in #1292892:

"yum-deprecated behaves more sanely here.

In case 1 [package exists but has dependency issues], it reports
the missing dependency and exits with an error

...

In case 2 [package cannot be found at all], it exits cleanly, but
prints a warning."

Note that this applies to yum's *default* behaviour: it had an
option, --skip-broken, which caused it to skip packages with
dependency errors.

That's exactly what we've wanted all along, and it's also what
1461539 requests. Unfortunately, the initial commit intended to
fix #1292892 - that's 91f9ce9 - did not quite behave as Mike
requested. It treated any 'mandatory' package having dependency
errors *or* not existing at all as fatal errors, while not
treating non-existence *or* errors on the part of a 'default'
or 'optional' package as a fatal error. This introduced *two*
differences from yum's behaviour (making the comps 'type' matter,
which it never did to yum, and failing on non-existence), which
I think was the source of quite a lot of confusion.

We then wound up filing bugs on this - like #1337731 - and the
response to that was 1e19018, which causes dnf to treat *neither*
case as a fatal error for *any* package, which is where we stand
at present.

When resolving a transaction, currently, if it cannot find a
package corresponding to an entry in a group, dnf will log a
warning and carry on. This is good and fine and just what we want
it to do. However, when a package is available but cannot be
installed, it does the wrong thing. The various forks of this
`trans_install` internal function all wind up passing
`optional=True` to the Goal, which tells it that it's fine to
just leave the package out if its dependencies can't be resolved.
Additionally, if this happens, `resolve()` itself does not log
anything.

If you try a group install through the CLI, it will tell you
about packages that have been left out due to dependency errors,
via the `_skipped_packages` function in `dnf/output.py` which
actually sucks them out of the Goal instance itself. But that's
no use to anything besides the CLI. Other things which use
`resolve()`, like anaconda, have no means of accessing this
information, so when this happens to them, the omission of the
package is not logged in any way at all, and they have no way to
find out about it.

This commit simply inverts the behaviour for packages that do
exist but have dependency errors again, so if *any* package in
a groupinstall operation exists but cannot be installed, this is
a fatal error. That's what yum did, and that's what dnf should
have done all along. It continues to be the case that the comps
'type' - mandatory, default, or optional - does not matter; this
applies to all three. Again, this is how yum behaved (in the
absence of --skip-broken). If you said you want to install a group
and included optional packages, and any of those optional packages
had a dependency error, the transaction would fail.

The comps 'types' were *never* intended to dictate yum/dnf
behaviour in terms of whether it should fail on error or not, as I
understand it; they were in fact related to installer UI behaviour.
In the old installer UI, after you selected a group, you would see
all the packages in the group listed. 'mandatory' packages would
be pre-checked for installation and the check would be greyed out
- you couldn't unselect them. 'default' packages would be
pre-checked for installation, but you *could* de-select them if you
wanted. 'optional' packages would not be pre-checked for
installation, but you could *select* them if you wanted. This was
the intent of the comps 'type', as I understand it.

Importantly, a package not existing at all will continue to *not*
be a fatal error, as this is handled *before* we reach the
`trans_install` function.

Signed-off-by: Adam Williamson <awilliam@redhat.com>