### PR TITLE
Don't use deprecated libmodulemd function

### DIFF
--- a/dnf/module/metadata_loader.py
+++ b/dnf/module/metadata_loader.py
@@ -61,4 +61,4 @@ class ModuleMetadataLoader(object):
         if PY3:
             modules_yaml = modules_yaml.decode("utf-8")
 
-        return Modulemd.Module.new_all_from_string_ext(modules_yaml)
+        return Modulemd.objects_from_string(modules_yaml)


### PR DESCRIPTION
libmodulemd 1.2 and later has a better function for reading in all
of the modulemd objects which can also report proper exceptions in
the event of a parse error.

Note: libmodulemd 1.4 will also add
Modulemd.object_from_string_ext() which will have an additional
returned array of any individual YAML subdocuments which failed
validation.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>