### PR TITLE
Format messages properly (RhBug:1509393)

### DIFF
--- a/dnf/cli/commands/clean.py
+++ b/dnf/cli/commands/clean.py
@@ -116,7 +116,7 @@ class CleanCommand(commands.Command):
                     return
             except dnf.exceptions.LockError as e:
                 if not self.base.conf.exit_on_lock:
-                    msg = _('Waiting for process with pid %d to finish.' % (e.pid))
+                    msg = _('Waiting for process with pid %d to finish.') % (e.pid)
                     logger.info(msg)
                     time.sleep(3)
                 else:

--- a/dnf/conf/read.py
+++ b/dnf/conf/read.py
@@ -58,7 +58,7 @@ class RepoReader(object):
         try:
             repo._populate(parser, id_, repofn, dnf.conf.PRIO_REPOCONFIG)
         except ValueError as e:
-            msg = _("Repository '%s': Error parsing config: %s" % (id_, e))
+            msg = _("Repository '%s': Error parsing config: %s") % (id_, e)
             raise dnf.exceptions.ConfigError(msg)
 
         # Ensure that the repo name is set
@@ -153,7 +153,7 @@ class ModuleReader(object):
                             _('Unknown configuration option: %s = %s in %s'),
                             ucd(name), ucd(value), ucd(module_path))
         except ValueError as e:
-            msg = _("Module '%s': Error parsing config: %s" % (id_, e))
+            msg = _("Module '%s': Error parsing config: %s") % (id_, e)
             raise dnf.exceptions.ConfigError(msg)
 
         # TODO: unset module.name?

--- a/dnf/lock.py
+++ b/dnf/lock.py
@@ -100,7 +100,7 @@ class ProcessLock(object):
                 msg = _('Malformed lock file found: %s.\n'
                         'Ensure no other dnf process is running and '
                         'remove the lock file manually or run '
-                        'systemd-tmpfiles --remove dnf.conf.' % (self.target))
+                        'systemd-tmpfiles --remove dnf.conf.') % (self.target)
                 raise LockError(msg)
 
     def _try_unlink(self):
@@ -136,7 +136,7 @@ class ProcessLock(object):
                 msg = '%s already locked by %d' % (self.description, pid)
                 raise ProcessLockError(msg, pid)
             if inform or prev_pid != pid:
-                msg = _('Waiting for process with pid %d to finish.' % (pid))
+                msg = _('Waiting for process with pid %d to finish.') % (pid)
                 logger.info(msg)
                 inform = False
                 prev_pid = pid


### PR DESCRIPTION
The error was caused by misplaced parentheses and caused the text to be
displayed always in English despite the translation being provided.

https://bugzilla.redhat.com/show_bug.cgi?id=1509393