### PR TITLE
Fix attribute error if data in ini not in module.conf

### DIFF
--- a/dnf/module/persistor.py
+++ b/dnf/module/persistor.py
@@ -24,8 +24,11 @@ class ModulePersistor(object):
     def set_data(self, repo_module, **kwargs):
         self.repo_modules.append(repo_module)
         for name, value in kwargs.items():
-            attribute = getattr(repo_module.conf, name)
-            attribute._set(value)
+            try:
+                attribute = getattr(repo_module.conf, name)
+                attribute._set(value)
+            except AttributeError:
+                continue
 
     def commit(self):
         self._commit = True


### PR DESCRIPTION
This happen when version of module was removed from ini in /etc

Traceback (most recent call last):
  File "/bin/dnf", line 58, in <module>
    main.user_main(sys.argv[1:], exit_code=True)
  File "/usr/lib/python3.6/site-packages/dnf/cli/main.py", line 179, in user_main
    errcode = main(args)
  File "/usr/lib/python3.6/site-packages/dnf/cli/main.py", line 64, in main
    return _main(base, args, cli_class, option_parser_class)
  File "/usr/lib/python3.6/site-packages/dnf/cli/main.py", line 99, in _main
    return cli_run(cli, base)
  File "/usr/lib/python3.6/site-packages/dnf/cli/main.py", line 115, in cli_run
    cli.run()
  File "/usr/lib/python3.6/site-packages/dnf/cli/cli.py", line 1044, in run
    return self.command.run()
  File "/usr/lib/python3.6/site-packages/dnf/cli/commands/module.py", line 266, in run
    self.subcmd.run_on_module()
  File "/usr/lib/python3.6/site-packages/dnf/cli/commands/module.py", line 143, in run_on_module
    self.base.conf.strict)
  File "/usr/lib/python3.6/site-packages/dnf/module/repo_module_dict.py", line 244, in install
    self.enable("{}:{}".format(module_version.name, module_version.stream))
  File "/usr/lib/python3.6/site-packages/dnf/module/repo_module_dict.py", line 224, in enable
    self.enable_by_version(module_version, save_immediately)
  File "/usr/lib/python3.6/site-packages/dnf/module/repo_module_dict.py", line 214, in enable_by_version
    self[dependency.name].enable(dependency.stream, self.base.conf.assumeyes)
  File "/usr/lib/python3.6/site-packages/dnf/module/repo_module.py", line 91, in enable
    self.parent.base._module_persistor.set_data(self, version=-1, profiles=[])
  File "/usr/lib/python3.6/site-packages/dnf/module/persistor.py", line 28, in set_data
    attribute = getattr(repo_module.conf, name)
  File "/usr/lib/python3.6/site-packages/dnf/conf/config.py", line 207, in __getattr__
    option = getattr(self._config, name)
AttributeError: 'NoneType' object has no attribute 'version'