### PR TITLE
Randomise start time via systemd timers

### DIFF
--- a/doc/automatic.rst
+++ b/doc/automatic.rst
@@ -81,9 +81,9 @@ Setting the mode of operation of the program.
     What kind of upgrades to look at. ``default`` signals looking for all available updates, ``security`` only those with an issued security advisory.
 
 ``random_sleep``
-    time in seconds, default: 300
+    time in seconds, default: 0
 
-    Maximal random delay before downloading.
+    Maximal random delay before downloading.  Note that, by default, the ``systemd`` timers also apply a random delay of up to 5 minutes.
 
 ----------------------
 ``[emitters]`` section

--- a/etc/dnf/automatic.conf
+++ b/etc/dnf/automatic.conf
@@ -3,7 +3,7 @@
 # default                            = all available upgrades
 # security                           = only the security upgrades
 upgrade_type = default
-random_sleep = 300
+random_sleep = 0
 
 # To just receive updates use dnf-automatic-notifyonly.timer
 

--- a/etc/systemd/dnf-automatic-download.timer
+++ b/etc/systemd/dnf-automatic-download.timer
@@ -8,6 +8,8 @@ After=network-online.target
 [Timer]
 OnBootSec=1h
 OnUnitInactiveSec=1d
+RandomizedDelaySec=5m
+AccuracySec=1s
 
 [Install]
 WantedBy=basic.target

--- a/etc/systemd/dnf-automatic-install.timer
+++ b/etc/systemd/dnf-automatic-install.timer
@@ -8,6 +8,8 @@ After=network-online.target
 [Timer]
 OnBootSec=1h
 OnUnitInactiveSec=1d
+RandomizedDelaySec=5m
+AccuracySec=1s
 
 [Install]
 WantedBy=basic.target

--- a/etc/systemd/dnf-automatic-notifyonly.timer
+++ b/etc/systemd/dnf-automatic-notifyonly.timer
@@ -8,6 +8,8 @@ After=network-online.target
 [Timer]
 OnBootSec=1h
 OnUnitInactiveSec=1d
+RandomizedDelaySec=5m
+AccuracySec=1s
 
 [Install]
 WantedBy=basic.target

--- a/etc/systemd/dnf-automatic.timer
+++ b/etc/systemd/dnf-automatic.timer
@@ -6,6 +6,8 @@ ConditionPathExists=!/run/ostree-booted
 [Timer]
 OnBootSec=1h
 OnUnitInactiveSec=1d
+RandomizedDelaySec=5m
+AccuracySec=1s
 
 [Install]
 WantedBy=basic.target


### PR DESCRIPTION
By moving the randomised delay from `dnf-automatic` to the systemd timers that call `dnf-automatic`, we get more accurate information from `systemctl list-timers`, and we allow `dnf-automatic` to be triggered immediately with, e.g., `systemctl start dnf-automatic-install.service`