### PR TITLE
Mark strftime format specifiers for translation

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -312,7 +312,7 @@ class BaseCli(dnf.Base):
     def format_changelog(self, changelog):
         """Return changelog formatted as in spec file"""
         chlog_str = '* %s %s\n%s\n' % (
-            changelog['timestamp'].strftime("%a %b %d %X %Y"),
+            changelog['timestamp'].strftime("%c"),
             dnf.i18n.ucd(changelog['author']),
             dnf.i18n.ucd(changelog['text']))
         return chlog_str

--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -318,7 +318,15 @@ class RepoQueryCommand(commands.Command):
             out.append('Changelog for %s' % str(pkg))
             for chlog in pkg.changelogs:
                 dt = chlog['timestamp']
-                out.append('* %s %s\n%s\n' % (dt.strftime("%a %b %d %Y"),
+                out.append('* %s %s\n%s\n' % (
+                    # TRANSLATORS: This is the date format for a changelog
+                    # in dnf repoquery. You are encouraged to change it
+                    # according to the requirements of your language. Format
+                    # specifiers used here: %a - abbreviated weekday name in
+                    # your language, %b - abbreviated month name in the correct
+                    # grammatical form, %d - day number (01-31), %Y - year
+                    # number (4 digits).
+                                              dt.strftime(_("%a %b %d %Y")),
                                               dnf.i18n.ucd(chlog['author']),
                                               dnf.i18n.ucd(chlog['text'])))
             return '\n'.join(out)
@@ -667,7 +675,8 @@ class PackageWrapper(object):
     def _get_timestamp(timestamp):
         if timestamp > 0:
             dt = datetime.datetime.utcfromtimestamp(timestamp)
-            return dt.strftime("%Y-%m-%d %H:%M")
+            # TRANSLATORS: This is the default time format for dnf repoquery.
+            return dt.strftime(_("%Y-%m-%d %H:%M"))
         else:
             return ''
 

--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -1606,7 +1606,12 @@ Transaction Summary
             else:
                 name = self._pwd_ui_username(transaction.loginuid, 24)
             name = ucd(name)
-            tm = time.strftime("%Y-%m-%d %H:%M",
+            # TRANSLATORS: This is the time format for dnf history list.
+            # You can change it but do it with caution because the output
+            # must be no longer than 16 characters. Format specifiers:
+            # %Y - year number (4 digits), %m - month (00-12), %d - day
+            # number (01-31), %H - hour (00-23), %M - minute (00-59).
+            tm = time.strftime(_("%Y-%m-%d %H:%M"),
                                time.localtime(transaction.beg_timestamp))
             num, uiacts = self._history_uiactions(transaction.data())
             name = fill_exact_width(name, 24, 24)


### PR DESCRIPTION
Sometimes translators should be able to choose the correct date and time format for their language.

I have deliberately skipped marking ```strftime("%c")``` for translation because ```"%c"``` already expands to the correct full date and time format for the user's language.

Please see if this is what you want. Definitely the non-English end users should not see ```"%b %d %Y"``` because _month-day-year_ order is English specific and really few languages (if any) use that order.