### PR TITLE
makecache --timer fixes

### DIFF
--- a/dnf/cli/commands/makecache.py
+++ b/dnf/cli/commands/makecache.py
@@ -38,7 +38,7 @@ class MakeCacheCommand(commands.Command):
 
     @staticmethod
     def set_argparser(parser):
-        parser.add_argument('--timer', action='store_true')
+        parser.add_argument('--timer', action='store_true', dest="timer_opt")
         # compatibility with dnf < 2.0
         parser.add_argument('timer', nargs='?', choices=['timer'],
                             metavar='timer', help=argparse.SUPPRESS)
@@ -50,6 +50,7 @@ class MakeCacheCommand(commands.Command):
         commands._checkEnabledRepo(self.base)
 
     def run(self):
+        timer = self.opts.timer is not None or self.opts.timer_opt
         msg = _("Making cache files for all metadata files.")
         logger.debug(msg)
-        return self.base.update_cache(self.opts.timer is not None)
+        return self.base.update_cache(timer)

--- a/etc/systemd/dnf-makecache.service
+++ b/etc/systemd/dnf-makecache.service
@@ -11,4 +11,4 @@ Nice=19
 IOSchedulingClass=2
 IOSchedulingPriority=7
 Environment="ABRT_IGNORE_PYTHON=1"
-ExecStart=/usr/bin/dnf makecache timer
+ExecStart=/usr/bin/dnf makecache --timer

--- a/etc/systemd/dnf-makecache.timer
+++ b/etc/systemd/dnf-makecache.timer
@@ -1,5 +1,5 @@
 [Unit]
-Description=dnf makecache timer
+Description=dnf makecache --timer
 ConditionKernelCommandLine=!rd.live.image
 # See comment in dnf-makecache.service
 ConditionPathExists=!/run/ostree-booted


### PR DESCRIPTION
This pull request changes `dnf-makecache.service` to use the `--timer` option as currently documented in the `dnf` manual, and fixes this option so that it actually takes effect.