### PR TITLE
Use conf.module_platform_id for 'dnf module enable'

### DIFF
--- a/dnf/module/module_base.py
+++ b/dnf/module/module_base.py
@@ -279,7 +279,8 @@ class ModuleBase(object):
         hot_fix_repos = [i.id for i in self.base.repos.iter_enabled() if i.module_hotfixes]
         try:
             solver_errors = self.base.sack.filter_modules(
-                self.base._moduleContainer, hot_fix_repos, self.base.conf.installroot, None,
+                self.base._moduleContainer, hot_fix_repos, self.base.conf.installroot,
+                self.base.conf.module_platform_id,
                 self.base.conf.debug_solver)
         except hawkey.Exception as e:
             raise dnf.exceptions.Error(ucd(e))


### PR DESCRIPTION
For some reason, with the refactor of modules to use libdnf objects in 85b0f1c, `None` was passed rather than `conf.module_platform_id` in one spot when calling `sack.filter_modules()`; add it back to fix 'dnf module enable'.

(Fix found with somewhat superficial inspection, I didn't try to understand all the code, so please check :-)