### PR TITLE
Not report scriplets errors as non-fatal

### DIFF
--- a/dnf/yum/rpmtrans.py
+++ b/dnf/yum/rpmtrans.py
@@ -425,12 +425,8 @@ class RPMTransaction(object):
         else:
             name = 'None'
 
-        if total:
-            msg = ("Error in %s scriptlet in rpm package %s" %
-                   (scriptlet_name, name))
-        else:
-            msg = ("Non-fatal %s scriptlet failure in rpm package %s" %
-                   (scriptlet_name, name))
+        msg = ("Error in %s scriptlet in rpm package %s" % (scriptlet_name, name))
+
         for display in self.displays:
             display.error(msg)
 


### PR DESCRIPTION
Due to rise of exception in case of non-fatal error dnf , we cannot report
it is as non-fatal error, because it results in transaction fail.

https://bugzilla.redhat.com/show_bug.cgi?id=1565123

Requires: https://github.com/rpm-software-management/ci-dnf-stack/pull/370