### PR TITLE
Fix crash in dnf group list after marking comps env as installed.

### DIFF
--- a/dnf/cli/commands/group.py
+++ b/dnf/cli/commands/group.py
@@ -74,10 +74,7 @@ class GroupCommand(commands.Command):
     def _environment_lists(self, patterns):
         def available_pred(env):
             env_found = self.base.history.env.get(env.id)
-            if env_found:
-                return not env_found.installed
-            else:
-                return True
+            return not(env_found)
 
         self._assert_comps()
         if patterns is None:


### PR DESCRIPTION
Reproducer:
* system without groups/envs installed
* $ dnf group mark install minimal-environment
* $ dnf group list

Traceback:
  File ".../dnf/cli/commands/group.py", line 78, in available_pred
    return not env_found.installed
  File ".../libdnf/transaction.py", line 344, in <lambda>
    __getattr__ = lambda self, name: _swig_getattr(self, CompsEnvironmentItem, name)
  File ".../libdnf/transaction.py", line 80, in _swig_getattr
    raise AttributeError("'%s' object has no attribute '%s'" % (class_type.__name__, name))