### PR TITLE
Do not call decode() on str type variable (RhBug:1570579)

### DIFF
--- a/dnf/module/metadata_loader.py
+++ b/dnf/module/metadata_loader.py
@@ -58,7 +58,7 @@ class ModuleMetadataLoader(object):
         with openfunc(self._metadata_fn or yaml_file_path, "r") as modules_yaml_fd:
             modules_yaml = modules_yaml_fd.read()
 
-        if PY3:
+        if PY3 and isinstance(modules_yaml, bytes):
             modules_yaml = modules_yaml.decode("utf-8")
 
         return Modulemd.Module.new_all_from_string(modules_yaml)


### PR DESCRIPTION
When gzip.open is used for compressed metadata loading modules_yaml_fd.read() returns bytes opposed to str which is returned from modules_yaml_fd.read() when regular open is used for opening uncompressed file.

After that modules_yaml.decode("utf-8") can not be called as modules_yaml variable is already str and thus not nave attribute 'decode'.

This patch fixed issue where decode("utf-8") shouldn't be called on something that's already string