### PR TITLE
[rpm] Catch rpm errors when reading package header.

### DIFF
--- a/dnf/rpm/__init__.py
+++ b/dnf/rpm/__init__.py
@@ -69,7 +69,11 @@ def _header(path):
     ts = transaction.initReadOnlyTransaction()
     with open(path) as package:
         fdno = package.fileno()
-        return ts.hdrFromFdno(fdno)
+        try:
+            hdr = ts.hdrFromFdno(fdno)
+        except rpm.error as e:
+            raise dnf.exceptions.Error("{0}: '{1}'".format(e, path))
+        return hdr
 
 
 def _invert(dct):


### PR DESCRIPTION
Rpm function hdrFromFdno can raise an exception.
Dnf needs to catch it in order to not fail with traceback.

https://bugzilla.redhat.com/show_bug.cgi?id=1657703