### PR TITLE
Log errors in repo metadata loading (RhBug:1589832)

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -389,7 +389,7 @@ class Base(object):
                     if load_system_repo != 'auto':
                         raise
             if load_available_repos:
-                errors = []
+                error_repos = []
                 mts = 0
                 age = time.time()
                 # Iterate over installed GPG keys and check their validity using DNSSEC
@@ -405,14 +405,15 @@ class Base(object):
                         logger.debug(_("%s: using metadata from %s."), r.id,
                                      dnf.util.normalize_time(
                                          r._repo.getMaxTimestamp()))
-                    except dnf.exceptions.RepoError as e:
+                    except dnf.exceptions.RepoError:
                         r._repo.expire()
                         if r.skip_if_unavailable is False:
                             raise
-                        errors.append(e)
+                        error_repos.append(r.id)
                         r.disable()
-                for e in errors:
-                    logger.warning(_("%s, ignoring this repo."), e)
+                if error_repos:
+                    logger.warning(
+                        _("Ignoring repositories: %s"), ', '.join(error_repos))
                 if self.repos._any_enabled():
                     if age != 0 and mts != 0:
                         logger.info(_("Last metadata expiration check: %s ago on %s."),

--- a/dnf/repo.py
+++ b/dnf/repo.py
@@ -565,6 +565,10 @@ class Repo(dnf.conf.RepoConf):
         try:
             ret = self._repo.load()
         except RuntimeError as e:
+            if self.skip_if_unavailable:
+                logger.warning(str(e))
+            else:
+                logger.error(str(e))
             raise dnf.exceptions.RepoError(str(e))
         self.metadata = Metadata(self._repo)
         return ret


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1589832
Logging in fill_sack is not sufficient as the loading can be called separately.
Therefore, in fill_sack, only the info about ignored repos is logged.

There are two minor issues:
- If repository fails and cannot be skipped, the error message is logged twice (once in repo.Repo.load(), and once in the final error). But it's still better than no error message at all for the API function call as it was before.
- If repository fails and can be skipped, the warning message is logged right away, and the information about ignoring is logged later. However, if another repository fails after that, the information about ignoring is never printed. The information could be moved to the repo.Repo.load() function, but then, if it's being run as API function, it might not be true.