### PR TITLE
[automatic] Fix the systemd ordering loop

### DIFF
--- a/etc/systemd/dnf-automatic-download.service
+++ b/etc/systemd/dnf-automatic-download.service
@@ -2,6 +2,7 @@
 Description=dnf automatic download updates
 # See comment in dnf-makecache.service
 ConditionPathExists=!/run/ostree-booted
+After=network-online.target
 
 [Service]
 Type=oneshot

--- a/etc/systemd/dnf-automatic-download.timer
+++ b/etc/systemd/dnf-automatic-download.timer
@@ -3,7 +3,6 @@ Description=dnf-automatic-download timer
 # See comment in dnf-makecache.service
 ConditionPathExists=!/run/ostree-booted
 Wants=network-online.target
-After=network-online.target
 
 [Timer]
 OnBootSec=1h
@@ -12,4 +11,4 @@ RandomizedDelaySec=5m
 AccuracySec=1s
 
 [Install]
-WantedBy=basic.target
+WantedBy=multi-user.target

--- a/etc/systemd/dnf-automatic-install.service
+++ b/etc/systemd/dnf-automatic-install.service
@@ -2,6 +2,7 @@
 Description=dnf automatic install updates
 # See comment in dnf-makecache.service
 ConditionPathExists=!/run/ostree-booted
+After=network-online.target
 
 [Service]
 Type=oneshot

--- a/etc/systemd/dnf-automatic-install.timer
+++ b/etc/systemd/dnf-automatic-install.timer
@@ -3,7 +3,6 @@ Description=dnf-automatic-install timer
 # See comment in dnf-makecache.service
 ConditionPathExists=!/run/ostree-booted
 Wants=network-online.target
-After=network-online.target
 
 [Timer]
 OnBootSec=1h
@@ -12,4 +11,4 @@ RandomizedDelaySec=5m
 AccuracySec=1s
 
 [Install]
-WantedBy=basic.target
+WantedBy=multi-user.target

--- a/etc/systemd/dnf-automatic-notifyonly.service
+++ b/etc/systemd/dnf-automatic-notifyonly.service
@@ -2,6 +2,7 @@
 Description=dnf automatic notification of updates
 # See comment in dnf-makecache.service
 ConditionPathExists=!/run/ostree-booted
+After=network-online.target
 
 [Service]
 Type=oneshot

--- a/etc/systemd/dnf-automatic-notifyonly.timer
+++ b/etc/systemd/dnf-automatic-notifyonly.timer
@@ -3,7 +3,6 @@ Description=dnf-automatic-notifyonly timer
 # See comment in dnf-makecache.service
 ConditionPathExists=!/run/ostree-booted
 Wants=network-online.target
-After=network-online.target
 
 [Timer]
 OnBootSec=1h
@@ -12,4 +11,4 @@ RandomizedDelaySec=5m
 AccuracySec=1s
 
 [Install]
-WantedBy=basic.target
+WantedBy=multi-user.target

--- a/etc/systemd/dnf-automatic.service
+++ b/etc/systemd/dnf-automatic.service
@@ -2,6 +2,7 @@
 Description=dnf automatic
 # See comment in dnf-makecache.service
 ConditionPathExists=!/run/ostree-booted
+After=network-online.target
 
 [Service]
 Type=oneshot

--- a/etc/systemd/dnf-automatic.timer
+++ b/etc/systemd/dnf-automatic.timer
@@ -2,6 +2,7 @@
 Description=dnf-automatic timer
 # See comment in dnf-makecache.service
 ConditionPathExists=!/run/ostree-booted
+Wants=network-online.target
 
 [Timer]
 OnBootSec=1h
@@ -10,4 +11,4 @@ RandomizedDelaySec=5m
 AccuracySec=1s
 
 [Install]
-WantedBy=basic.target
+WantedBy=multi-user.target


### PR DESCRIPTION
This basically only applies theses patches also on dnf-automatic-*
timers and services:

* d1f4da94 - move the ordering after network to .service
* 4ca1555a - move to multi-user