### PR TITLE
Remove module without specifying stream (RhBug:1576689)

### DIFF
--- a/dnf/module/repo_module_dict.py
+++ b/dnf/module/repo_module_dict.py
@@ -459,7 +459,7 @@ class RepoModuleDict(OrderedDict):
                 continue
 
             conf = self[module_form.name].conf
-            if module_form.stream != conf.stream:
+            if module_form.stream and module_form.stream != conf.stream:
                 raise DifferentStreamEnabledException(module_form.name)
 
             if conf and conf.profiles:


### PR DESCRIPTION
Make it possible to remove a module without specifying a stream when there is
only one stream installed.

Signed-off-by: Rafael Fonseca <r4f4rfs@gmail.com>