### PR TITLE
Smooth upgrade path for yum

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -38,15 +38,18 @@
 %endif
 
 # configurable name for the compat yum package
+%global yum_compat_level minimal
 %global yum_subpackage_name %{name}-yum
 
 # provide nextgen-yum4 on rhel <= 7 to avoid conflict with existing yum
 %if 0%{?rhel} && 0%{?rhel} <= 7
+    %global yum_compat_level preview
     %global yum_subpackage_name nextgen-yum4
 %endif
 
 # provide yum on rhel >= 8, it replaces old yum
 %if 0%{?rhel} && 0%{?rhel} >= 8
+    %global yum_compat_level full
     %global yum_subpackage_name yum
 %endif
 
@@ -315,7 +318,7 @@ ln -sr  %{buildroot}%{confdir}/%{name}.conf %{buildroot}%{_sysconfdir}/yum.conf
 %if %{with python3}
 ln -sr  %{buildroot}%{_bindir}/dnf-3 %{buildroot}%{_bindir}/yum
 %else
-%if 0%{?rhel} && 0%{?rhel} <= 7
+%if "%{yum_compat_level}" == "preview"
 ln -sr  %{buildroot}%{_bindir}/dnf-2 %{buildroot}%{_bindir}/yum4
 ln -sr  %{buildroot}%{_mandir}/man8/dnf.8.gz %{buildroot}%{_mandir}/man8/yum4.8.gz
 rm -f %{buildroot}%{_mandir}/man8/yum.8.gz
@@ -323,7 +326,7 @@ rm -f %{buildroot}%{_mandir}/man8/yum.8.gz
 ln -sr  %{buildroot}%{_bindir}/dnf-2 %{buildroot}%{_bindir}/yum
 %endif
 %endif
-%if "%{yum_subpackage_name}" == "yum"
+%if "%{yum_compat_level}" == "full"
 mkdir -p %{buildroot}%{_sysconfdir}/yum
 ln -sr  %{buildroot}%{pluginconfpath} %{buildroot}%{_sysconfdir}/yum/pluginconf.d
 ln -sr  %{buildroot}%{confdir}/protected.d %{buildroot}%{_sysconfdir}/yum/protected.d
@@ -416,7 +419,7 @@ ln -sr  %{buildroot}%{confdir}/vars %{buildroot}%{_sysconfdir}/yum/vars
 %{_sysconfdir}/libreport/events.d/collect_dnf.conf
 
 %files -n %{yum_subpackage_name}
-%if "%{yum_subpackage_name}" == "yum"
+%if "%{yum_compat_level}" == "full"
 %{_bindir}/yum
 %{_sysconfdir}/yum.conf
 %{_sysconfdir}/yum/pluginconf.d
@@ -438,12 +441,12 @@ ln -sr  %{buildroot}%{confdir}/vars %{buildroot}%{_sysconfdir}/yum/vars
 %exclude %{_mandir}/man1/yum-aliases.1*
 %endif
 
-%if "%{yum_subpackage_name}" == "%{name}-yum"
+%if "%{yum_compat_level}" == "minimal"
 %{_bindir}/yum
 %{_mandir}/man8/yum.8*
 %endif
 
-%if "%{yum_subpackage_name}" == "nextgen-yum4"
+%if "%{yum_compat_level}" == "preview"
 %{_bindir}/yum4
 %{_mandir}/man8/yum4.8*
 %exclude %{_mandir}/man8/yum.8*

--- a/dnf.spec
+++ b/dnf.spec
@@ -211,7 +211,8 @@ Conflicts:      dnfdaemon < %{conflicts_dnfdaemon_version}
 
 %description -n python2-%{name}
 Python 2 interface to DNF.
-%endif  # %%{with python2}
+%endif
+# ^ %{with python2}
 
 %if %{with python3}
 %package -n python3-%{name}

--- a/dnf.spec
+++ b/dnf.spec
@@ -147,13 +147,7 @@ Common data and configuration files for DNF
 %package -n %{yum_subpackage_name}
 Requires:       %{name} = %{version}-%{release}
 Summary:        %{pkg_summary}
-%if 0%{?fedora}
-%if 0%{?fedora} >= 31
-Conflicts:      yum
-%else
 Conflicts:      yum < 3.4.3-505
-%endif
-%endif
 
 %description -n %{yum_subpackage_name}
 %{pkg_description}
@@ -449,13 +443,8 @@ ln -sr  %{buildroot}%{confdir}/vars %{buildroot}%{_sysconfdir}/yum/vars
 %if "%{yum_subpackage_name}" == "%{name}-yum"
 %{_bindir}/yum
 %{_mandir}/man8/yum.8*
-%if 0%{?fedora} >= 31
-%{_sysconfdir}/yum.conf
-%{_mandir}/man5/yum.conf.5*
-%else
 %exclude %{_sysconfdir}/yum.conf
 %exclude %{_mandir}/man5/yum.conf.5*
-%endif
 %endif
 
 %if %{with python2}

--- a/dnf.spec
+++ b/dnf.spec
@@ -298,17 +298,23 @@ mkdir -p %{buildroot}%{py2pluginpath}/
 %if %{with python3}
 mkdir -p %{buildroot}%{py3pluginpath}/__pycache__/
 %endif
-ln -sr  %{buildroot}%{confdir}/%{name}.conf %{buildroot}%{_sysconfdir}/yum.conf
 mkdir -p %{buildroot}%{_localstatedir}/log/
 mkdir -p %{buildroot}%{_var}/cache/dnf/
 touch %{buildroot}%{_localstatedir}/log/%{name}.log
 %if %{with python3}
 ln -sr %{buildroot}%{_bindir}/dnf-3 %{buildroot}%{_bindir}/dnf
 mv %{buildroot}%{_bindir}/dnf-automatic-3 %{buildroot}%{_bindir}/dnf-automatic
-ln -sr  %{buildroot}%{_bindir}/dnf-3 %{buildroot}%{_bindir}/yum
 %else
 ln -sr %{buildroot}%{_bindir}/dnf-2 %{buildroot}%{_bindir}/dnf
 mv %{buildroot}%{_bindir}/dnf-automatic-2 %{buildroot}%{_bindir}/dnf-automatic
+%endif
+rm -vf %{buildroot}%{_bindir}/dnf-automatic-*
+
+# YUM compat layer
+ln -sr  %{buildroot}%{confdir}/%{name}.conf %{buildroot}%{_sysconfdir}/yum.conf
+%if %{with python3}
+ln -sr  %{buildroot}%{_bindir}/dnf-3 %{buildroot}%{_bindir}/yum
+%else
 %if 0%{?rhel} && 0%{?rhel} <= 7
 ln -sr  %{buildroot}%{_bindir}/dnf-2 %{buildroot}%{_bindir}/yum4
 ln -sr  %{buildroot}%{_mandir}/man8/dnf.8.gz %{buildroot}%{_mandir}/man8/yum4.8.gz
@@ -317,7 +323,6 @@ rm -f %{buildroot}%{_mandir}/man8/yum.8.gz
 ln -sr  %{buildroot}%{_bindir}/dnf-2 %{buildroot}%{_bindir}/yum
 %endif
 %endif
-rm -vf %{buildroot}%{_bindir}/dnf-automatic-*
 %if "%{yum_subpackage_name}" == "yum"
 mkdir -p %{buildroot}%{_sysconfdir}/yum
 ln -sr  %{buildroot}%{pluginconfpath} %{buildroot}%{_sysconfdir}/yum/pluginconf.d
@@ -413,38 +418,35 @@ ln -sr  %{buildroot}%{confdir}/vars %{buildroot}%{_sysconfdir}/yum/vars
 %files -n %{yum_subpackage_name}
 %if "%{yum_subpackage_name}" == "yum"
 %{_bindir}/yum
-%{_mandir}/man8/yum.8*
 %{_sysconfdir}/yum.conf
 %{_sysconfdir}/yum/pluginconf.d
 %{_sysconfdir}/yum/protected.d
 %{_sysconfdir}/yum/vars
-%{_mandir}/man5/yum.conf.5.*
 %{_mandir}/man8/yum.8*
+%{_mandir}/man5/yum.conf.5.*
 %{_mandir}/man8/yum-shell.8*
 %{_mandir}/man1/yum-aliases.1*
 %config(noreplace) %{confdir}/protected.d/yum.conf
 %else
-%exclude %{_mandir}/man8/yum-shell.8*
-%exclude %{_mandir}/man1/yum-aliases.1*
+%exclude %{_sysconfdir}/yum.conf
 %exclude %{_sysconfdir}/yum/pluginconf.d
 %exclude %{_sysconfdir}/yum/protected.d
 %exclude %{_sysconfdir}/yum/vars
 %exclude %{confdir}/protected.d/yum.conf
+%exclude %{_mandir}/man5/yum.conf.5.*
+%exclude %{_mandir}/man8/yum-shell.8*
+%exclude %{_mandir}/man1/yum-aliases.1*
 %endif
 
 %if "%{yum_subpackage_name}" == "nextgen-yum4"
 %{_bindir}/yum4
 %{_mandir}/man8/yum4.8*
-%exclude %{_sysconfdir}/yum.conf
-%exclude %{_mandir}/man5/yum.conf.5.*
 %exclude %{_mandir}/man8/yum.8*
 %endif
 
 %if "%{yum_subpackage_name}" == "%{name}-yum"
 %{_bindir}/yum
 %{_mandir}/man8/yum.8*
-%exclude %{_sysconfdir}/yum.conf
-%exclude %{_mandir}/man5/yum.conf.5*
 %endif
 
 %if %{with python2}

--- a/dnf.spec
+++ b/dnf.spec
@@ -438,15 +438,15 @@ ln -sr  %{buildroot}%{confdir}/vars %{buildroot}%{_sysconfdir}/yum/vars
 %exclude %{_mandir}/man1/yum-aliases.1*
 %endif
 
+%if "%{yum_subpackage_name}" == "%{name}-yum"
+%{_bindir}/yum
+%{_mandir}/man8/yum.8*
+%endif
+
 %if "%{yum_subpackage_name}" == "nextgen-yum4"
 %{_bindir}/yum4
 %{_mandir}/man8/yum4.8*
 %exclude %{_mandir}/man8/yum.8*
-%endif
-
-%if "%{yum_subpackage_name}" == "%{name}-yum"
-%{_bindir}/yum
-%{_mandir}/man8/yum.8*
 %endif
 
 %if %{with python2}


### PR DESCRIPTION
Changes the `dnf-yum` subpackage name to `yum` for Fedora 31, ensuring the removal of the original `yum` as well as consistency with RHEL.

For more details, please see the commit messages.

[Similar change for the dnf-utils -> yum-utils transition.](https://github.com/rpm-software-management/dnf-plugins-core/pull/327)