### PR TITLE
[modularity] implicit empty default profile (RhBug:1568165)

### DIFF
--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -116,7 +116,7 @@ class Option(object):
         return self._actual is None
 
     def _is_runtimeonly(self):
-        """Was value changed from default?"""
+        """Is value for internal use only at runtime?"""
         return self._runtimeonly
 
     def _parse(self, strval):

--- a/dnf/module/repo_module_version.py
+++ b/dnf/module/repo_module_version.py
@@ -67,7 +67,7 @@ class RepoModuleVersion(object):
 
         result = False
         for profile in profiles:
-            if profile not in self.profiles:
+            if profile not in self.profiles + ['default']:
                 self.report_profile_error(profile, defaults_used)
 
             for nevra_object in self.profile_nevra_objects(profile):
@@ -164,7 +164,12 @@ class RepoModuleVersion(object):
         return "{}-{}".format(nevra_object.name, nevra_object.evr())
 
     def rpms(self, profile):
-        return self.module_metadata.get_profiles()[profile].get_rpms().get()
+        module_profiles = self.module_metadata.get_profiles()
+        if profile not in module_profiles and profile in ['default']:
+            result = []
+        else:
+            result = module_profiles[profile].get_rpms().get()
+        return result
 
     def profile_nevra_objects(self, profile):
         result = []


### PR DESCRIPTION
According to the [modulemd specification](https://github.com/fedora-modularity/libmodulemd/blob/master/spec.v2.yaml), the `default` profile is always to be assumed to exist. If it is not explicitly defined, the tooling should expect it to be empty.

This is to provide a reasonable fallback and enhance the user experience.

https://bugzilla.redhat.com/show_bug.cgi?id=1568165