### PR TITLE
Unify behavior of list and module list commands

### DIFF
--- a/dnf/cli/commands/module.py
+++ b/dnf/cli/commands/module.py
@@ -65,8 +65,11 @@ class ModuleCommand(commands.Command):
                     self.opts.module_spec, libdnf.module.ModulePackageContainer.ModuleState_UNKNOWN)
             if output:
                 print(output)
-            else:
-                raise dnf.exceptions.Error(_('No matching Modules to list'))
+                return
+            msg = _('No matching Modules to list')
+            if self.opts.module_spec:
+                raise dnf.exceptions.Error(msg)
+            logger.warning(msg)
 
     class InfoSubCommand(SubCommand):
 

--- a/dnf/module/module_base.py
+++ b/dnf/module/module_base.py
@@ -185,7 +185,7 @@ class ModuleBase(object):
 
         if remove_package_set:
             keep_pkg_names = self.base._moduleContainer.getInstalledPkgNames()
-            remove_package_set.difference(keep_pkg_names)
+            remove_package_set = remove_package_set.difference(keep_pkg_names)
             if remove_package_set:
                 query = self.base.sack.query().installed().filterm(name=remove_package_set)
                 if query:


### PR DESCRIPTION
In case tat no argument used and no output, it returns only warning and
RC 0. This is yum compatible behavior.

Requires: https://github.com/rpm-software-management/libdnf/pull/583