### PR TITLE
WIP [modularity] implicit empty default profile (RhBug:1568165)

### DIFF
--- a/dnf/module/repo_module_version.py
+++ b/dnf/module/repo_module_version.py
@@ -67,7 +67,7 @@ class RepoModuleVersion(object):
 
         result = False
         for profile in profiles:
-            if profile not in self.profiles:
+            if profile not in self.profiles + ['default']:
                 self.report_profile_error(profile, defaults_used)
 
             for nevra_object in self.profile_nevra_objects(profile):
@@ -158,7 +158,12 @@ class RepoModuleVersion(object):
         return "{}-{}".format(nevra_object.name, nevra_object.evr())
 
     def rpms(self, profile):
-        return self.module_metadata.peek_profiles()[profile].peek_rpms().dup()
+        module_profiles = self.module_metadata.peek_profiles()
+        if profile not in module_profiles and profile in ['default']:
+            result = []
+        else:
+            result = module_profiles[profile].peek_rpms().dup()
+        return result
 
     def profile_nevra_objects(self, profile):
         result = []


### PR DESCRIPTION
_Note: this PR is a rebase of PR #1077 against the master branch._

According to the modulemd specification, the default profile is always to be assumed to exist. If it is not explicitly defined, the tooling should expect it to be empty.

This is to provide a reasonable fallback and enhance the user experience.

https://bugzilla.redhat.com/show_bug.cgi?id=1568165