### PR TITLE
automatic: set a timeout for EmailEmitter SMTP connections

### DIFF
--- a/dnf/automatic/emitter.py
+++ b/dnf/automatic/emitter.py
@@ -100,7 +100,7 @@ class EmailEmitter(Emitter):
 
         # Send the email
         try:
-            smtp = smtplib.SMTP(self._conf.email_host)
+            smtp = smtplib.SMTP(self._conf.email_host, timeout=300)
             smtp.sendmail(email_from, email_to, message.as_string())
             smtp.close()
         except smtplib.SMTPException as exc:


### PR DESCRIPTION
When sending emails, the dnf-automatic EmailEmitter was not
setting any timeout for the SMTP connection. The docs state that
"if not specified, the global default timeout setting will be
used", but in practice, it seems like the attempt to connect
just blocked forever if the server wasn't responding, and this
was causing the stuck dnf-automatic processes we kept finding on
Fedora infra systems:

https://bugzilla.redhat.com/show_bug.cgi?id=1627909

ultimately the culprit was bad postfix configuration, but if
the server is busted, dnf-automatic probably shouldn't just hang
forever. 5 minutes for each blocking operation seems like more
than long enough.

Signed-off-by: Adam Williamson <awilliam@redhat.com>