### PR TITLE
Fix package.remote_location (RhBug:1649284)

### DIFF
--- a/dnf/package.py
+++ b/dnf/package.py
@@ -242,10 +242,7 @@ class Package(hawkey.Package):
         if mirrors:
             return schemes_filter(mirrors)
         elif self.repo.baseurl:
-            if isinstance(self.repo.baseurl, list):
-                return schemes_filter(self.repo.baseurl)
-            else:
-                return schemes_filter([self.repo.baseurl])
+            return schemes_filter(self.repo.baseurl)
 
     def _is_local_pkg(self):
         if self.repoid == "@System":


### PR DESCRIPTION
After moving config to libdnf, the repo.baseurl is always of VectorString type.

https://bugzilla.redhat.com/show_bug.cgi?id=1649284