### PR TITLE
Unify --hep with man for module-spec (RhBug:1678689)

### DIFF
--- a/dnf/cli/commands/module.py
+++ b/dnf/cli/commands/module.py
@@ -272,7 +272,7 @@ class ModuleCommand(commands.Command):
     def set_argparser(self, parser):
         subcommand_help = [subcmd.aliases[0] for subcmd in self.SUBCMDS]
         parser.add_argument('subcmd', nargs=1, choices=subcommand_help)
-        parser.add_argument('module_spec', nargs='*')
+        parser.add_argument('module_spec', metavar='module-spec', nargs='*')
 
         narrows = parser.add_mutually_exclusive_group()
         narrows.add_argument('--enabled', dest='enabled',


### PR DESCRIPTION
Man page was mentioning module-spec but --help showed module_spec. The
difference makes difficult for user to easily combine both sources.

https://bugzilla.redhat.com/show_bug.cgi?id=1678689