### PR TITLE
replace ??? with ---

### DIFF
--- a/dnf/cli/progress.py
+++ b/dnf/cli/progress.py
@@ -147,7 +147,7 @@ class MultiFileProgressMeter(dnf.callback.DownloadProgress):
                 p = 3
                 n = 0 if n < 0 else n
                 bar = ' ' * n + '=' * p
-                msg = '%3s%% [%-*s]%s' % ('???', bl, bar, msg)
+                msg = '     [%-*s]%s' % (bl, bar, msg)
                 left -= bl + 7
                 self.unknown_progres = self.unknown_progres + 3 if self.unknown_progres + 3 < bl \
                     else 0


### PR DESCRIPTION
This unifies the semantics with time_eta and rate, used few lines above.
And according to several people, I asked the question mark people confuse, while dashes do not.

This results in `'---% [bar]msg'`
The other option I considered:
* `'N/A%  [bar]msg'`
* `'      [bar]msg'`