### PR TITLE
Implements libdnf logger

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -1,5 +1,5 @@
 # default dependencies
-%global hawkey_version 0.14.0
+%global hawkey_version 0.16.0
 %global librepo_version 1.9.0
 %global libcomps_version 0.1.8
 %global libmodulemd_version 1.4.0
@@ -73,7 +73,7 @@
 It supports RPMs, modules and comps groups & environments.
 
 Name:           dnf
-Version:        3.0.3
+Version:        3.0.4
 Release:        1%{?dist}
 Summary:        %{pkg_summary}
 # For a breakdown of the licensing, see PACKAGE-LICENSING


### PR DESCRIPTION
Defines an LibdnfLoggerCB class that forwards messages from libdnf to DNF logger.

Depends on https://github.com/rpm-software-management/libdnf/pull/499