### PR TITLE
docs: remove repoquery man page

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -5,7 +5,7 @@
 %global rpm_version 4.14.0
 
 # conflicts
-%global conflicts_dnf_plugins_core_version 3.0.4
+%global conflicts_dnf_plugins_core_version 3.1
 %global conflicts_dnf_plugins_extras_version 3.0.2
 %global conflicts_dnfdaemon_version 0.3.19
 
@@ -72,7 +72,7 @@
 It supports RPMs, modules and comps groups & environments.
 
 Name:           dnf
-Version:        3.6.1
+Version:        3.7.0
 Release:        1%{?dist}
 Summary:        %{pkg_summary}
 # For a breakdown of the licensing, see PACKAGE-LICENSING
@@ -433,12 +433,10 @@ ln -sr  %{buildroot}%{confdir}/vars %{buildroot}%{_sysconfdir}/yum/vars
 %{_sysconfdir}/yum/pluginconf.d
 %{_sysconfdir}/yum/protected.d
 %{_sysconfdir}/yum/vars
-%{_mandir}/man1/repoquery.1.*
 %{_mandir}/man5/yum.conf.5.*
 %{_mandir}/man8/yum.8*
 %{_mandir}/man8/yum-shell.8*
 %else
-%exclude %{_mandir}/man1/repoquery.1.*
 %exclude %{_mandir}/man8/yum-shell.8*
 %exclude %{_sysconfdir}/yum/pluginconf.d
 %exclude %{_sysconfdir}/yum/protected.d

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -21,6 +21,4 @@ if (NOT WITH_MAN EQUAL 0)
     INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/dnf.conf.5
               ${CMAKE_CURRENT_BINARY_DIR}/yum.conf.5
               DESTINATION share/man/man5)
-    INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/repoquery.1
-              DESTINATION share/man/man1)
 endif()

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -244,8 +244,6 @@ man_pages = [
      AUTHORS, 8),
     ('command_ref', 'yum', u'redirecting to DNF Command Reference',
      AUTHORS, 8),
-    ('command_ref', 'repoquery', u'redirecting to DNF Command Reference',
-     AUTHORS, 1),
     ('command_ref', 'yum-shell', u'redirecting to DNF Command Reference',
      AUTHORS, 8),
 ]


### PR DESCRIPTION
For consistency, this man page will be provided by dnf-utils which also
provides the actual CLI shim called "repoquery".