### PR TITLE
Remove select_user_installed()

### DIFF
--- a/dnf/db/history.py
+++ b/dnf/db/history.py
@@ -492,16 +492,6 @@ class SwdbInterface(object):
         # TODO: return True also for libdnf.transaction.TransactionItemReason_UNKNOWN?
         return False
 
-    def select_user_installed(self, pkgs):
-        """Select user installed packages from list of pkgs"""
-        result = []
-        for po in pkgs:
-            reason = self.swdb.resolveRPMTransactionItemReason(po.name, po.arch, -1)
-            if reason != libdnf.transaction.TransactionItemReason_USER:
-                continue
-            result.append(po)
-        return result
-
     def get_erased_reason(self, pkg, first_trans, rollback):
         """Get reason of package before transaction being undone. If package
         is already installed in the system, keep his reason.


### PR DESCRIPTION
The functionality was replaced by libdnf query filter userinstalled().
Additional the implementation is incorrect.

Requires: https://github.com/rpm-software-management/libdnf/pull/462