### PR TITLE
Printing tables in module list

### DIFF
--- a/dnf/module/module_base.py
+++ b/dnf/module/module_base.py
@@ -488,7 +488,7 @@ class ModuleBase(object):
 
     def _create_and_fill_table(self, latest):
         table = libdnf.smartcols.Table()
-        table.setTermforce(libdnf.smartcols.Table.TermForce_ALWAYS)
+        table.setTermforce(libdnf.smartcols.Table.TermForce_AUTO)
         table.enableMaxout(True)
         column_name = table.newColumn("Name")
         column_stream = table.newColumn("Stream")

--- a/dnf/module/module_base.py
+++ b/dnf/module/module_base.py
@@ -562,7 +562,7 @@ class ModuleBase(object):
 
     def _format_header(self, table):
         line = table.getLine(0)
-        return table.toString(line, line).split('\n', 1)[0]
+        return table.toString(line, line).split('\n', 1)[0] + '\n'
 
     def _format_repoid(self, repo_name):
         return "{}\n".format(self.base.output.term.bold(repo_name))


### PR DESCRIPTION
Add missing newline after table header (RhBug: https://bugzilla.redhat.com/show_bug.cgi?id=1629702 )
Set termforce to AUTO to automatically detect if stdout is terminal