### PR TITLE
Improve performance of repoquery --resolve (RhBug:1539803)

### DIFF
--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -266,7 +266,7 @@ class RepoQueryCommand(commands.Command):
                 self.cli._option_conflict("--recursive", "--exactdeps")
             if not any([self.opts.whatrequires,
                         (self.opts.packageatr == "requires" and self.opts.resolve)]):
-                raise dnf.exceptions.Error(
+                raise dnf.cli.CliError(
                     _("Option '--recursive' has to be used with '--whatrequires <REQ>' "
                       "(optionaly with '--alldeps', but not with '--exactdeps'), or with "
                       "'--requires <REQ> --resolve'"))

--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -468,28 +468,29 @@ class RepoQueryCommand(commands.Command):
 
         pkgs = set()
         if self.opts.packageatr:
+            rels = set()
             for pkg in q.run():
                 if self.opts.list != 'userinstalled' or self.base._is_userinstalled(pkg):
                     if self.opts.packageatr == 'depends':
-                        rels = pkg.requires + pkg.enhances + pkg.suggests + pkg.supplements + \
-                               pkg.recommends
+                        rels.update(pkg.requires + pkg.enhances + pkg.suggests + \
+                                    pkg.supplements + pkg.recommends)
                     else:
-                        rels = getattr(pkg, OPTS_MAPPING[self.opts.packageatr])
-                    for rel in rels:
-                        pkgs.add(str(rel))
+                        rels.update(getattr(pkg, OPTS_MAPPING[self.opts.packageatr]))
             if self.opts.resolve:
                 # find the providing packages and show them
                 if self.opts.list == "installed":
                     query = self.filter_repo_arch(self.opts, self.base.sack.query())
                 else:
                     query = self.filter_repo_arch(self.opts, self.base.sack.query().available())
-                providers = query.filter(provides=list(pkgs))
+                providers = query.filter(provides=rels)
                 if self.opts.recursive:
                     providers = providers.union(
                         self._get_recursive_providers_query(query, providers))
                 pkgs = set()
                 for pkg in providers.latest().run():
                     pkgs.add(self.build_format_fn(self.opts, pkg))
+            else:
+                pkgs.update(str(rel) for rel in rels)
         elif self.opts.location:
             for pkg in q.run():
                 location = pkg.remote_location()

--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -478,7 +478,7 @@ class RepoQueryCommand(commands.Command):
             for pkg in q.run():
                 if self.opts.list != 'userinstalled' or self.base._is_userinstalled(pkg):
                     if self.opts.packageatr == 'depends':
-                        rels.update(pkg.requires + pkg.enhances + pkg.suggests + \
+                        rels.update(pkg.requires + pkg.enhances + pkg.suggests +
                                     pkg.supplements + pkg.recommends)
                     else:
                         rels.update(getattr(pkg, OPTS_MAPPING[self.opts.packageatr]))

--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -255,6 +255,12 @@ class RepoQueryCommand(commands.Command):
         if self.opts.querytags:
             return
 
+        if self.opts.resolve and not self.opts.packageatr:
+            raise dnf.cli.CliError(
+                _("Option '--resolve' has to be used together with one of the "
+                  "'--conflicts', '--depends', '--enhances', '--provides', '--recommends', "
+                  "'--requires', '--requires-pre', '--suggests' or '--supplements' options"))
+
         if self.opts.recursive:
             if self.opts.exactdeps:
                 self.cli._option_conflict("--recursive", "--exactdeps")


### PR DESCRIPTION
--resolve makes only sense together with packageatr. And in this
case, there is no need of provides__glob filter which makes
query awfully slow. Replaced with provides filter.

https://bugzilla.redhat.com/show_bug.cgi?id=1539803