### PR TITLE
Command search: use AND for keys result, remove autosearch in descr and URLs

### DIFF
--- a/dnf/cli/commands/search.py
+++ b/dnf/cli/commands/search.py
@@ -85,7 +85,7 @@ class SearchCommand(commands.Command):
             self._search_counted(counter, 'name', arg)
             self._search_counted(counter, 'summary', arg)
 
-        if self.opts.all or counter.total() == 0:
+        if self.opts.all:
             for arg in args:
                 self._search_counted(counter, 'description', arg)
                 self._search_counted(counter, 'url', arg)

--- a/dnf/cli/commands/search.py
+++ b/dnf/cli/commands/search.py
@@ -89,6 +89,12 @@ class SearchCommand(commands.Command):
             for arg in args:
                 self._search_counted(counter, 'description', arg)
                 self._search_counted(counter, 'url', arg)
+        else:
+            needles = len(args)
+            pkgs = list(counter.keys())
+            for pkg in pkgs:
+                if len(counter.matched_needles(pkg)) != needles:
+                    del counter[pkg]
 
         used_attrs = None
         matched_needles = None

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -1184,7 +1184,11 @@ Search Command
 --------------
 
 ``dnf [options] search [--all] <keywords>...``
-    Search package metadata for the keywords. Keywords are matched as case-insensitive substrings, globbing is supported. By default the command will only look at package names and summaries, failing that (or whenever ``all`` was given as an argument) it will match against package descriptions and URLs. The result is sorted from the most relevant results to the least.
+    Search package metadata for the keywords. Keywords are matched as case-insensitive substrings, globbing is supported.
+    By default lists packages that match all requested keys (AND operation). Keys are searched in package names and summaries.
+    If option "--all" is used, lists packages that match at least one of keys (OR operation).
+    And in addition keys are searched in package descriptions and URLs.
+    The result is sorted from the most relevant results to the least.
 
 This command by default does not force a sync of expired metadata. See also :ref:`\metadata_synchronization-label`.
 


### PR DESCRIPTION
- Remove autoactivation of search in descriptions and URLs.
- By default lists only packages that match all requested keys (AND operation) instead of OR operation. If  option "--all" is used, lists packages that match at least one of keys (OR operation) And in addition keys are searched in package descriptions and URLs.