### PR TITLE
Use `shlex` for command_email; Add sendwait to example command

### DIFF
--- a/dnf/automatic/emitter.py
+++ b/dnf/automatic/emitter.py
@@ -26,6 +26,7 @@ import logging
 import dnf.pycomp
 import smtplib
 import email.utils
+import shlex
 import subprocess
 
 APPLIED = _("The following updates have been applied on '%s':")
@@ -130,7 +131,8 @@ class CommandEmitterMixIn(object):
         stdin_feed = stdin_fmt.format(**msg).encode('utf-8')
 
         # Execute the command
-        subp = subprocess.Popen(command, shell=True, stdin=subprocess.PIPE)
+        args = shlex.split(command)
+        subp = subprocess.Popen(args, shell=True, stdin=subprocess.PIPE)
         subp.communicate(stdin_feed)
         subp.stdin.close()
         if subp.wait() != 0:

--- a/etc/dnf/automatic.conf
+++ b/etc/dnf/automatic.conf
@@ -61,7 +61,7 @@ email_host = localhost
 # The shell command to use to send email. This is a Python format string,
 # as used in str.format(). The format function will pass shell-quoted arguments
 # called body, subject, email_from, email_to.
-# command_format = "mail -s {subject} -r {email_from} {email_to}"
+# command_format = "mail -S sendwait -s {subject} -r {email_from} {email_to}"
 
 # The contents of stdin to pass to the command. It is a format string with the
 # same arguments as `command_format`.


### PR DESCRIPTION
I was not able to make example command running without making these modifications to code and config.

I was trying to make it work on Fedora 28
Name         : dnf-automatic
Version      : 2.7.5
Release      : 12.fc28
