### PR TITLE
Calculate sack version from all installed packages (RhBug:1624291)

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -1,5 +1,5 @@
 # default dependencies
-%global hawkey_version 0.20.0
+%global hawkey_version 0.21.0
 %global libcomps_version 0.1.8
 %global libmodulemd_version 1.4.0
 %global rpm_version 4.14.0

--- a/dnf/sack.py
+++ b/dnf/sack.py
@@ -68,14 +68,14 @@ class Sack(hawkey.Sack):
             self.installonly = installonly
         self.installonly_limit = installonly_limit
 
-    def query(self):
+    def query(self, flags=0):
         # :api
         """Factory function returning a DNF Query."""
-        return dnf.query.Query(self)
+        return dnf.query.Query(self, flags)
 
     def _rpmdb_version(self):
         # TODO: verify ordering
-        pkgs = self.query().installed().run()
+        pkgs = self.query(hawkey.IGNORE_EXCLUDES).installed().run()
         main = SackVersion()
         for i in pkgs:
             # TODO: what if _pkgid is not sha1


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1624291

Requires: https://github.com/rpm-software-management/libdnf/pull/603