### PR TITLE
Implements --changelogs option for dnf check-update

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -307,9 +307,10 @@ class BaseCli(dnf.Base):
 
     def format_changelog(self, changelog):
         """Return changelog formated as in spec file"""
-        chlog_str = '* %s %s\n%s\n' % (changelog['timestamp'].strftime("%a %b %d %Y"),
-                                       dnf.i18n.ucd(changelog['author']),
-                                       dnf.i18n.ucd(changelog['text']))
+        chlog_str = '* %s %s\n%s\n' % (
+            changelog['timestamp'].strftime("%a %b %d %X %Y"),
+            dnf.i18n.ucd(changelog['author']),
+            dnf.i18n.ucd(changelog['text']))
         return chlog_str
 
     def print_changelogs(self, packages):

--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -264,12 +264,17 @@ class CheckUpdateCommand(Command):
 
     @staticmethod
     def set_argparser(parser):
+        parser.add_argument('--changelogs', dest='changelogs',
+                            default=False, action='store_true',
+                            help=_('show changelogs before update'))
         parser.add_argument('packages', nargs='*', metavar=_('PACKAGE'))
 
     def configure(self):
         demands = self.cli.demands
         demands.sack_activation = True
         demands.available_repos = True
+        if self.opts.changelogs:
+            demands.changelogs = True
         _checkEnabledRepo(self.base)
 
     def run(self):
@@ -280,7 +285,8 @@ class CheckUpdateCommand(Command):
             query = query.union(obsoletes)
         self.cli._populate_update_security_filter(self.opts, query, cmp_type="gte")
 
-        found = self.base.check_updates(self.opts.packages, print_=True)
+        found = self.base.check_updates(self.opts.packages, print_=True,
+                                        changelogs=self.opts.changelogs)
         if found:
             self.cli.demands.success_exit_status = 100
 

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -410,9 +410,9 @@ Check Command
 Check Update Command
 --------------------
 
-``dnf [options] check-update [<package-specs>...]``
+``dnf [options] check-update [--changelogs] [<package-specs>...]``
 
-    Non-interactively checks if updates of the specified packages are available. If no ``<package-specs>`` are given, checks whether any updates at all are available for your system. DNF exit code will be 100 when there are updates available and a list of the updates will be printed, 0 if not and 1 if an error occurs.
+    Non-interactively checks if updates of the specified packages are available. If no ``<package-specs>`` are given, checks whether any updates at all are available for your system. DNF exit code will be 100 when there are updates available and a list of the updates will be printed, 0 if not and 1 if an error occurs. If ``--changelogs`` option is specified, also changelog delta of packages about to be updated is printed.
 
     Please note that having a specific newer version available for an installed package (and reported by ``check-update``) does not imply that subsequent ``dnf upgrade`` will install it. The difference is that ``dnf upgrade`` must also ensure the satisfiability of all dependencies and other restrictions.
 


### PR DESCRIPTION
When this option is on, dnf will print out changelogs of packages
which are going to be updated. Changelogs for supbackages are grouped
together.