### PR TITLE
Enumerate valid switches for repoquery --tree

### DIFF
--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -455,11 +455,13 @@ class RepoQueryCommand(commands.Command):
                     pkg_list += tmp_query.run()
             q = self.base.sack.query().filterm(pkg=pkg_list)
         if self.opts.tree:
-            if not self.opts.whatrequires and not self.opts.packageatr:
+            if not self.opts.whatrequires and self.opts.packageatr not in (
+                    'conflicts', 'enhances', 'obsoletes', 'provides', 'recommends',
+                    'requires', 'suggests', 'supplements'):
                 raise dnf.exceptions.Error(
-                    _("No switch specified\nusage: dnf repoquery [--whatrequires|"
-                        "--requires|--conflicts|--obsoletes|--enhances|--suggest|"
-                        "--provides|--supplements|--recommends] [key] [--tree]\n\n"
+                    _("No valid switch specified\nusage: dnf repoquery [--conflicts|"
+                        "--enhances|--obsoletes|--provides|--recommends|--requires|"
+                        "--suggest|--supplements|--whatrequires] [key] [--tree]\n\n"
                         "description:\n  For the given packages print a tree of the packages."))
             self.tree_seed(q, orquery, self.opts)
             return


### PR DESCRIPTION
Previously command accepted --depends and --requires_pre,
which failed with traceback:

$ dnf repoquery --tree --depends acpi
Last metadata expiration check: 0:49:11 ago on Čt 22. březen 2018, 07:23:03 CET.
acpi-0:1.7-6.fc26.x86_64
Traceback (most recent call last):
  File "/usr/bin/dnf", line 58, in <module>
    main.user_main(sys.argv[1:], exit_code=True)
  File "/usr/lib/python3.6/site-packages/dnf/cli/main.py", line 179, in user_main
    errcode = main(args)
  File "/usr/lib/python3.6/site-packages/dnf/cli/main.py", line 64, in main
    return _main(base, args, cli_class, option_parser_class)
  File "/usr/lib/python3.6/site-packages/dnf/cli/main.py", line 99, in _main
    return cli_run(cli, base)
  File "/usr/lib/python3.6/site-packages/dnf/cli/main.py", line 115, in cli_run
    cli.run()
  File "/usr/lib/python3.6/site-packages/dnf/cli/cli.py", line 1021, in run
    return self.command.run()
  File "/usr/lib/python3.6/site-packages/dnf/cli/commands/repoquery.py", line 464, in run
    self.tree_seed(q, orquery, self.opts)
  File "/usr/lib/python3.6/site-packages/dnf/cli/commands/repoquery.py", line 576, in tree_seed
    strpkg = getattr(pkg, opts.packageatr)
AttributeError: 'Package' object has no attribute 'depends'