### PR TITLE
[doc] Remove incorrect description of install @<spec> (RhBug:1649356)

### DIFF
--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -717,9 +717,6 @@ Install Command
 
     See also :ref:`\configuration_files_replacement_policy-label`.
 
-``dnf [options] install @<spec>...``
-    Alias for `dnf module install` command.
-
 .. _install_examples-label:
 
 Install Examples


### PR DESCRIPTION
Already described for install <spec> - it can be both module spec or group spec.