### PR TITLE
[history] Populate history operations via goal rather than directly.

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -617,7 +617,7 @@ class BaseCli(dnf.Base):
 #            operations += history.transaction_nevra_ops(id_)
 
         try:
-            self._history_undo_operations(mobj, old.tid + 1, True)
+            self._history_undo_operations(mobj, old.tid + 1, True, strict=self.conf.strict)
         except dnf.exceptions.PackagesNotInstalledError as err:
             raise
             logger.info(_('No package %s installed.'),
@@ -649,9 +649,7 @@ class BaseCli(dnf.Base):
         mobj = dnf.db.history.MergedTransactionWrapper(old)
 
         try:
-            self._history_undo_operations(
-                mobj,
-                old.tid)
+            self._history_undo_operations(mobj, old.tid, strict=self.conf.strict)
         except dnf.exceptions.PackagesNotInstalledError as err:
             logger.info(_('No package %s installed.'),
                         self.output.term.bold(ucd(err.pkg_spec)))


### PR DESCRIPTION
When transaction is populated directly, running scriptlets ends up
with errors: RuntimeError: TransactionItem not found for key: <rpm-name>
Using populating transaction via goal and Base._goal2transaction()
fixes the problem.

Resolves: rhbz#1625259