### PR TITLE
Document that you can filter off of sourcerpm

### DIFF
--- a/doc/api_queries.rst
+++ b/doc/api_queries.rst
@@ -80,6 +80,7 @@
     provides*    Hawkey.Reldep  match against packages' provides
     requires     string         match against packages' requirements
     requires*    Hawkey.Reldep  match against packages' requirements
+    sourcerpm    string         match against packages' source rpm
     upgrades     boolean        see :meth:`upgrades`. Defaults to ``False``.
     ==========   ============== ======================================================
 


### PR DESCRIPTION
The API query filter documentation does not currently indicate that
filtering based on sourcerpm is possible. The underlying Hawkey library has
supported this functionality since the Fedora 18 (RHBug:857941) timeframe.

Signed-off-by: Kyle Walker <kwalker@redhat.com>