### PR TITLE
Zchunk support for dnf

### DIFF
--- a/dnf/repo.py
+++ b/dnf/repo.py
@@ -61,7 +61,7 @@ _CACHEDIR_RE = r'(?P<repoid>[%s]+)\-[%s]{16}' % (re.escape(_REPOID_CHARS),
 # particular type.  The filename is expected to not contain the base cachedir
 # path components.
 CACHE_FILES = {
-    'metadata': r'^%s\/.*(xml(\.gz|\.xz|\.bz2)?|asc|cachecookie|%s)$' %
+    'metadata': r'^%s\/.*(xml(\.zck|\.gz|\.xz|\.bz2)?|asc|cachecookie|%s)$' %
                 (_CACHEDIR_RE, _MIRRORLIST_FILENAME),
     'packages': r'^%s\/%s\/.+rpm$' % (_CACHEDIR_RE, _PACKAGES_RELATIVE_DIR),
     'dbcache': r'^.+(solv|solvx)$',

--- a/dnf/repo.py
+++ b/dnf/repo.py
@@ -752,6 +752,13 @@ class Repo(dnf.conf.RepoConf):
         if self.sslclientkey:
             h.setopt(librepo.LRO_SSLCLIENTKEY, self.sslclientkey)
 
+        # setup cache directory
+        if self.basecachedir:
+            try:
+                h.setopt(librepo.LRO_CACHEDIR, self.basecachedir)
+            except AttributeError:
+                pass
+
         # setup download progress
         h.progresscb = self._md_pload._progress_cb
         self._md_pload.fastest_mirror_running = False


### PR DESCRIPTION
This set has two patches:
The first recognizes zchunk files as legitimate cache files.
If librepo supports setting the cache directory, the second patch passes basecachedir to it.  This is necessary for librepo to find old zchunk metadata to delta against.  This patch is backwards compatible with versions of librepo that don't support setting the cache