### PR TITLE
Not provide a hint about man pages for module enable

### DIFF
--- a/dnf/cli/commands/module.py
+++ b/dnf/cli/commands/module.py
@@ -310,8 +310,3 @@ class ModuleCommand(commands.Command):
                 raise CliError(
                     "dnf {} {}: too few arguments".format(self.opts.command[0],
                                                           self.opts.subcmd[0]))
-
-    def run_transaction(self):
-        if self.opts.subcmd[0] in ('enable',):
-            logger.info(_("\nSwitching module streams does not alter installed packages "
-                          "(see 'module enable' in dnf(8) for details)"))


### PR DESCRIPTION
The hint was replaced by error if module switch take place (module
install/enable ). The section that provided additional information in
man pages was already deleted, because relevant information was already
provided by module enable/install command.