### PR TITLE
Allow to enable module dependencies (RhBug:1622566)

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -1,5 +1,5 @@
 # default dependencies
-%global hawkey_version 0.21.0
+%global hawkey_version 0.22.0
 %global libcomps_version 0.1.8
 %global libmodulemd_version 1.4.0
 %global rpm_version 4.14.0
@@ -72,7 +72,7 @@
 It supports RPMs, modules and comps groups & environments.
 
 Name:           dnf
-Version:        3.7.0
+Version:        3.7.1
 Release:        1%{?dist}
 Summary:        %{pkg_summary}
 # For a breakdown of the licensing, see PACKAGE-LICENSING

--- a/dnf/module/module_base.py
+++ b/dnf/module/module_base.py
@@ -274,6 +274,10 @@ class ModuleBase(object):
             self.base._moduleContainer, hot_fix_repos, self.base.conf.installroot, None,
             self.base.conf.debug_solver
         )
+        for nsvcap, moduleDict in module_dicts.values():
+            for streamDict in moduleDict.values():
+                for modules in streamDict.values():
+                    self.base._moduleContainer.enableDependencyTree(modules)
         return no_match_specs, error_spec, solver_errors, module_dicts
 
     def _modules_reset_or_disable(self, module_specs, to_state):


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1622566

Requires: https://github.com/rpm-software-management/libdnf/pull/609
Requires: https://github.com/rpm-software-management/ci-dnf-stack/pull/399