### PR TITLE
Document module info --profile (RhBug:1622580)

### DIFF
--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -824,7 +824,7 @@ In case stream is not specified enabled or default stream is used, in this order
 ``dnf [options] module info <module_spec>...``
     Print detailed information about given module stream.
 
-``dnf [options] module profile <module_spec>...``
+``dnf [options] module info --profile <module_spec>...``
     Print detailed information about given module profiles.
 
 .. _provides_command-label:


### PR DESCRIPTION
Originally there was an alias as module subcommand, but it was removed
as a redundant functionality.

https://bugzilla.redhat.com/show_bug.cgi?id=1622580