### PR TITLE
Use ConfigParser from libdnf instead of python-iniparse

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -1,12 +1,12 @@
 # default dependencies
-%global hawkey_version 0.25.0
+%global hawkey_version 0.27.0
 %global libcomps_version 0.1.8
 %global libmodulemd_version 1.4.0
 %global rpm_version 4.14.0
 
 # conflicts
-%global conflicts_dnf_plugins_core_version 4.0.2
-%global conflicts_dnf_plugins_extras_version 3.0.2
+%global conflicts_dnf_plugins_core_version 4.0.5
+%global conflicts_dnf_plugins_extras_version 4.0.3
 %global conflicts_dnfdaemon_version 0.3.19
 
 # override dependencies for rhel 7
@@ -72,7 +72,7 @@
 It supports RPMs, modules and comps groups & environments.
 
 Name:           dnf
-Version:        4.1.0
+Version:        4.2.0
 Release:        1%{?dist}
 Summary:        %{pkg_summary}
 # For a breakdown of the licensing, see PACKAGE-LICENSING
@@ -196,13 +196,9 @@ Requires:       python2-libdnf >= %{hawkey_version}
 Requires:       python2-libcomps >= %{libcomps_version}
 Requires:       python2-libdnf
 %if 0%{?rhel} && 0%{?rhel} <= 7
-BuildRequires:  python-iniparse
-Requires:       python-iniparse
 BuildRequires:  rpm-python >= %{rpm_version}
 Requires:       rpm-python >= %{rpm_version}
 %else
-BuildRequires:  python2-iniparse
-Requires:       python2-iniparse
 BuildRequires:  python2-rpm >= %{rpm_version}
 Requires:       python2-rpm >= %{rpm_version}
 Recommends:     rpm-plugin-systemd-inhibit
@@ -220,7 +216,6 @@ Summary:        Python 3 interface to DNF
 BuildRequires:  python3-devel
 BuildRequires:  python3-hawkey >= %{hawkey_version}
 BuildRequires:  python3-libdnf >= %{hawkey_version}
-BuildRequires:  python3-iniparse
 BuildRequires:  python3-libcomps >= %{libcomps_version}
 BuildRequires:  python3-libdnf
 BuildRequires:  libmodulemd >= %{libmodulemd_version}
@@ -237,7 +232,6 @@ Requires:       deltarpm
 %endif
 Requires:       python3-hawkey >= %{hawkey_version}
 Requires:       python3-libdnf >= %{hawkey_version}
-Requires:       python3-iniparse
 Requires:       python3-libcomps >= %{libcomps_version}
 Requires:       python3-libdnf
 BuildRequires:  python3-rpm >= %{rpm_version}

--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -34,7 +34,6 @@ import dnf.exceptions
 import dnf.util
 import dnf.logging
 import hawkey
-import iniparse.compat
 import logging
 import socket
 import argparse

--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -31,7 +31,6 @@ import dnf.exceptions
 import dnf.pycomp
 import dnf.util
 import hawkey
-import iniparse
 import logging
 import os
 import libdnf.conf
@@ -319,23 +318,22 @@ class BaseConfig(object):
         substitutions - instance of base.conf.substitutions
         modify     - dict of modified options
         """
-        with open(filename) as fp:
-            ini = iniparse.INIConfig(fp)
+        parser = libdnf.conf.ConfigParser()
+        parser.read(filename)
 
         # b/c repoids can have $values in them we need to map both ways to figure
         # out which one is which
-        if section_id not in ini:
-            for sect in ini:
+        if not parser.hasSection(section_id):
+            for sect in parser.getData():
                 if libdnf.conf.ConfigParser.substitute(sect, substitutions) == section_id:
                     section_id = sect
 
         for name, value in modify.items():
             if isinstance(value, list):
                 value = ' '.join(value)
-            ini[section_id][name] = value
+            parser.setValue(section_id, name, value)
 
-        with open(filename, "w") as fp:
-            fp.write(str(ini))
+        parser.write(filename, False)
 
 
 class MainConf(BaseConfig):


### PR DESCRIPTION
Only one ConfigParser (from libdnf library) is used on all places now.
The python-iniparse module is not used anymore.
Dependency on it was removed.

Depends on:
https://github.com/rpm-software-management/libdnf/pull/682
https://github.com/rpm-software-management/dnf-plugins-core/pull/322
https://github.com/rpm-software-management/dnf-plugins-extras/pull/148