### PR TITLE
re-introduce _none_ value parsing

### DIFF
--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -247,7 +247,7 @@ class BaseConfig(object):
         if parser.hasSection(section):
             for name in parser.getData()[section]:
                 value = parser.getSubstitutedValue(section, name)
-                if not value or value == 'None':
+                if not value or value in ['None', '_none_']:
                     value = ''
                 if hasattr(self._config, name):
                     try:


### PR DESCRIPTION
Yum (and DNF before v3) used _none_ as the value to override parameters in specific repo definitions. This was removed and now scenarios when Fedora 29 runs a mock with a different OS (older Fedora or CentOS) there is an incompatibility in parsing these parameters. This patch re-introduces _none_ as a valid value.
