### PR TITLE
Replace remove by disabling word (RhBug:1583596)

### DIFF
--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -1149,7 +1149,7 @@ class Output(object):
 
         removedProfiles = sorted(dict(self.base._moduleContainer.getRemovedProfiles()).items())
         if removedProfiles:
-            action = _("Removing module profiles")
+            action = _("Disabling module profiles")
             lines = []
             for name, profiles in removedProfiles:
                 for profile in list(profiles):


### PR DESCRIPTION
"removing module profiles" sounds very much like it is removing the
actual packages from a profile.

https://bugzilla.redhat.com/show_bug.cgi?id=1583596