### PR TITLE
Fix alias list command (RhBug:1666325)

### DIFF
--- a/dnf/cli/commands/alias.py
+++ b/dnf/cli/commands/alias.py
@@ -146,7 +146,7 @@ class AliasCommand(commands.Command):
     def list_alias(self, cmd):
         args = [cmd]
         try:
-            self.aliases_base._resolve(args)
+            args = self.aliases_base._resolve(args)
         except dnf.exceptions.Error as e:
             logger.error(_('%s, alias %s'), e, cmd)
         else:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1666325
List the resolved alias instead of the original command.