### PR TITLE
Fix remove command error when no packages marked for removal (RhBug:1541832)

### DIFF
--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -676,7 +676,7 @@ class RepoPkgsCommand(Command):
                         done = True
 
             if not done:
-                raise dnf.exceptions.Error(_('No packages marked for removal.'))
+                logger.info(_('No packages marked for removal.'))
 
     class UpgradeSubCommand(Command):
         """Implementation of the upgrade sub-command."""

--- a/dnf/cli/commands/remove.py
+++ b/dnf/cli/commands/remove.py
@@ -87,7 +87,8 @@ class RemoveCommand(commands.Command):
             instonly = self.base._get_installonly_query(q.installed())
             dups = q.duplicated().difference(instonly)
             if not dups:
-                raise dnf.exceptions.Error(_('No duplicated packages found for removal.'))
+                logger.info(_('No duplicated packages found for removal.'))
+                return
 
             for (name, arch), pkgs_list in dups._na_dict().items():
                 if len(pkgs_list) < 2:
@@ -112,7 +113,7 @@ class RemoveCommand(commands.Command):
                 for pkg in instonly:
                     self.base.package_remove(pkg)
             else:
-                raise dnf.exceptions.Error(
+                logger.info(
                     _('No old installonly packages found for removal.'))
             return
 
@@ -142,4 +143,4 @@ class RemoveCommand(commands.Command):
                 done = True
 
         if not done:
-            raise dnf.exceptions.Error(_('No packages marked for removal.'))
+            logger.info(_('No packages marked for removal.'))

--- a/tests/cli/commands/test_remove.py
+++ b/tests/cli/commands/test_remove.py
@@ -54,9 +54,9 @@ class RemoveCommandTest(tests.support.ResultTestCase):
         stdout = dnf.pycomp.StringIO()
 
         with tests.support.wiretap_logs('dnf', logging.INFO, stdout):
-            self.assertRaises(dnf.exceptions.Error, tests.support.command_run, self.cmd,
-                              ['non-existent'])
+            tests.support.command_run(self.cmd, ['non-existent'])
 
         self.assertEqual(stdout.getvalue(),
-                         'No match for argument: non-existent\n')
+                         'No match for argument: non-existent\n'
+                         'No packages marked for removal.\n')
         self.assertResult(self.cmd.base, self.cmd.base.sack.query().installed())


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1541832
Removing not installed package should return 0, just like installing already
installed package.