### PR TITLE
Add deprecated label on --excludepkgs option

### DIFF
--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -191,8 +191,13 @@ Options
     Include enhancement relevant packages. Applicable for install, repoquery, updateinfo, and
     upgrade command.
 
+.. _exclude_option-label:
+
 ``-x <package-spec>, --exclude=<package-spec>``
     Exclude packages specified by ``<package-spec>`` from the operation.
+
+``--excludepkgs=<package-spec>``
+    Deprecated option. It was replaced by \-\ :ref:`-exclude <exclude_option-label>` option.
 
 ``--forcearch=<arch>``
     Force the use of an architecture. Any architecture can be specified.


### PR DESCRIPTION
The option was not known to yum, therefore it is only dnf specific. Providing
multiple aliases sound like a good idea, but it is very confusing to users.