### PR TITLE
[transaction] Make transaction content available for plugins.

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -1,5 +1,5 @@
 # default dependencies
-%global hawkey_version 0.22.2
+%global hawkey_version 0.22.3
 %global libcomps_version 0.1.8
 %global libmodulemd_version 1.4.0
 %global rpm_version 4.14.0
@@ -72,7 +72,7 @@
 It supports RPMs, modules and comps groups & environments.
 
 Name:           dnf
-Version:        4.0.8
+Version:        4.0.9
 Release:        1%{?dist}
 Summary:        %{pkg_summary}
 # For a breakdown of the licensing, see PACKAGE-LICENSING

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -500,7 +500,8 @@ class Base(object):
             if self._sack and self._moduleContainer:
                 # sack must be set to enable operations on moduleContainer
                 self._moduleContainer.rollback()
-            self.history.close()
+            if self._history is not None:
+                self.history.close()
             self._comps_trans = dnf.comps.TransactionBunch()
             self._transaction = None
 
@@ -861,6 +862,13 @@ class Base(object):
         self._plugins.run_transaction()
 #        if self.history.group_active() and self._trans_success:
 #            self.history.group.commit()
+
+        # Plugins were executed already.
+        # They may have used information about the last transaction.
+        # Closing history/transaction here because nobody is supposed to read it anymore.
+        self.history.close()
+        self._history = None
+
         return tid
 
     def _trans_error_summary(self, errstring):

--- a/tests/support.py
+++ b/tests/support.py
@@ -685,10 +685,12 @@ class DnfBaseTestCase(TestCase):
             if tsi.getState() == libdnf.transaction.TransactionItemState_UNKNOWN:
                 tsi.setState(libdnf.transaction.TransactionItemState_DONE)
         self.history.end("")
+        self.history.close()
 
     def _swdb_commit(self, tsis=None):
         self._swdb_begin(tsis)
         self._swdb_end()
+        self.history.close()
 
 
 class ResultTestCase(DnfBaseTestCase):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -50,6 +50,7 @@ class BaseTest(tests.support.TestCase):
             if tsi.getState() == libdnf.transaction.TransactionItemState_UNKNOWN:
                 tsi.setState(libdnf.transaction.TransactionItemState_DONE)
         history.end("")
+        history.close()
 
     def test_instance(self):
         base = tests.support.MockBase()
@@ -127,6 +128,7 @@ class BaseTest(tests.support.TestCase):
             if tsi.getState() == libdnf.transaction.TransactionItemState_UNKNOWN:
                 tsi.setState(libdnf.transaction.TransactionItemState_DONE)
         history.end("")
+        history.close()
 
         pkg, = base.sack.query().installed().filter(name='pepper')
         self.assertEqual(base.history.user_installed(pkg), True)
@@ -148,6 +150,7 @@ class BaseTest(tests.support.TestCase):
             if tsi.getState() == libdnf.transaction.TransactionItemState_UNKNOWN:
                 tsi.setState(libdnf.transaction.TransactionItemState_DONE)
         history.end("")
+        history.close()
 
         pkg, = base.sack.query().installed().filter(name='pepper')
         self.assertEqual(base.history.user_installed(pkg), False)


### PR DESCRIPTION
Libdnf introduced closeTransaction() that allows to close transaction outside
endTransaction() and that makes the transaction available for plugins.