### PR TITLE
dnf-makecache.timer: move the ordering after network to .service

### DIFF
--- a/etc/systemd/dnf-makecache.service
+++ b/etc/systemd/dnf-makecache.service
@@ -5,6 +5,8 @@ Description=dnf makecache
 # anyone who wants that could override this via a file in /etc.
 ConditionPathExists=!/run/ostree-booted
 
+After=network-online.target
+
 [Service]
 Type=oneshot
 Nice=19

--- a/etc/systemd/dnf-makecache.timer
+++ b/etc/systemd/dnf-makecache.timer
@@ -4,7 +4,6 @@ ConditionKernelCommandLine=!rd.live.image
 # See comment in dnf-makecache.service
 ConditionPathExists=!/run/ostree-booted
 Wants=network-online.target
-After=network-online.target
 
 [Timer]
 OnBootSec=10min


### PR DESCRIPTION
The timer does not need the network. The service needs it. Move the
After=network-online.target line to the service file. Wants=network-online.target
is still in .timer, which means that the network-online.target and services that
implement it will be pulled in from the .timer and started eagerly. But there is
no ordering, so they only need to finish before the .service is started.

Keeping the ordering dependency between timer and network-online.target means
that network-online.target is ordered before multi-user.target, which is wrong,
because it delays multi-user.target for no good reason.

This patch changes the ordering so that the service will be started
{10 minutes after boot} or when the network is available, whatever is
later, and not 10 minutes after {the network is available and the
boot is finished, whatever is later}.

Tested by running an affected system without AdamWill's patch but with this patch,
and confirming that the ordering loop is gone. (AdamWill's patch is correct on its
own, because putting this timer and the associated service in basic.target is
bonkers.)

Follow-up for 3144280dc7b4adc95427aa57aaac67d4c7bc45f1.

Signed-off-by: Zbigniew Jędrzejewski-Szmek <zbyszek@in.waw.pl>