### PR TITLE
Function locale.format is deprecated (RhBug:1609479)

### DIFF
--- a/dnf/pycomp.py
+++ b/dnf/pycomp.py
@@ -64,7 +64,7 @@ if PY3:
 
     # functions that don't take unicode arguments in py2
     ModuleType = lambda m: types.ModuleType(m)
-    format = locale.format
+    format = locale.format_string
     def setlocale(category, loc=None):
         locale.setlocale(category, loc)
     def write_to_file(f, content):


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1609479