### PR TITLE
Add basic integration with %_pkgverify_level

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -957,6 +957,24 @@ class Cli(object):
         if self.base.conf.color != 'auto':
             self.base.output.term.reinit(color=self.base.conf.color)
 
+        if rpm.expandMacro('%_pkgverify_level') in ('signature', 'all'):
+            forcing = False
+            for repo in self.base.repos.iter_enabled():
+                if repo.gpgcheck:
+                    continue
+                repo.gpgcheck = True
+                forcing = True
+            if not self.base.conf.localpkg_gpgcheck:
+                self.base.conf.localpkg_gpgcheck = True
+                forcing = True
+            if forcing:
+                logger.warning(
+                    _("Warning: Enforcing GPG signature check globally "
+                      "as per active RPM security policy (see 'gpgcheck' in "
+                      "dnf.conf(5) for how to squelch this message)"
+                      )
+                )
+
     def _read_conf_file(self, releasever=None):
         timer = dnf.logging.Timer('config')
         conf = self.base.conf

--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -275,7 +275,7 @@ class OptionParser(argparse.ArgumentParser):
                                  help=_("disable removal of dependencies that are no longer used"))
         main_parser.add_argument("--nogpgcheck", action="store_false",
                                  default=None, dest='gpgcheck',
-                                 help=_("disable gpg signature checking"))
+                                 help=_("disable gpg signature checking (if RPM policy allows)"))
         main_parser.add_argument("--color", dest="color", default=None,
                                  help=_("control whether color is used"))
         main_parser.add_argument("--refresh", dest="freshest_metadata",

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -279,7 +279,7 @@ Options
     Do not install documentation. Sets the rpm flag 'RPMTRANS_FLAG_NODOCS'.
 
 ``--nogpgcheck``
-    Skip checking GPG signatures on packages.
+    Skip checking GPG signatures on packages (if RPM policy allows).
 
 ``--noplugins``
     Disable all plugins.

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -452,7 +452,12 @@ configuration.
 ``gpgcheck``
     :ref:`boolean <boolean-label>`
 
-    Whether to perform GPG signature check on packages found in this repository. The default is False.
+    Whether to perform GPG signature check on packages found in this repository.
+    The default is False.
+
+    This option can only be used to strengthen the active RPM security policy set with the ``%_pkgverify_level`` macro (see the ``/usr/lib/rpm/macros`` file for details).
+    That means, if the macro is set to 'signature' or 'all' and this option is False, it will be overridden to True during DNF runtime, and a warning will be printed.
+    To squelch the warning, make sure this option is True for every enabled repository, and also enable :ref:`localpkg_gpgcheck <localpkg_gpgcheck-label>`.
 
 .. _include-label:
 
@@ -470,10 +475,14 @@ configuration.
 
     Determines how DNF resolves host names. Set this to '4'/'IPv4' or '6'/'IPv6' to resolve to IPv4 or IPv6 addresses only. By default, DNF resolves to either addresses.
 
+.. _localpkg_gpgcheck-label:
+
 ``localpkg_gpgcheck``
     :ref:`boolean <boolean-label>`
 
-    Whether to perform a GPG signature check on local packages (packages in a file, not in a repositoy). The default is False.
+    Whether to perform a GPG signature check on local packages (packages in a file, not in a repository).
+    The default is False.
+    This option is subject to the active RPM security policy (see :ref:`gpgcheck <gpgcheck-label>` for more details).
 
 ``max_parallel_downloads``
     :ref:`integer <integer-label>`


### PR DESCRIPTION
RPM 4.14.2 introduced a new low-level security policy for package
verification configured with the %_pkgverify_level macro:

http://rpm.org/wiki/Releases/4.14.2

In DNF, signature verification is done via RPM but in a separate step
that precedes the transaction itself (BaseCli.gpgsigcheck()).  We can
make use of that to catch signature errors and/or import public keys the
same way as if gpgcheck was enabled from the start.  To that end, this
commit forces the gpgcheck and localpkg_gpgcheck options to True if the
policy would result in signature verification anyway.

Resolves RHEL-8 bug:
https://bugzilla.redhat.com/show_bug.cgi?id=1614351