### PR TITLE
Add showvars command to show active DNF vars

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -55,6 +55,7 @@ import dnf.cli.commands.swap
 import dnf.cli.commands.updateinfo
 import dnf.cli.commands.upgrade
 import dnf.cli.commands.upgrademinimal
+import dnf.cli.commands.showvars
 import dnf.cli.demand
 import dnf.cli.option_parser
 import dnf.conf
@@ -690,6 +691,7 @@ class Cli(object):
         self.register_command(dnf.cli.commands.updateinfo.UpdateInfoCommand)
         self.register_command(dnf.cli.commands.upgrade.UpgradeCommand)
         self.register_command(dnf.cli.commands.upgrademinimal.UpgradeMinimalCommand)
+        self.register_command(dnf.cli.commands.showvars.ShowVarsCommand)
         self.register_command(dnf.cli.commands.InfoCommand)
         self.register_command(dnf.cli.commands.ListCommand)
         self.register_command(dnf.cli.commands.ProvidesCommand)

--- a/dnf/cli/commands/showvars.py
+++ b/dnf/cli/commands/showvars.py
@@ -1,0 +1,49 @@
+# showvars.py
+# showvars CLI command.
+#
+# Copyright (C) 2016-2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from dnf.cli import commands
+from dnf.i18n import _
+
+import dnf.conf.substitutions
+
+import logging
+
+logger = logging.getLogger("dnf")
+
+class ShowVarsCommand(commands.Command):
+    """A class containing methods needed by the cli to execute the
+    showvars command.
+    """
+
+    aliases = ('showvars',)
+    summary = _('show all active dnf variables')
+
+    def run(self):
+        logger.debug(_('Getting dnf vars for: ' + self.base.conf.installroot))
+        dnfvars = dnf.conf.substitutions.Substitutions()
+        dnfvars.update_from_etc(self.base.conf.installroot)
+
+        print("releasever=" + self.base.conf.releasever)
+        print("basearch=" + self.base.conf.basearch)
+        for var in dnfvars:
+            print(var + '=' + dnfvars[var])

--- a/tests/cli/commands/test_showvars.py
+++ b/tests/cli/commands/test_showvars.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2014-2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+from __future__ import absolute_import
+
+import dnf.cli.commands.showvars as showvars
+
+import tests.support
+
+class TestVars(tests.support.TestCase):
+
+    @mock.patch('dnf.rpm.detect_releasever', return_value=69)
+    def test_showvars(self):
+        cmd = showvars.ShowVarsCommand(tests.support.mock.MagicMock())
+        cmd.base.conf = dnf.conf.Conf()
+        tests.support.command_run(cmd, ['showvars'])


### PR DESCRIPTION
This creates a quick cli interface to see what DNF vars are set for your dnf runtime.  Folks using dnf vars (under /etc/dnf/vars) such as myself would benefit from a quick way of seeing what is set.