### PR TITLE
Change reposdir handling in installroot (RhBug:1582535)

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -930,7 +930,7 @@ class Cli(object):
         conf.read(priority=dnf.conf.PRIO_MAINCONFIG)
 
         # search reposdir file inside the installroot first
-        conf._search_inside_installroot('reposdir')
+        conf._search_reposdir_inside_installroot()
 
         # cachedir, logs, releasever, and gpgkey are taken from or stored in installroot
         subst = conf.substitutions


### PR DESCRIPTION
It will use host repos even if repos dir path exists in istallroot but
it doesn't contain any *.repo file.

https://bugzilla.redhat.com/show_bug.cgi?id=1582535