### PR TITLE
[conf] Fix BaseConfig's __getattr__() and __str__() methods.

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -1,5 +1,5 @@
 # default dependencies
-%global hawkey_version 0.16.1
+%global hawkey_version 0.16.2
 %global librepo_version 1.9.0
 %global libcomps_version 0.1.8
 %global libmodulemd_version 1.4.0
@@ -73,7 +73,7 @@
 It supports RPMs, modules and comps groups & environments.
 
 Name:           dnf
-Version:        3.1.0
+Version:        3.1.1
 Release:        1%{?dist}
 Summary:        %{pkg_summary}
 # For a breakdown of the licensing, see PACKAGE-LICENSING

--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -202,7 +202,9 @@ class BaseConfig(object):
         setattr(type(self), name, property(prop_get, prop_set))
 
     def __getattr__(self, name):
-        option = getattr(self._config, name, None)
+        if "_config" not in self.__dict__:
+            raise AttributeError("'{}' object has no attribute '{}'".format(self.__class__, name))
+        option = getattr(self._config, name)
         if option is None:
             return None
         try:
@@ -249,7 +251,11 @@ class BaseConfig(object):
         out.append('[%s]' % self._section)
         if self._config:
             for optBind in self._config.optBinds():
-                out.append('%s: %s' % (optBind.first, optBind.second.getValueString()))
+                try:
+                    value = optBind.second.getValueString()
+                except RuntimeError:
+                    value = ""
+                out.append('%s: %s' % (optBind.first, value))
         return '\n'.join(out)
 
     def _get_option(self, name):


### PR DESCRIPTION
__getattr__() must raise AttributteError instead of returning None to make copy() work properly.
__str__() was crashing on unset values. Empty string is returned in such cases now.