### PR TITLE
Define attributes for non existent ghost entries

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -407,15 +407,15 @@ ln -sr  %{buildroot}%{confdir}/vars %{buildroot}%{_sysconfdir}/yum/vars
 %config(noreplace) %{confdir}/%{name}.conf
 %config(noreplace) %{confdir}/protected.d/%{name}.conf
 %config(noreplace) %{_sysconfdir}/logrotate.d/%{name}
-%ghost %{_localstatedir}/log/hawkey.log
-%ghost %{_localstatedir}/log/%{name}.log
-%ghost %{_localstatedir}/log/%{name}.librepo.log
-%ghost %{_localstatedir}/log/%{name}.rpm.log
-%ghost %{_localstatedir}/log/%{name}.plugin.log
-%ghost %{_sharedstatedir}/%{name}
-%ghost %{_sharedstatedir}/%{name}/groups.json
-%ghost %{_sharedstatedir}/%{name}/yumdb
-%ghost %{_sharedstatedir}/%{name}/history
+%ghost %attr(644,-,-) %{_localstatedir}/log/hawkey.log
+%ghost %attr(644,-,-) %{_localstatedir}/log/%{name}.log
+%ghost %attr(644,-,-) %{_localstatedir}/log/%{name}.librepo.log
+%ghost %attr(644,-,-) %{_localstatedir}/log/%{name}.rpm.log
+%ghost %attr(644,-,-) %{_localstatedir}/log/%{name}.plugin.log
+%ghost %attr(755,-,-) %dir %{_sharedstatedir}/%{name}
+%ghost %attr(644,-,-) %{_sharedstatedir}/%{name}/groups.json
+%ghost %attr(755,-,-) %dir %{_sharedstatedir}/%{name}/yumdb
+%ghost %attr(755,-,-) %dir %{_sharedstatedir}/%{name}/history
 %{_mandir}/man5/%{name}.conf.5*
 %{_tmpfilesdir}/%{name}.conf
 %{_sysconfdir}/libreport/events.d/collect_dnf.conf


### PR DESCRIPTION
If ghost entries do not have attributes defined and you run:
  rpm --restore dnf-data
you end up with 0000 permissions there for existing files and
directories.

Attributes set based on permissions on default Fedora 29
installation.

When defining %ghost entries for non existing files or directories it should be mandatory to define all essential attributes because otherwise 'rpm --restore' does not do expected thing.

dnf-data-4.0.4-1.fc29.noarch
defines:
% rpm -qvl dnf-data
---------- 1 root root 0 Oct 15 15:00 /var/lib/dnf
---------- 1 root root 0 Oct 15 15:00 /var/lib/dnf/groups.json
---------- 1 root root 0 Oct 15 15:00 /var/lib/dnf/history
---------- 1 root root 0 Oct 15 15:00 /var/lib/dnf/yumdb
---------- 1 root root 0 Oct 15 15:00 /var/log/dnf.librepo.log
---------- 1 root root 0 Oct 15 15:00 /var/log/dnf.plugin.log
---------- 1 root root 0 Oct 15 15:00 /var/log/dnf.rpm.log
---------- 1 root root 0 Oct 15 15:00 /var/log/hawkey.log