### PR TITLE
Hide messages created only for logging (RhBug:1639998)

### DIFF
--- a/dnf/yum/rpmtrans.py
+++ b/dnf/yum/rpmtrans.py
@@ -142,7 +142,7 @@ class LoggingTransactionDisplay(ErrorTransactionDisplay):
     def filelog(self, package, action):
         action_str = dnf.transaction.FILE_ACTIONS[action]
         msg = '%s: %s' % (action_str, package)
-        self.rpm_logger.info(msg)
+        self.rpm_logger.log(dnf.logging.SUBDEBUG, msg)
 
 
 class RPMTransaction(object):


### PR DESCRIPTION
The redirected output is created only for logging in rpm log. The output
in terminal use different format of same information.

https://bugzilla.redhat.com/show_bug.cgi?id=1639998