### PR TITLE
Enable setting the proxy authentication method (RhBug:1387622)

### DIFF
--- a/dnf/repo.py
+++ b/dnf/repo.py
@@ -67,6 +67,18 @@ CACHE_FILES = {
     'dbcache': r'^.+(solv|solvx)$',
 }
 
+# Map string from config option proxy_auth_method to librepo LrAuth value
+PROXYAUTHMETHODS = {
+    'none': librepo.LR_AUTH_NONE,
+    'basic': librepo.LR_AUTH_BASIC,
+    'digest': librepo.LR_AUTH_DIGEST,
+    'negotiate': librepo.LR_AUTH_NEGOTIATE,
+    'ntlm': librepo.LR_AUTH_NTLM,
+    'digest_ie': librepo.LR_AUTH_DIGEST_IE,
+    'ntlm_wb': librepo.LR_AUTH_NTLM_WB,
+    'any': librepo.LR_AUTH_ANY,
+}
+
 logger = logging.getLogger("dnf")
 
 
@@ -746,7 +758,8 @@ class Repo(dnf.conf.RepoConf):
             raise dnf.exceptions.Error(_("Maximum download speed is lower than minimum. "
                                          "Please change configuration of minrate or throttle"))
         h.maxspeed = maxspeed
-        h.setopt(librepo.LRO_PROXYAUTHMETHODS, librepo.LR_AUTH_ANY)
+        h.setopt(librepo.LRO_PROXYAUTHMETHODS,
+                 PROXYAUTHMETHODS.get(self.proxy_auth_method, librepo.LR_AUTH_ANY))
         h.proxy = self.proxy
         if self.timeout > 0:
             h.connecttimeout = self.timeout

--- a/doc/api_conf.rst
+++ b/doc/api_conf.rst
@@ -146,6 +146,25 @@ Configurable settings of the :class:`dnf.Base` object are stored into a :class:`
 
     The password to use for connecting to the proxy server. Defaults to ``None``.
 
+  .. attribute:: proxy_auth_method
+
+    The authentication method used by the proxy server. Valid values are
+
+    ==========     ==========================================================
+    method         meaning
+    ==========     ==========================================================
+    basic          HTTP Basic authentication
+    digest         HTTP Digest authentication
+    negotiate      HTTP Negotiate (SPNEGO) authentication
+    ntlm           HTTP NTLM authentication
+    digest_ie      HTTP Digest authentication with an IE flavor
+    ntlm_wb        NTLM delegating to winbind helper
+    none           None auth method
+    any            All suitable methods
+    ==========     ==========================================================
+
+    Defaults to ``any``
+
   .. attribute:: releasever
 
     Used for substitution of ``$releasever`` in the repository configuration.

--- a/doc/api_repos.rst
+++ b/doc/api_repos.rst
@@ -139,6 +139,25 @@ Repository Configuration
 
     The password to use for connecting to the proxy server. Defaults to ``None``.
 
+  .. attribute:: proxy_auth_method
+
+    The authentication method used by the proxy server. Valid values are
+
+    ==========     ==========================================================
+    method         meaning
+    ==========     ==========================================================
+    basic          HTTP Basic authentication
+    digest         HTTP Digest authentication
+    negotiate      HTTP Negotiate (SPNEGO) authentication
+    ntlm           HTTP NTLM authentication
+    digest_ie      HTTP Digest authentication with an IE flavor
+    ntlm_wb        NTLM delegating to winbind helper
+    none           None auth method
+    any            All suitable methods
+    ==========     ==========================================================
+
+    Defaults to ``any``
+
   .. attribute:: repofile
 
     The path to configuration file of the class.

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -460,6 +460,11 @@ configuration.
 
     The password to use for connecting to the proxy server. Empty by default.
 
+``proxy_auth_method``
+    :ref:`string <string-label>`
+
+    The authentication method used by the proxy server. Valid values are 'basic', 'digest', 'negotiate', 'ntlm', 'digest_ie', 'ntlm_wb', 'none' and 'any' (default).
+
 .. _repo_gpgcheck-label:
 
 ``repo_gpgcheck``


### PR DESCRIPTION
Proxy authentication method can be set both in main or repo config
files.

https://bugzilla.redhat.com/show_bug.cgi?id=1387622

Requires https://github.com/rpm-software-management/libdnf/pull/461