### PR TITLE
Unify behavior of remove and module remove

### DIFF
--- a/dnf/cli/commands/module.py
+++ b/dnf/cli/commands/module.py
@@ -200,7 +200,13 @@ class ModuleCommand(commands.Command):
             demands.sack_activation = True
 
         def run_on_module(self):
-            self.module_base.remove(self.opts.module_spec)
+            skipped_groups = self.module_base.remove(self.opts.module_spec)
+            if not skipped_groups:
+                return
+            groups = set(self.opts.module_spec)
+            if not groups.difference(skipped_groups):
+                raise dnf.exceptions.MarkingErrors(no_match_group_specs=skipped_groups)
+            logger.error(dnf.exceptions.MarkingErrors(no_match_group_specs=skipped_groups))
 
     class ProvidesSubCommand(SubCommand):
 

--- a/dnf/module/module_base.py
+++ b/dnf/module/module_base.py
@@ -232,13 +232,14 @@ class ModuleBase(object):
         for moduleName, streamDict in moduleDict.items():
             moduleState = self.base._moduleContainer.getModuleState(moduleName)
             if len(streamDict) > 1:
-                if moduleState != STATE_DEFAULT and moduleState != STATE_ENABLED:
+                if moduleState != STATE_DEFAULT and moduleState != STATE_ENABLED \
+                        and moduleState != STATE_DISABLED:
                     raise EnableMultipleStreamsException(moduleName)
                 if moduleState == STATE_ENABLED:
                     stream = self.base._moduleContainer.getEnabledStream(moduleName)
                 else:
                     stream = self.base._moduleContainer.getDefaultStream(moduleName)
-                if stream not in streamDict:
+                if not stream or stream not in streamDict:
                     raise EnableMultipleStreamsException(moduleName)
                 for key in sorted(streamDict.keys()):
                     if key == stream:


### PR DESCRIPTION
Now if there will be nothing to remove, the command will fail. If
something was unresolved, then the command will return 0. This behavior
is identical to "dnf remove" command.

https://bugzilla.redhat.com/show_bug.cgi?id=1629848