### PR TITLE
Aliases: Fix a minor typo in the help message

### DIFF
--- a/dnf/cli/commands/alias.py
+++ b/dnf/cli/commands/alias.py
@@ -46,7 +46,7 @@ class AliasCommand(commands.Command):
         enable_group = parser.add_mutually_exclusive_group()
         enable_group.add_argument(
             '--enable-resolving', default=False, action='store_true',
-            help=_('enable aliases resolving)'))
+            help=_('enable aliases resolving'))
         enable_group.add_argument(
             '--disable-resolving', default=False, action='store_true',
             help=_('disable aliases resolving'))


### PR DESCRIPTION
I may be wrong but I am pretty sure this is what you meant. Please review ASAP and push an update to Zanata. Please note that some translators have started translating the string ```"enable aliases resolving)"``` already.