### PR TITLE
[conf, dnf-automatic] remove _add_option() and _option dict from BaseConfig 

### DIFF
--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -106,26 +106,6 @@ class Option(object):
                                                  % (value, str(e)),
                                                  raw_error=str(e))
 
-    def _is_default(self):
-        """Was value changed from default?"""
-        return self._option.getPriority() == PRIO_DEFAULT
-
-    # def _is_runtimeonly(self):
-        """Was value changed from default?"""
-        # return self._runtimeonly
-
-    def _parse(self, strval):
-        """Parse the string value to the option's native value."""
-        # pylint: disable=R0201
-        return self._option.fromString(strval)
-
-    def _tostring(self):
-        """Convert the option's native actual value to a string."""
-        val = ('' if self._is_default() or
-               self._option.getPriority() == PRIO_EMPTY
-               else self._option.getValueString())
-        return str(val)
-
 
 class IntOption(Option):
     def __init__(self, default=0):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,25 +30,6 @@ import tests.support
 from tests.support import mock
 
 
-class OptionTest(tests.support.TestCase):
-
-    class Cfg(BaseConfig):
-        def __init__(self):
-            super(OptionTest.Cfg, self).__init__()
-            self._add_option('a_setting', Option("roundabout"))
-
-    def test_option(self):
-        cfg = self.Cfg()
-        # default
-        self.assertEqual(cfg.a_setting, "roundabout")
-        # new value with high priority
-        cfg.a_setting = "turn left"
-        self.assertEqual(cfg.a_setting, "turn left")
-        # new value with lower priority does nothing
-        cfg._set_value('a_setting', "turn right", dnf.conf.PRIO_DEFAULT)
-        self.assertEqual(cfg.a_setting, "turn left")
-
-
 class CacheTest(tests.support.TestCase):
 
     @mock.patch('dnf.util.am_i_root', return_value=True)


### PR DESCRIPTION
Now the dnf-automatic uses libdnf options directly instead of private functions from DNF.
The _add_option() was a temporary solution for dnf-automatic, no needed anymore.
