### PR TITLE
Unify behavior of module list with list (RhBug:1647382)

### DIFF
--- a/dnf/cli/commands/module.py
+++ b/dnf/cli/commands/module.py
@@ -67,10 +67,9 @@ class ModuleCommand(commands.Command):
             if output:
                 print(output)
                 return
-            msg = _('No matching Modules to list')
             if self.opts.module_spec:
+                msg = _('No matching Modules to list')
                 raise dnf.exceptions.Error(msg)
-            logger.warning(msg)
 
     class InfoSubCommand(SubCommand):
 


### PR DESCRIPTION
"dnf list" command without argument does not log any warning if there is
nothing to report. "dnf module list" should behave by the same way.

https://bugzilla.redhat.com/show_bug.cgi?id=1647382