### PR TITLE
Add bash-completion for core plugins (RhBug: 1135986) (RhBug:1425812)

### DIFF
--- a/etc/bash_completion.d/dnf
+++ b/etc/bash_completion.d/dnf
@@ -405,6 +405,10 @@ _dnf()
         esac
         ;;
 
+    debuginfo-install)
+        _dnf_show_packages list available
+        ;;
+
     *)
         complete_commands="$cmd_list"
         ;;

--- a/etc/bash_completion.d/dnf
+++ b/etc/bash_completion.d/dnf
@@ -387,6 +387,9 @@ _dnf()
         esac
         ;;
 
+    copr)
+        complete_commands="help enable disable remove list search"
+        ;;
 
     *)
         complete_commands="$cmd_list"

--- a/etc/bash_completion.d/dnf
+++ b/etc/bash_completion.d/dnf
@@ -375,6 +375,19 @@ _dnf()
         _filedir "$fext"
         ;;
 
+    config-manager)
+        extra_options="--save --set-enabled --set-disabled --add-repo --dump --dump-variables"
+
+        case "$( _dnf_get_first_command "--set-enabled --set-disabled" )" in
+        --set-enabled)
+            complete_commands="$( _dnf_commands_helper repolist disabled "$cur" )"
+            ;;
+        --set-disabled)
+            complete_commands="$( _dnf_commands_helper repolist enabled "$cur" )"
+        esac
+        ;;
+
+
     *)
         complete_commands="$cmd_list"
         ;;

--- a/etc/bash_completion.d/dnf
+++ b/etc/bash_completion.d/dnf
@@ -360,6 +360,21 @@ _dnf()
 
     whatprovides) ;;
 
+    build*dep)
+        extra_options="-D --define --spec --srpm"
+
+        local fext="@(src.rpm|spec)"
+        case "$( _dnf_get_first_command "--spec --srpm" )" in
+        --spec)
+            fext="@(spec)"
+            ;;
+        --srpm)
+            fext="@(src.rpm)"
+        esac
+
+        _filedir "$fext"
+        ;;
+
     *)
         complete_commands="$cmd_list"
         ;;

--- a/etc/bash_completion.d/dnf
+++ b/etc/bash_completion.d/dnf
@@ -422,6 +422,10 @@ _dnf()
         extra_options="-u --useronly"
         ;;
 
+    playground)
+        complete_commands="enable disable upgrade"
+        ;;
+
     *)
         complete_commands="$cmd_list"
         ;;

--- a/etc/bash_completion.d/dnf
+++ b/etc/bash_completion.d/dnf
@@ -418,6 +418,10 @@ _dnf()
         esac
         ;;
 
+    needs-restarting)
+        extra_options="-u --useronly"
+        ;;
+
     *)
         complete_commands="$cmd_list"
         ;;

--- a/etc/bash_completion.d/dnf
+++ b/etc/bash_completion.d/dnf
@@ -435,6 +435,17 @@ _dnf()
             _dnf_show_packages list available ;;
         esac
         ;;
+
+    repo*graph) ;;
+
+    repomanage)
+        extra_options="-o --old -n --new -s --space -k --keep"
+        ;;
+
+    reposync)
+        extra_options="-p --download-path"
+        ;;
+
     *)
         complete_commands="$cmd_list"
         ;;

--- a/etc/bash_completion.d/dnf
+++ b/etc/bash_completion.d/dnf
@@ -391,6 +391,11 @@ _dnf()
         complete_commands="help enable disable remove list search"
         ;;
 
+    debug-dump)
+        extra_options="--norepos"
+        _filedir
+        ;;
+
     *)
         complete_commands="$cmd_list"
         ;;

--- a/etc/bash_completion.d/dnf
+++ b/etc/bash_completion.d/dnf
@@ -426,6 +426,15 @@ _dnf()
         complete_commands="enable disable upgrade"
         ;;
 
+    repoclosure)
+        extra_options="--arch --check -n --newest --pkg"
+        case $prev in
+        --check)
+            _dnf_show_packages repolist all ;;
+        --pkg)
+            _dnf_show_packages list available ;;
+        esac
+        ;;
     *)
         complete_commands="$cmd_list"
         ;;

--- a/etc/bash_completion.d/dnf
+++ b/etc/bash_completion.d/dnf
@@ -396,6 +396,15 @@ _dnf()
         _filedir
         ;;
 
+    debug-restore)
+        extra_options="--output --install-latest --ignore-arch --filter-types"
+        case $prev in
+        --filter-types)
+            complete_commands="install remove replace"
+            ;;
+        esac
+        ;;
+
     *)
         complete_commands="$cmd_list"
         ;;

--- a/etc/bash_completion.d/dnf
+++ b/etc/bash_completion.d/dnf
@@ -409,6 +409,15 @@ _dnf()
         _dnf_show_packages list available
         ;;
 
+    download)
+        extra_options="--source --debuginfo --arch --resolve --url --urlprotocols"
+        case $prev in
+        --urlprotocols)
+            complete_commands="http https rsync ftp"
+            ;;
+        esac
+        ;;
+
     *)
         complete_commands="$cmd_list"
         ;;


### PR DESCRIPTION
The completions are only shown if the `python3-dnf-plugins-core` is installed.

https://bugzilla.redhat.com/show_bug.cgi?id=1135986
https://bugzilla.redhat.com/show_bug.cgi?id=1425812