### PR TITLE
[history] Fix traceback in dnf info.

### DIFF
--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -488,7 +488,7 @@ class Output(object):
 
         output_list = []
         (hibeg, hiend) = self._highlight(highlight)
-        pkg_data = {}
+        pkg_data = None
         if pkg._from_system:
             pkg_data = self.history.package_data(pkg)
 

--- a/dnf/db/history.py
+++ b/dnf/db/history.py
@@ -32,6 +32,7 @@ from .group import GroupPersistor, EnvironmentPersistor, RPMTransaction
 
 class RPMTransactionItemWrapper(object):
     def __init__(self, swdb, item):
+        assert item is not None
         self._swdb = swdb
         self._item = item
 
@@ -353,6 +354,8 @@ class SwdbInterface(object):
         """Get package data for package"""
         # trans item is returned
         result = self.swdb.getRPMTransactionItem(str(pkg))
+        if result is None:
+            return result
         result = RPMTransactionItemWrapper(self, result)
         return result
 


### PR DESCRIPTION
When an installed package wasn't found in history database,
dnf info <package> ended up with a traceback.
Resolves: rhbz#1583618