### PR TITLE
Fix dnf foo --help

### DIFF
--- a/doc/examples/install_plugin.py
+++ b/doc/examples/install_plugin.py
@@ -18,7 +18,8 @@
 
 
 import dnf.cli
-
+from dnf.i18n import _
+from dnf.cli.option_parser import OptionParser
 
 # The parent class allows registration to the CLI manager.
 class Command(dnf.cli.Command):


### PR DESCRIPTION
Addressing
```
Traceback (most recent call last):
  File "/usr/bin/dnf", line 58, in <module>
    main.user_main(sys.argv[1:], exit_code=True)
  File "/usr/lib/python3.7/site-packages/dnf/cli/main.py", line 179, in user_main
    errcode = main(args)
  File "/usr/lib/python3.7/site-packages/dnf/cli/main.py", line 64, in main
    return _main(base, args, cli_class, option_parser_class)
  File "/usr/lib/python3.7/site-packages/dnf/cli/main.py", line 95, in _main
    cli.configure(list(map(ucd, args)), option_parser())
  File "/usr/lib/python3.7/site-packages/dnf/cli/cli.py", line 940, in configure
    self.optparser.print_help(self.command)
  File "/usr/lib/python3.7/site-packages/dnf/cli/option_parser.py", line 407, in print_help
    cp = self._command_parser(command)
  File "/usr/lib/python3.7/site-packages/dnf/cli/option_parser.py", line 341, in _command_parser
    command.set_argparser(self)
  File "/usr/lib/python3.7/site-packages/dnf-plugins/foo.py", line 29, in set_argparser
    parser.add_argument('package', nargs='+', metavar=_('PACKAGE'),
NameError: name '_' is not defined
```
and
```
Traceback (most recent call last):
  File "/usr/bin/dnf", line 58, in <module>
    main.user_main(sys.argv[1:], exit_code=True)
  File "/usr/lib/python3.7/site-packages/dnf/cli/main.py", line 179, in user_main
    errcode = main(args)
  File "/usr/lib/python3.7/site-packages/dnf/cli/main.py", line 64, in main
    return _main(base, args, cli_class, option_parser_class)
  File "/usr/lib/python3.7/site-packages/dnf/cli/main.py", line 95, in _main
    cli.configure(list(map(ucd, args)), option_parser())
  File "/usr/lib/python3.7/site-packages/dnf/cli/cli.py", line 940, in configure
    self.optparser.print_help(self.command)
  File "/usr/lib/python3.7/site-packages/dnf/cli/option_parser.py", line 407, in print_help
    cp = self._command_parser(command)
  File "/usr/lib/python3.7/site-packages/dnf/cli/option_parser.py", line 341, in _command_parser
    command.set_argparser(self)
  File "/usr/lib/python3.7/site-packages/dnf-plugins/foo.py", line 30, in set_argparser
    action=OptionParser.ParseSpecGroupFileCallback,
NameError: name 'OptionParser' is not defined
```