### PR TITLE
Fix handling password protected repos (RhBug:1575998)

### DIFF
--- a/dnf/repo.py
+++ b/dnf/repo.py
@@ -77,14 +77,16 @@ def repo_id_invalid(repo_id):
     return dnf.util.first(invalids)
 
 
-def _user_pass_str(user, password, quote=True):
+def _user_pass_str(user, password, quote):
+    """Returns user and password in user:password form. If quote is True,
+    special characters in user and password are URL encoded.
+    """
     if user is None:
         return None
-    if quote:
-        user = dnf.pycomp.urllib_quote(user)
     if password is None:
         password = ''
     if quote:
+        user = dnf.pycomp.urllib_quote(user)
         password = dnf.pycomp.urllib_quote(password)
     return '%s:%s' % (user, password)
 
@@ -728,7 +730,7 @@ class Repo(dnf.conf.RepoConf):
         # setup username/password if needed
         if self.username:
             h.setopt(librepo.LRO_USERPWD,
-                     _user_pass_str(self.username, self.password, quote=False))
+                     _user_pass_str(self.username, self.password, False))
 
         # setup ssl stuff
         if self.sslcacert:
@@ -759,7 +761,7 @@ class Repo(dnf.conf.RepoConf):
         else:
             h.connecttimeout = None
             h.lowspeedtime = None
-        h.proxyuserpwd = _user_pass_str(self.proxy_username, self.proxy_password)
+        h.proxyuserpwd = _user_pass_str(self.proxy_username, self.proxy_password, True)
         h.sslverifypeer = h.sslverifyhost = self.sslverify
         return h
 

--- a/dnf/repo.py
+++ b/dnf/repo.py
@@ -77,11 +77,15 @@ def repo_id_invalid(repo_id):
     return dnf.util.first(invalids)
 
 
-def _user_pass_str(user, password):
+def _user_pass_str(user, password, quote=True):
     if user is None:
         return None
-    user = dnf.pycomp.urllib_quote(user)
-    password = '' if password is None else dnf.pycomp.urllib_quote(password)
+    if quote:
+        user = dnf.pycomp.urllib_quote(user)
+    if password is None:
+        password = ''
+    if quote:
+        password = dnf.pycomp.urllib_quote(password)
     return '%s:%s' % (user, password)
 
 
@@ -723,7 +727,8 @@ class Repo(dnf.conf.RepoConf):
 
         # setup username/password if needed
         if self.username:
-            h.setopt(librepo.LRO_USERPWD, _user_pass_str(self.username, self.password))
+            h.setopt(librepo.LRO_USERPWD,
+                     _user_pass_str(self.username, self.password, quote=False))
 
         # setup ssl stuff
         if self.sslcacert:

--- a/dnf/util.py
+++ b/dnf/util.py
@@ -55,7 +55,7 @@ def _non_repo_handle(conf=None):
             else int(conf.bandwidth * conf.throttle)
         handle.proxy = conf.proxy
         handle.proxyuserpwd = dnf.repo._user_pass_str(conf.proxy_username,
-                                                      conf.proxy_password)
+                                                      conf.proxy_password, True)
         handle.sslverifypeer = handle.sslverifyhost = conf.sslverify
     return handle
 

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -69,13 +69,16 @@ class RepoFunctionsTest(tests.support.TestCase):
         self.assertEqual(index, 7)
 
     def test_user_pass_str(self):
-        user = 'cap'
+        user = 'name@host.com'
         passwd = 'bag'
-        self.assertEqual(dnf.repo._user_pass_str(user, passwd), 'cap:bag')
+        self.assertEqual(dnf.repo._user_pass_str(user, passwd, False), 'name@host.com:bag')
+        self.assertEqual(dnf.repo._user_pass_str(user, passwd, True), 'name%40host.com:bag')
+        user = 'cap'
+        self.assertEqual(dnf.repo._user_pass_str(user, passwd, True), 'cap:bag')
         passwd = 'm:ltr'
-        self.assertEqual(dnf.repo._user_pass_str(user, passwd), 'cap:m%3Altr')
+        self.assertEqual(dnf.repo._user_pass_str(user, passwd, True), 'cap:m%3Altr')
         user = None
-        self.assertEqual(dnf.repo._user_pass_str(user, passwd), None)
+        self.assertEqual(dnf.repo._user_pass_str(user, passwd, True), None)
 
 
 class RepoTestMixin(object):


### PR DESCRIPTION
According to https://curl.haxx.se/libcurl/c/CURLOPT_USERPWD.html user
and password strings are not URL decoded before use (This is different to
CURLOPT_USERPWD - https://curl.haxx.se/libcurl/c/CURLOPT_PROXYUSERPWD.html).

This commit fixes using usernames containing for example @ character,
which is quite widely used.

https://bugzilla.redhat.com/show_bug.cgi?id=1575998