### PR TITLE
Not allow direct module switch (RhBug:1669491)

### DIFF
--- a/dnf/cli/commands/module.py
+++ b/dnf/cli/commands/module.py
@@ -31,6 +31,14 @@ import libdnf
 import dnf.module.module_base
 import dnf.exceptions
 
+
+def report_module_switch(switchedModules):
+    msg1 = _("The operation would result in switching of module '{0}' stream '{1}' to "
+             "stream '{2}'")
+    for moduleName, streams in switchedModules.items():
+        logger.warning(msg1.format(moduleName, streams[0], streams[1]))
+
+
 class ModuleCommand(commands.Command):
     class SubCommand(commands.Command):
 
@@ -115,6 +123,14 @@ class ModuleCommand(commands.Command):
                             libdnf.module.ModulePackageContainer.ModuleErrorType_ERROR_IN_DEFAULTS:
                         raise e
                 logger.error(str(e))
+            switchedModules = dict(self.base._moduleContainer.getSwitchedStreams())
+            if switchedModules:
+                report_module_switch(switchedModules)
+                msg = _("It is not possible to switch enabled streams of a module.\n"
+                        "It is recommended to remove all installed content from the module, and "
+                        "reset the module using 'dnf module reset <module_name>' command. After "
+                        "you reset the module, you can enable the other stream.")
+                raise dnf.exceptions.Error(msg)
 
     class DisableSubCommand(SubCommand):
 
@@ -178,6 +194,14 @@ class ModuleCommand(commands.Command):
                     if e.no_match_group_specs or e.error_group_specs:
                         raise e
                 logger.error(str(e))
+            switchedModules = dict(self.base._moduleContainer.getSwitchedStreams())
+            if switchedModules:
+                report_module_switch(switchedModules)
+                msg = _("It is not possible to switch enabled streams of a module.\n"
+                        "It is recommended to remove all installed content from the module, and "
+                        "reset the module using 'dnf module reset <module_name>' command. After "
+                        "you reset the module, you can install the other stream.")
+                raise dnf.exceptions.Error(msg)
 
     class UpdateSubCommand(SubCommand):
 

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -870,6 +870,11 @@ Module subcommands take :ref:`\<module-spec>\ <specifying_modules-label>` that s
     In case no profile was provided, all default profiles get installed.
     Module streams get enabled accordingly.
 
+    This command cannot be used for switching module streams. It is recommended to remove all
+    installed content from the module, and reset the module using
+    :ref:`reset <module_reset_command-label>` command. After you reset the module, you can install
+    the other stream.
+
 ``dnf [options] module update <module-spec>...``
     Update RPMs in installed module profiles.
     In case no profile was provided, all installed profiles get updated.
@@ -887,12 +892,10 @@ Module subcommands take :ref:`\<module-spec>\ <specifying_modules-label>` that s
     of modular dependency issue the operation will be rejected. To perform action anyway please use
     \-\ :ref:`-skip-broken option <skip-broken_option-label>`.
 
-    This command can also be used for switching module streams.
-    RPMs from the original stream become unavailable and RPMs from the new
-    stream become available in the package set.
-    The operation does not alter installed packages and their configuration.
-    It is suggested to use the ``dnf distro-sync`` command
-    to synchronize to the latest available RPMs from the new stream.
+    This command cannot be used for switching module streams. It is recommended to remove all
+    installed content from the module, and reset the module using
+    :ref:`reset <module_reset_command-label>` command. After you reset the module, you can enable
+    the other stream.
 
 .. _module_disable_command-label:
 
@@ -900,6 +903,8 @@ Module subcommands take :ref:`\<module-spec>\ <specifying_modules-label>` that s
     Disable a module. All related module streams will become unavailable. In case of modular
     dependency issue the operation will be rejected. To perform action anyway please use \-\
     :ref:`-skip-broken option <skip-broken_option-label>`.
+
+.. _module_reset_command-label:
 
 ``dnf [options] module reset <module-spec>...``
     Reset module state so it's no longer enabled or disabled.


### PR DESCRIPTION
Switching streams is so dangerous that possibility for direct stream
change is not acceptable.

The patch change a behavior of install and enable subcommands.

https://bugzilla.redhat.com/show_bug.cgi?id=1669491