### PR TITLE
dns extension for automatic key management

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -171,6 +171,7 @@ BuildRequires:  python2-libdnf >= %{hawkey_version}
 BuildRequires:  python2-libcomps >= %{libcomps_version}
 BuildRequires:  python2-libdnf
 BuildRequires:  python2-nose
+Requires:       python2-enum34
 BuildRequires:  libmodulemd >= %{libmodulemd_version}
 Requires:       libmodulemd >= %{libmodulemd_version}
 %if (0%{?rhel} && 0%{?rhel} <= 7)
@@ -185,6 +186,7 @@ Requires:       pyliblzma
 Requires:       %{name}-data = %{version}-%{release}
 %if 0%{?fedora}
 Recommends:     deltarpm
+Recommends:     python2-unbound
 %endif
 %if 0%{?centos}
 Requires:       deltarpm
@@ -240,6 +242,7 @@ Requires:       python3-libcomps >= %{libcomps_version}
 Requires:       python3-libdnf
 BuildRequires:  python3-rpm >= %{rpm_version}
 Requires:       python3-rpm >= %{rpm_version}
+Recommends:     python3-unbound
 %if 0%{?rhel} && 0%{?rhel} <= 7
 Requires:       rpm-plugin-systemd-inhibit
 %else

--- a/dnf.spec
+++ b/dnf.spec
@@ -171,15 +171,18 @@ BuildRequires:  python2-libdnf >= %{hawkey_version}
 BuildRequires:  python2-libcomps >= %{libcomps_version}
 BuildRequires:  python2-libdnf
 BuildRequires:  python2-nose
-Requires:       python2-enum34
 BuildRequires:  libmodulemd >= %{libmodulemd_version}
 Requires:       libmodulemd >= %{libmodulemd_version}
 %if (0%{?rhel} && 0%{?rhel} <= 7)
 BuildRequires:  pygpgme
 Requires:       pygpgme
+BuildRequires:  python-enum34
+Requires:       python-enum34
 %else
 BuildRequires:  python2-gpg
 Requires:       python2-gpg
+BuildRequires:  python2-enum34
+Requires:       python2-enum34
 %endif
 BuildRequires:  pyliblzma
 Requires:       pyliblzma

--- a/dnf/dnssec.py
+++ b/dnf/dnssec.py
@@ -1,3 +1,27 @@
+# dnssec.py
+# DNS extension for automatic GPG key verification
+#
+# Copyright (C) 2012-2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
 from enum import Enum
 import base64
 import hashlib

--- a/dnf/dnssec.py
+++ b/dnf/dnssec.py
@@ -1,0 +1,259 @@
+from enum import Enum
+import base64
+import hashlib
+import logging
+import re
+
+from dnf.i18n import _
+import dnf.rpm.transaction
+import dnf.exceptions
+
+logger = logging.getLogger("dnf")
+
+
+RR_TYPE_OPENPGPKEY = 61
+
+
+class DnssecError(dnf.exceptions.Error):
+    """
+    Exception used in the dnssec module
+    """
+    pass
+
+
+def email2location(email_address, tag="_openpgpkey"):
+    # type: (str, str) -> str
+    """
+    Implements RFC 7929, section 3
+    https://tools.ietf.org/html/rfc7929#section-3
+    :param email_address:
+    :param tag:
+    :return:
+    """
+    split = email_address.split("@")
+    if len(split) != 2:
+        raise DnssecError()
+
+    local = split[0]
+    domain = split[1]
+    hash = hashlib.sha256()
+    hash.update(local.encode('utf-8'))
+    digest = base64.b16encode(hash.digest()[0:28])\
+        .decode("utf-8")\
+        .lower()
+    return digest + "." + tag + "." + domain
+
+
+class Validity(Enum):
+    """
+    Output of the verification algorithm.
+    TODO: this type might be simplified in order to less reflect the underlying DNS layer.
+    TODO: more specifically the variants from 3 to 5 should have more understandable names
+    """
+    VALID = 1
+    REVOKED = 2
+    PROVEN_NONEXISTENCE = 3
+    RESULT_NOT_SECURE = 4
+    BOGUS_RESULT = 5
+    ERROR = 9
+
+
+class NoKey:
+    """
+    This class represents an absence of a key in the cache. It is an expression of non-existence
+    using the Python's type system.
+    """
+    pass
+
+
+class KeyInfo:
+    """
+    Wrapper class for email and associated verification key, where both are represented in
+    form of a string.
+    """
+    def __init__(self, email=None, key=None):
+        self.email = email
+        self.key = key
+
+    @staticmethod
+    def from_rpm_key_object(userid, raw_key):
+        # type: (str, bytes) -> KeyInfo
+        """
+        Since dnf uses different format of the key than the one used in DNS RR, I need to convert
+        the former one into the new one.
+        """
+        input_email = re.search('<(.*@.*)>', userid)
+        if input_email is None:
+            raise DnssecError
+
+        email = input_email.group(1)
+        key = raw_key.decode('ascii').split('\n')
+
+        start = 0
+        stop = 0
+        for i in range(0, len(key)):
+            if key[i] == '-----BEGIN PGP PUBLIC KEY BLOCK-----':
+                start = i
+            if key[i] == '-----END PGP PUBLIC KEY BLOCK-----':
+                stop = i
+
+        cat_key = ''.join(key[start + 2:stop - 1]).encode('ascii')
+        return KeyInfo(email, cat_key)
+
+
+class DNSSECKeyVerification:
+    """
+    The main class when it comes to verification itself. It wraps Unbound context and a cache with
+    already obtained results.
+    """
+
+    # Mapping from email address to b64 encoded public key or NoKey in case of proven nonexistence
+    _cache = {}
+    # type: Dict[str, Union[str, NoKey]]
+
+    @staticmethod
+    def _cache_hit(key_union, input_key_string):
+        # type: (Union[str, NoKey], str) -> Validity
+        """
+        Compare the key in case it was found in the cache.
+        """
+        if key_union == input_key_string:
+            return Validity.VALID
+        elif key_union is NoKey:
+            return Validity.PROVEN_NONEXISTENCE
+        else:
+            return Validity.REVOKED
+
+    @staticmethod
+    def _cache_miss(input_key):
+        # type: (KeyInfo) -> Validity
+        """
+        In case the key was not found in the cache, create an Unbound context and contact the DNS
+        system
+        """
+        try:
+            import unbound
+        except ImportError as e:
+            raise RuntimeError("Configuration option 'gpgkey_dns_verification' requires\
+            libunbound ({})".format(e))
+
+        ctx = unbound.ub_ctx()
+        if ctx.set_option("verbosity:", "0") != 0:
+            logger.debug("Unbound context: Failed to set verbosity")
+
+        if ctx.set_option("qname-minimisation:", "yes") != 0:
+            logger.debug("Unbound context: Failed to set qname minimisation")
+
+        if ctx.resolvconf() != 0:
+            logger.debug("Unbound context: Failed to read resolv.conf")
+
+        if ctx.add_ta_file("/var/lib/unbound/root.key") != 0:
+            logger.debug("Unbound context: Failed to add trust anchor file")
+
+        status, result = ctx.resolve(email2location(input_key.email),
+                                     RR_TYPE_OPENPGPKEY, unbound.RR_CLASS_IN)
+        if status != 0:
+            return Validity.ERROR
+        if result.bogus:
+            return Validity.BOGUS_RESULT
+        if not result.secure:
+            return Validity.RESULT_NOT_SECURE
+        if result.nxdomain:
+            return Validity.PROVEN_NONEXISTENCE
+        if not result.havedata:
+            # TODO: This is weird result, but there is no way to perform validation, so just return
+            # an error
+            return Validity.ERROR
+        else:
+            data = result.data.as_raw_data()[0]
+            dns_data_b64 = base64.b64encode(data)
+            if dns_data_b64 == input_key.key:
+                return Validity.VALID
+            else:
+                return Validity.REVOKED
+
+    @staticmethod
+    def verify(input_key):
+        # type: (KeyInfo) -> Validity
+        """
+        Public API. Use this method to verify a KeyInfo object.
+        """
+        key_union = DNSSECKeyVerification._cache.get(input_key.email)
+        if key_union is not None:
+            return DNSSECKeyVerification._cache_hit(key_union, input_key.key)
+        else:
+            result = DNSSECKeyVerification._cache_miss(input_key)
+            if result == Validity.VALID:
+                DNSSECKeyVerification._cache[input_key.email] = input_key.key
+            elif result == Validity.PROVEN_NONEXISTENCE:
+                DNSSECKeyVerification._cache[input_key.email] = NoKey()
+            return result
+
+
+def nice_user_msg(ki, v):
+    # type: (KeyInfo, Validity) -> str
+    """
+    Inform the user about key validity in a human readable way.
+    """
+    prefix = _("DNSSEC extension: Key for user ") + ki.email + " "
+    if v == Validity.VALID:
+        return prefix + _("is valid.")
+    else:
+        return prefix + _("has unknown status.")
+
+
+def any_msg(m):
+    # type: (str) -> str
+    """
+    Label any given message with DNSSEC extension tag
+    """
+    return _("DNSSEC extension: ") + m
+
+
+class RpmImportedKeys:
+    """
+    Wrapper around keys, that are imported in the RPM database.
+
+    The keys are stored in packages with name gpg-pubkey, where the version and
+    release is different for each of them. The key content itself is stored as
+    an ASCII armored string in the package description, so it needs to be parsed
+    before it can be used.
+    """
+    @staticmethod
+    def _query_db_for_gpg_keys():
+        # type: () -> List[KeyInfo]
+        # TODO: base.conf.installroot ?? -----------------------\
+        transaction_set = dnf.rpm.transaction.TransactionWrapper()
+        packages = transaction_set.dbMatch("name", "gpg-pubkey")
+        return_list = []
+        for pkg in packages:
+            packager = pkg['packager'].decode('ascii')
+            email = re.search('<(.*@.*)>', packager).group(1)
+            description = pkg['description']
+            key_lines = description.decode('ascii').split('\n')[3:-3]
+            key_str = ''.join(key_lines)
+            return_list += [KeyInfo(email, key_str.encode('ascii'))]
+
+        return return_list
+
+    @staticmethod
+    def check_imported_keys_validity():
+        keys = RpmImportedKeys._query_db_for_gpg_keys()
+        logger.info(any_msg(_("Testing already imported keys for their validity.")))
+        for key in keys:
+            result = DNSSECKeyVerification.verify(key)
+            # TODO: remove revoked keys automatically and possibly ask user to confirm
+            if result == Validity.VALID:
+                logger.info(any_msg("GPG Key {} is valid".format(key.email)))
+            elif result == Validity.PROVEN_NONEXISTENCE:
+                logger.info(any_msg("GPG Key {} does not support DNS"
+                                    " verification".format(key.email)))
+            elif result == Validity.BOGUS_RESULT:
+                logger.info(any_msg("GPG Key {} could not be verified, because DNSSEC signatures"
+                                    " are bogus. Possible causes: wrong configuration of the DNS"
+                                    " server, MITM attack".format(key.email)))
+            elif result == Validity.REVOKED:
+                logger.info(any_msg("GPG Key {} has been revoked and should"
+                                    " be removed immediately".format(key.email)))
+            else:
+                logger.info(any_msg("GPG Key {} could not be tested".format(key.email)))

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -130,6 +130,23 @@ or :ref:`mirrorlist <mirrorlist-label>` option definition.
 
     Should the dnf client exit immediately when something else has the lock. Default is False
 
+``gpgkey_dns_verification``
+    :ref:`boolean <boolean-label>`
+
+    Should the dnf attempt to automatically verify GPG verification keys using the DNS
+    system. This option requires libunbound to be installed on the client system. This
+    system has two main features. The first one is to check if any of the already
+    installed keys have been revoked. Automatic removal of the key is not yet available,
+    so it is up to the user, to remove revoked keys from the system. The second feature is
+    automatic verification of new keys when a repository is added to the system. In
+    interactive mode, the result is written to the output as a suggestion to the user. In
+    non-interactive mode (i.e. when -y is used), this system will automatically accept
+    keys that are available in the DNS and are correctly signed using DNSSEC. It will also
+    accept keys that do not exist in the DNS system and their NON-existence is
+    cryptographically proven using DNSSEC. This is mainly to preserve backward
+    compatibility.
+
+
 ``group_package_types``
     :ref:`list <list-label>`
 

--- a/tests/modules/etc/dnf/dnf.conf
+++ b/tests/modules/etc/dnf/dnf.conf
@@ -1,0 +1,8 @@
+[main]
+gpgcheck=0
+installonly_limit=3
+clean_requirements_on_remove=True
+install_weak_deps=0
+modulesdir=etc/dnf/modules.d
+reposdir=/home/msehnout/Fedora/dnf/dnf-2.7.5-modularity-6/tests/modules/etc/dnf/repos.d
+moduledefaultsdir=/home/msehnout/Fedora/dnf/dnf-2.7.5-modularity-6/tests/modules/etc/dnf/modules.defaults.d

--- a/tests/modules/etc/dnf/repos.d/test.repo
+++ b/tests/modules/etc/dnf/repos.d/test.repo
@@ -1,0 +1,6 @@
+[test]
+name=Test
+baseurl=file:///home/msehnout/Fedora/dnf/dnf-2.7.5-modularity-6/tests/modules/modules/_all/x86_64/
+enabled=1
+gpgcheck=0
+metadata_expire=0

--- a/tests/test_dnssec.py
+++ b/tests/test_dnssec.py
@@ -38,8 +38,8 @@ RPM_RAW_KEY = b'-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQENBFqWzewBCADMHY8wL2Gm
               b'xLKOqVy/jsySqIHK96RrjY/m8Q9\nBzsi/6fj/GHkewaM8zaeNLHE7MgXFZAuJ8lzjD0r2oBD' \
               b'JGeBKfjjz9xh26YWjG/A\noiolXfliTEox6p0bf820eRhdX9UdSesBROL3rkB+hM5FOT8crSP' \
               b'JsuGZWJ9brikf\nsurWyU+5AQ0EWpbN7AEIAK0/PThuvsLdDGe5HeZn3VdrFcD9QSOV9Xjos8' \
-              b'zWkwx8\nv0t4KXPM4GshyU2ddNjgA+00LhzjACm2ropT5vdvKPtf8lRGOcWWHkiMPdDW/R3/\
-              nI5S0Oh1WFNrQZwQSXn/DoPnhUZNGErpZlUzF00BEltwoVWgT1n81Bp486U3oziZn\nUM8kxXXY' \
+              b'zWkwx8\nv0t4KXPM4GshyU2ddNjgA+00LhzjACm2ropT5vdvKPtf8lRGOcWWHkiMPdDW/R3/\n' \
+              b'I5S0Oh1WFNrQZwQSXn/DoPnhUZNGErpZlUzF00BEltwoVWgT1n81Bp486U3oziZn\nUM8kxXXY' \
               b'2PN8aTfWjsxOSmjyu2m7abeyjTqX9s++vUCQhmCNboSY1AhXF8GQl1Ce\nmpHVv0hOuC6Bead' \
               b'ZRXEfEF0sQogswXpFhYG4GFUvVzKBn00/5phNWHvff1GDjzZz\nmVcRPje+rH6gGP8tpQn7NL' \
               b'1SvrazSqSOih//FfV73EMAEQEAAYkBNgQYAQgAIBYh\nBMwU+9636QKkbYsjdMKSn1VZ4I5DB' \

--- a/tests/test_dnssec.py
+++ b/tests/test_dnssec.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2014-2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+import dnf.dnssec
+
+import tests.support
+
+
+RPM_USER = 'RPM Packager (The guy who creates packages) <packager@example.com>'
+EMAIL = 'packager@example.com'
+RPM_RAW_KEY = b'-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQENBFqWzewBCADMHY8wL2Gm+aeShboOf' \
+              b'G96/h/OJ8FHj+xrihPGY34FwLVqtvO+\nlRIO6t3w5y7O1MWzR1ePtQg1T1sg1s9UeoDRMZoV' \
+              b'gzZdRXtQH1Jy9xpTeMfL31ml\nc3wOnitcH0AdWhT7xnnlaCeJuMrX82PWtiJNd+Cy+bgyLfL' \
+              b'MwX18cimwYCnyIHQ5\n4qiiywXa1paVHkbEJdbd8f4AxArsHX33xCv76wct2uXiHYAHu67rE5' \
+              b'FhQ0mEqfIZ\nHwuFljGPj5UMgyd6MRMuL2Ho1hL7FDPIxDBv5tMWeZJszixIsCkA9Kc1ibylD' \
+              b'z9I\nx/keH1K9XXSb/o2EIfF6sWYcj0wNvJllIHAfABEBAAG0QlJQTSBQYWNrYWdlciAo\nVG' \
+              b'hlIGd1eSB3aG8gY3JlYXRlcyBwYWNrYWdlcykgPHBhY2thZ2VyQGV4YW1wbGUu\nY29tPokBT' \
+              b'gQTAQgAOBYhBMwU+9636QKkbYsjdMKSn1VZ4I5DBQJals3sAhsDBQsJ\nCAcCBhUKCQgLAgQW' \
+              b'AgMBAh4BAheAAAoJEMKSn1VZ4I5D6icH/2GY2MMnmcDO+ApI\nF6gGg9itzAHLTNcxEMl9ht1' \
+              b'Gu3JQ/VdsvMQ6lG+U8yffEmsfQebtt1UaMVXzyt0t\ncSOBJvVEI6qc6skvfea3hqL4srtTOC' \
+              b'wu7ZBA9gOE+eB5BWBspFUVIwUO1GKT48uz\nV6CaODLitaxc7NrJ9HYw4C4+ICCfbIJhjM/Hq' \
+              b'xLKOqVy/jsySqIHK96RrjY/m8Q9\nBzsi/6fj/GHkewaM8zaeNLHE7MgXFZAuJ8lzjD0r2oBD' \
+              b'JGeBKfjjz9xh26YWjG/A\noiolXfliTEox6p0bf820eRhdX9UdSesBROL3rkB+hM5FOT8crSP' \
+              b'JsuGZWJ9brikf\nsurWyU+5AQ0EWpbN7AEIAK0/PThuvsLdDGe5HeZn3VdrFcD9QSOV9Xjos8' \
+              b'zWkwx8\nv0t4KXPM4GshyU2ddNjgA+00LhzjACm2ropT5vdvKPtf8lRGOcWWHkiMPdDW/R3/\
+              nI5S0Oh1WFNrQZwQSXn/DoPnhUZNGErpZlUzF00BEltwoVWgT1n81Bp486U3oziZn\nUM8kxXXY' \
+              b'2PN8aTfWjsxOSmjyu2m7abeyjTqX9s++vUCQhmCNboSY1AhXF8GQl1Ce\nmpHVv0hOuC6Bead' \
+              b'ZRXEfEF0sQogswXpFhYG4GFUvVzKBn00/5phNWHvff1GDjzZz\nmVcRPje+rH6gGP8tpQn7NL' \
+              b'1SvrazSqSOih//FfV73EMAEQEAAYkBNgQYAQgAIBYh\nBMwU+9636QKkbYsjdMKSn1VZ4I5DB' \
+              b'QJals3sAhsMAAoJEMKSn1VZ4I5DshgIALSn\nLy7KL0bcqxoiEZT+P9O+gX34J2NEfITlu3MZ' \
+              b'yN26LbyJS7HuN1vmuUc/UM0ff7AW\n6eElCNFr5HQOrFELUZWiX7f4U8ihRN39g1PKRGANlUc' \
+              b'Lm1Z/JnKyYbyzRK70o5A3\n5EiXEHwY62c/b8I1N4kzNKpa0eQcJ7F8XoZhau0UsxqueVPeEI' \
+              b'aHX+fjbalz67ea\niFTu8MurdGKntVE1dOPYbGvZE0+HxfDOoVo05bRUH8By7dDgVaI9EijrV' \
+              b'zjA5jHP\nJxNIj9AQP9W8zst3l3d9v8o0Pw+L4cWzv+aBFakfjKGugs6lA53fB3RCfZ7OrMwC' \
+              b'\nBvlTfDigK9X50K6XoP0=\n=6SRV\n-----END PGP PUBLIC KEY BLOCK-----\n'
+ASCII_RAW_KEY = b'mQENBFqWzewBCADMHY8wL2Gm+aeShboOfG96/h/OJ8FHj+xrihPGY34FwLVqtvO+lRIO6t3' \
+                b'w5y7O1MWzR1ePtQg1T1sg1s9UeoDRMZoVgzZdRXtQH1Jy9xpTeMfL31mlc3wOnitcH0AdWh' \
+                b'T7xnnlaCeJuMrX82PWtiJNd+Cy+bgyLfLMwX18cimwYCnyIHQ54qiiywXa1paVHkbEJdbd8' \
+                b'f4AxArsHX33xCv76wct2uXiHYAHu67rE5FhQ0mEqfIZHwuFljGPj5UMgyd6MRMuL2Ho1hL7' \
+                b'FDPIxDBv5tMWeZJszixIsCkA9Kc1ibylDz9Ix/keH1K9XXSb/o2EIfF6sWYcj0wNvJllIHA' \
+                b'fABEBAAG0QlJQTSBQYWNrYWdlciAoVGhlIGd1eSB3aG8gY3JlYXRlcyBwYWNrYWdlcykgPH' \
+                b'BhY2thZ2VyQGV4YW1wbGUuY29tPokBTgQTAQgAOBYhBMwU+9636QKkbYsjdMKSn1VZ4I5DB' \
+                b'QJals3sAhsDBQsJCAcCBhUKCQgLAgQWAgMBAh4BAheAAAoJEMKSn1VZ4I5D6icH/2GY2MMn' \
+                b'mcDO+ApIF6gGg9itzAHLTNcxEMl9ht1Gu3JQ/VdsvMQ6lG+U8yffEmsfQebtt1UaMVXzyt0' \
+                b'tcSOBJvVEI6qc6skvfea3hqL4srtTOCwu7ZBA9gOE+eB5BWBspFUVIwUO1GKT48uzV6CaOD' \
+                b'Litaxc7NrJ9HYw4C4+ICCfbIJhjM/HqxLKOqVy/jsySqIHK96RrjY/m8Q9Bzsi/6fj/GHke' \
+                b'waM8zaeNLHE7MgXFZAuJ8lzjD0r2oBDJGeBKfjjz9xh26YWjG/AoiolXfliTEox6p0bf820' \
+                b'eRhdX9UdSesBROL3rkB+hM5FOT8crSPJsuGZWJ9brikfsurWyU+5AQ0EWpbN7AEIAK0/PTh' \
+                b'uvsLdDGe5HeZn3VdrFcD9QSOV9Xjos8zWkwx8v0t4KXPM4GshyU2ddNjgA+00LhzjACm2ro' \
+                b'pT5vdvKPtf8lRGOcWWHkiMPdDW/R3/I5S0Oh1WFNrQZwQSXn/DoPnhUZNGErpZlUzF00BEl' \
+                b'twoVWgT1n81Bp486U3oziZnUM8kxXXY2PN8aTfWjsxOSmjyu2m7abeyjTqX9s++vUCQhmCN' \
+                b'boSY1AhXF8GQl1CempHVv0hOuC6BeadZRXEfEF0sQogswXpFhYG4GFUvVzKBn00/5phNWHv' \
+                b'ff1GDjzZzmVcRPje+rH6gGP8tpQn7NL1SvrazSqSOih//FfV73EMAEQEAAYkBNgQYAQgAIB' \
+                b'YhBMwU+9636QKkbYsjdMKSn1VZ4I5DBQJals3sAhsMAAoJEMKSn1VZ4I5DshgIALSnLy7KL' \
+                b'0bcqxoiEZT+P9O+gX34J2NEfITlu3MZyN26LbyJS7HuN1vmuUc/UM0ff7AW6eElCNFr5HQO' \
+                b'rFELUZWiX7f4U8ihRN39g1PKRGANlUcLm1Z/JnKyYbyzRK70o5A35EiXEHwY62c/b8I1N4k' \
+                b'zNKpa0eQcJ7F8XoZhau0UsxqueVPeEIaHX+fjbalz67eaiFTu8MurdGKntVE1dOPYbGvZE0' \
+                b'+HxfDOoVo05bRUH8By7dDgVaI9EijrVzjA5jHPJxNIj9AQP9W8zst3l3d9v8o0Pw+L4cWzv' \
+                b'+aBFakfjKGugs6lA53fB3RCfZ7OrMwCBvlTfDigK9X50K6XoP0='
+
+
+class EmailToLocationTest(tests.support.TestCase):
+
+    def test_convert_simple_email_to_domain(self):
+        input = 'hugh@example.com'
+        output = 'c93f1e400f26708f98cb19d936620da35eec8f72e57f9eec01c1afd6._openpgpkey.example.com'
+        self.assertEqual(dnf.dnssec.email2location(input), output)
+
+
+class KeyInfoTest(tests.support.TestCase):
+
+    def test_key_info_from_rpm_key_object_email_part(self):
+        key_info = dnf.dnssec.KeyInfo.from_rpm_key_object(RPM_USER, RPM_RAW_KEY)
+        self.assertEqual(key_info.email, EMAIL)
+
+    def test_key_info_from_rpm_key_object_key_part(self):
+        key_info = dnf.dnssec.KeyInfo.from_rpm_key_object(RPM_USER, RPM_RAW_KEY)
+        self.assertEqual(key_info.key, ASCII_RAW_KEY)


### PR DESCRIPTION
**Motivation**
Every time a new repository is added with GPG signed packages, dnf asks the user to accept the verification key, but there seems to be very little amount of users who actually do the key verification instead of simply accepting the key.
```
Importing GPG key 0x46CD093F:
 Userid     : "msehnout_neovim (None) <msehnout#neovim@copr.fedora.org>"
 Fingerprint: 5E84 DA77 A5C0 121E D09C 60B9 4603 C1E8 46CD 093F
 From       : https://copr-be.cloud.fedora.org/msehnout/neovim/pubkey.gpg
Is this ok [y/N]: y
Key imported successfully
```
Of course the official keys are available in the local file system:
```
gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
```
and others are downloaded over TLS secured HTTP:
```
gpgkey=https://dl.google.com/linux/linux_signing_key.pub
```
but still, there is no need to do the verification manually.

Unfortunately there is no way of automatic key revocation. GPG keys are stored inside of the RPM database and they simply stay there forever.

**Implementation**
DNS can be used to store any data even GPG keys as defined in RFC 7929:
https://tools.ietf.org/html/rfc7929
These records are then signed using DNSSEC, thus ensuring authenticity.

dnf can use libundound as an implementation of a validating resolver to obtain the key using DNS and verify it using DNSSEC. This way the verification process will be automatic.

**Testing**
I am currently using custom VM with a simulation of the DNS hierarchy. I could try to turn it into a Vagrantfile, that would run the testing environment. Is it ok for you or would you like to use a different approach to testing?

**Pending issues**

 * libunbound configuration file
 * testing of backwards compatibility (some domains might not have correct DNSSEC setup)

This work is based on my master's thesis, but the text is not finished yet. It will be ready in 2-3 weeks.