### PR TITLE
Remove _moduleContainer attribute from sack

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -1,5 +1,5 @@
 # default dependencies
-%global hawkey_version 0.30.0
+%global hawkey_version 0.31.0
 %global libcomps_version 0.1.8
 %global libmodulemd_version 1.4.0
 %global rpm_version 4.14.0
@@ -79,7 +79,7 @@
 It supports RPMs, modules and comps groups & environments.
 
 Name:           dnf
-Version:        4.2.4
+Version:        4.2.5
 Release:        1%{?dist}
 Summary:        %{pkg_summary}
 # For a breakdown of the licensing, see PACKAGE-LICENSING

--- a/dnf/sack.py
+++ b/dnf/sack.py
@@ -31,7 +31,6 @@ from dnf.pycomp import basestring
 class Sack(hawkey.Sack):
     def __init__(self, *args, **kwargs):
         super(Sack, self).__init__(*args, **kwargs)
-        self._moduleContainer = None
 
     def _configure(self, installonly=None, installonly_limit=0):
         if installonly:


### PR DESCRIPTION
It is replaced by attribute from hawkey object. It allows to set
ModuleContainar also for C sack and then use it in queries. This is a
temporary solution before sack is provided by swig binding.