### PR TITLE
Set default priority for cachedir (RhBug:1651646)

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -871,7 +871,7 @@ class Cli(object):
         try:
             if opts.cacheonly:
                 opt = self.base.conf._get_option("cachedir")
-                opt._set(self.base.conf.system_cachedir, dnf.conf.PRIO_COMMANDLINE)
+                opt._set(self.base.conf.system_cachedir, dnf.conf.PRIO_DEFAULT)
                 self.demands.cacheonly = True
             self.base.conf._configure_from_options(opts)
             self._read_conf_file(opts.releasever)


### PR DESCRIPTION
With cacheonly option it changed cachedir to root cache with commandline
priority. It prevents to redirect it to location according to dnf.conf.
We can apply the change with default priority, because we use only
different default value.

https://bugzilla.redhat.com/show_bug.cgi?id=1651646