### PR TITLE
Collections deprecation warning on Python 3.7+ (RhBug:1598039)

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -38,7 +38,10 @@ from dnf.util import _parse_specs
 from dnf.db.history import SwdbInterface
 from dnf.yum import misc
 from functools import reduce
-import collections
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 import datetime
 import dnf.callback
 import dnf.comps
@@ -855,7 +858,7 @@ class Base(object):
 
     def do_transaction(self, display=()):
         # :api
-        if not isinstance(display, collections.Sequence):
+        if not isinstance(display, Sequence):
             display = [display]
         display = \
             [dnf.yum.rpmtrans.LoggingTransactionDisplay()] + list(display)

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -28,7 +28,10 @@ from . import output
 from dnf.cli import CliError
 from dnf.i18n import ucd, _
 
-import collections
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 import dnf
 import dnf.cli.commands
 import dnf.cli.commands.autoremove
@@ -228,7 +231,7 @@ class BaseCli(dnf.Base):
         if self.conf.downloadonly:
             return
 
-        if not isinstance(display, collections.Sequence):
+        if not isinstance(display, Sequence):
             display = [display]
         display = [output.CliTransactionDisplay()] + list(display)
         super(BaseCli, self).do_transaction(display)

--- a/dnf/persistor.py
+++ b/dnf/persistor.py
@@ -26,7 +26,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from dnf.i18n import _
-import collections
 import distutils.version
 import dnf.util
 import errno


### PR DESCRIPTION
In Python 3.8, the abstract base classes in collections.abc will no longer be
exposed in the regular collections module. This will help create a clearer
distinction between the concrete classes and the abstract base classes.
https://docs.python.org/3.7/whatsnew/3.7.html#id3

https://bugzilla.redhat.com/show_bug.cgi?id=1598039