### PR TITLE
Better search of provides in /(s)bin/

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -2169,7 +2169,16 @@ class Base(object):
         providers = dnf.query._by_provides(self.sack, provides_spec)
         if providers:
             return providers, [provides_spec]
-        binary_provides = [prefix + provides_spec for prefix in ['/usr/bin/', '/usr/sbin/']]
+        if provides_spec.startswith('/bin/') or provides_spec.startswith('/sbin/'):
+            # compatibility for packages thad didn't do UsrMove
+            binary_provides = ['/usr' + provides_spec]
+        elif provides_spec.startswith('/'):
+            # provides_spec is a file path
+            return providers, [provides_spec]
+        else:
+            # suppose that provides_spec is a command, search in /usr/sbin/
+            binary_provides = [prefix + provides_spec
+                               for prefix in ['/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/']]
         return self.sack.query().filterm(file__glob=binary_provides), binary_provides
 
     def _history_undo_operations(self, operations, first_trans, rollback=False, strict=True):

--- a/doc/cli_vs_yum.rst
+++ b/doc/cli_vs_yum.rst
@@ -93,9 +93,9 @@ following will work::
 
 ``include`` directive name of [main] and Repo configuration is a more logical and better named counterpart of ``exclude`` in DNF.
 
-=====================================================================
-``dnf provides /bin/<file>`` does not find any packages on Fedora
-=====================================================================
+====================================================
+``dnf provides /bin/<file>`` is not fully supported
+====================================================
 
 After `UsrMove <https://fedoraproject.org/wiki/Features/UsrMove>`_ there's no
 directory ``/bin`` on Fedora systems and no files get installed there,

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -960,8 +960,32 @@ Provides Command
     Finds the packages providing the given ``<provide-spec>``. This is useful
     when one knows a filename and wants to find what package (installed or not)
     provides this file.
+    The ``<provide-spec>`` is gradually looked for at following locations:
 
-This command by default does not force a sync of expired metadata. See also :ref:`\metadata_synchronization-label`.
+    1. The ``<provide-spec>`` is matched with all file provides of any available package::
+
+        $ dnf provides /usr/bin/gzip
+        gzip-1.9-9.fc29.x86_64 : The GNU data compression program
+        Matched from:
+        Filename    : /usr/bin/gzip
+
+    2. Then all provides of all available packages are searched::
+
+        $ dnf provides "gzip(x86-64)"
+        gzip-1.9-9.fc29.x86_64 : The GNU data compression program
+        Matched from:
+        Provide     : gzip(x86-64) = 1.9-9.fc29
+
+    3. DNF assumes that the ``<provide-spec>`` is a system command, prepends it with ``/usr/bin/``, ``/usr/sbin/`` prefixes (one at a time) and does the file provides search again. For legacy reasons (packages that didn't do UsrMove) also ``/bin`` and ``/sbin`` prefixes are being searched::
+
+        $ dnf provides zless
+        gzip-1.9-9.fc29.x86_64 : The GNU data compression program
+        Matched from:
+        Filename    : /usr/bin/zless
+
+    4. If this last step also fails, DNF returns "Error: No Matches found".
+
+    This command by default does not force a sync of expired metadata. See also :ref:`\metadata_synchronization-label`.
 
 .. _reinstall_command-label:
 


### PR DESCRIPTION
Command "dnf provides /bin/bzip2" was unable to find match.
This is part of yum compatibility, yum was able to do it.