### PR TITLE
[config] Return vector options as tuple

### DIFF
--- a/dnf/cli/commands/check.py
+++ b/dnf/cli/commands/check.py
@@ -68,7 +68,7 @@ class CheckCommand(commands.Command):
             self.opts.check_types = {'all'}
         else:
             self.opts.check_types = set(self.opts.check_types)
-        self.base.conf.disable_excludes += ["all"]
+        self.base.conf.disable_excludes += ("all",)
 
     def run(self):
         output_set = set()

--- a/dnf/cli/commands/group.py
+++ b/dnf/cli/commands/group.py
@@ -413,9 +413,9 @@ class GroupCommand(commands.Command):
 
         if cmd == 'install':
             if self.opts.with_optional:
-                types = tuple(self.base.conf.group_package_types + ['optional'])
+                types = self.base.conf.group_package_types + ('optional',)
             else:
-                types = tuple(self.base.conf.group_package_types)
+                types = self.base.conf.group_package_types
 
             self._remark = True
             try:

--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -213,11 +213,11 @@ class BaseConfig(object):
         except Exception as ex:
             return None
         if isinstance(value, libdnf.conf.VectorString):
-            return list(value)
+            return tuple(value)
         if type(value).__name__ == "VectorString":
             # every module generated with swig provides a different VectorString class
             # that's why isinstance() is insufficient and the type has to be matched by name
-            return list(value)
+            return tuple(value)
         if isinstance(value, str):
             return ucd(value)
         return value

--- a/dnf/repodict.py
+++ b/dnf/repodict.py
@@ -87,7 +87,7 @@ class RepoDict(dict):
         for path in baseurl:
             if '://' not in path:
                 path = 'file://{}'.format(os.path.abspath(path))
-            repo.baseurl += [substitute(path)]
+            repo.baseurl += (substitute(path),)
         for (key, value) in kwargs.items():
             setattr(repo, key, substitute(value))
         self.add(repo)

--- a/tests/conf/test_read.py
+++ b/tests/conf/test_read.py
@@ -40,7 +40,7 @@ class RepoReaderTest(tests.support.TestCase):
 
         r1 = all_repos[0]
         self.assertEqual(r1.id, 'fixing')
-        self.assertEqual(r1.baseurl, ['http://cracks'])
+        self.assertEqual(r1.baseurl, ('http://cracks',))
 
         r2 = all_repos[1]
         self.assertEqual(r2.id, 'rain')

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -171,7 +171,7 @@ class CommonTest(tests.support.ResultTestCase):
 
     def test_pkg_install_installonly(self):
         """Test that installonly packages are installed, not upgraded."""
-        self.base.conf.installonlypkgs += ['hole']
+        self.base.conf.installonlypkgs += ('hole',)
         p = self.base.sack.query().available().filter(
             nevra='hole-1-2.x86_64')[0]
         self.assertEqual(1, self.base.package_install(p))
@@ -244,7 +244,7 @@ class MultilibAllTest(tests.support.ResultTestCase):
 
     def test_install_installonly(self):
         """Test that installonly packages are installed, not upgraded."""
-        self.base.conf.installonlypkgs += ['hole']
+        self.base.conf.installonlypkgs += ('hole',)
         self.base.install('hole-1-2')
         installed, removed = self.installed_removed(self.base)
         self.assertGreaterEqual(
@@ -384,7 +384,7 @@ class MultilibBestTest(tests.support.ResultTestCase):
 
     def test_install_installonly(self):
         """Test that installonly packages are installed, not upgraded."""
-        self.base.conf.installonlypkgs += ['hole']
+        self.base.conf.installonlypkgs += ('hole',)
         self.base.install('hole-1-2')
         installed, removed = self.installed_removed(self.base)
         self.assertGreaterEqual(


### PR DESCRIPTION
*list* was returned before. It was confusing because it returns "copy". Modifying of the returned list do not change configuration.
Immutable object *tuple* is returned now.
This is an 'interface change'. More info there: 
https://bugzilla.redhat.com/show_bug.cgi?id=1595917
https://bugzilla.redhat.com/show_bug.cgi?id=1625434