### PR TITLE
[transaction] Make transaction content available for commands

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -863,12 +863,6 @@ class Base(object):
 #        if self.history.group_active() and self._trans_success:
 #            self.history.group.commit()
 
-        # Plugins were executed already.
-        # They may have used information about the last transaction.
-        # Closing history/transaction here because nobody is supposed to read it anymore.
-        self.history.close()
-        self._history = None
-
         return tid
 
     def _trans_error_summary(self, errstring):


### PR DESCRIPTION
Although plugins were executed already, commands were not and still may need
to access the history/transaction. This was breaking the system-upgrade plugin.
The history is closed as a part of base.close().