### PR TITLE
Do not use string for librepo.LRO_URLS option (RhBug:1608025)

### DIFF
--- a/dnf/util.py
+++ b/dnf/util.py
@@ -92,7 +92,7 @@ def _non_repo_handle(conf=None):
 def _urlopen_progress(url, conf, progress=None):
     handle = _non_repo_handle(conf)
     handle.repotype = librepo.LR_YUMREPO
-    handle.setopt(librepo.LRO_URLS, os.path.dirname(url))
+    handle.setopt(librepo.LRO_URLS, [os.path.dirname(url)])
     if progress is None:
         progress = dnf.callback.NullDownloadProgress()
     pload = dnf.repo.RemoteRPMPayload(url, conf, handle, progress)


### PR DESCRIPTION
Using string value for LRO_URLS is deprecated, use list of strings instead.

https://bugzilla.redhat.com/show_bug.cgi?id=1608025