### PR TITLE
 [conf] Update substitutions from special environment variables

### DIFF
--- a/dnf/conf/substitutions.py
+++ b/dnf/conf/substitutions.py
@@ -19,10 +19,12 @@
 #
 
 import os
+import re
 
 import dnf
 import dnf.exceptions
 
+ENVIRONMENT_VARS_RE = re.compile(r'^DNF_VARS_[A-Za-z0-9_]+$')
 
 class Substitutions(dict):
 
@@ -31,11 +33,10 @@ class Substitutions(dict):
         self._update_from_env()
 
     def _update_from_env(self):
-        for num in range(0, 10):
-            env = 'DNF%d' % num
-            val = os.environ.get(env, '')
-            if val:
-                self[env] = val
+        numericvars = ['DNF%d' % num for num in range(0, 10)]
+        for key, val in os.environ.items():
+            if ENVIRONMENT_VARS_RE.match(key) or key in numericvars:
+                self[key] = val
 
     def update_from_etc(self, installroot):
         fsvars = []

--- a/dnf/conf/substitutions.py
+++ b/dnf/conf/substitutions.py
@@ -24,7 +24,7 @@ import re
 import dnf
 import dnf.exceptions
 
-ENVIRONMENT_VARS_RE = re.compile(r'^DNF_VARS_[A-Za-z0-9_]+$')
+ENVIRONMENT_VARS_RE = re.compile(r'^DNF_VAR_[A-Za-z0-9_]+$')
 
 class Substitutions(dict):
 

--- a/dnf/conf/substitutions.py
+++ b/dnf/conf/substitutions.py
@@ -18,9 +18,10 @@
 # Red Hat, Inc.
 #
 
+import os
+
 import dnf
 import dnf.exceptions
-import os
 
 
 class Substitutions(dict):

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -397,9 +397,9 @@ Right side of every repo option can be enriched by the following variables:
     Refers to the release version of operating system which DNF derives from information available in RPMDB.
 
 
-In addition to these hard coded variables, user-defined ones can also be used. They can be defined either via :ref:`variable files <varfiles-label>`, or by using special environmental variables. The names of these variables must be prefixed with DNF_VARS\_ and they can only consist of alphanumeric characters and underscores::
+In addition to these hard coded variables, user-defined ones can also be used. They can be defined either via :ref:`variable files <varfiles-label>`, or by using special environmental variables. The names of these variables must be prefixed with DNF_VAR\_ and they can only consist of alphanumeric characters and underscores::
 
-    $ DNF_VARS_MY_VARIABLE=value
+    $ DNF_VAR_MY_VARIABLE=value
 
 ==================================
  Options for both [main] and Repo

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -396,6 +396,11 @@ Right side of every repo option can be enriched by the following variables:
 
     Refers to the release version of operating system which DNF derives from information available in RPMDB.
 
+
+In addition to these hard coded variables, user-defined ones can also be used. They can be defined either via :ref:`variable files <varfiles-label>`, or by using special environmental variables. The names of these variables must be prefixed with DNF_VARS\_ and they can only consist of alphanumeric characters and underscores::
+
+    $ DNF_VARS_MY_VARIABLE=value
+
 ==================================
  Options for both [main] and Repo
 ==================================
@@ -632,6 +637,8 @@ Files
 
 ``Repository``
     /etc/yum.repos.d/
+
+.. _varfiles-label:
 
 ``Variables``
     Any properly named file in /etc/dnf/vars is turned into a variable named after the filename (or

--- a/tests/conf/test_substitutions.py
+++ b/tests/conf/test_substitutions.py
@@ -48,7 +48,7 @@ class SubstitutionsFromEnvironmentTest(tests.support.TestCase):
         os.environ['DNF_VAR_MALFORMED '] = 'not this'
         conf = dnf.conf.Conf()
         os.environ = env
-        self.assertItemsEqual(
+        self.assertCountEqual(
             conf.substitutions.keys(),
             ['basearch', 'arch', 'DNF_VAR_GENRE', 'DNF_VAR_EMPTY'])
         self.assertEqual('opera', conf.substitutions['DNF_VAR_GENRE'])

--- a/tests/conf/test_substitutions.py
+++ b/tests/conf/test_substitutions.py
@@ -41,14 +41,14 @@ class SubstitutionsFromEnvironmentTest(tests.support.TestCase):
 
     def test_named(self):
         env = os.environ
-        os.environ['DNF_VARS_GENRE'] = 'opera'
-        os.environ['DNF_VARS_EMPTY'] = ''
-        os.environ['DNF_VARS_MAL$FORMED'] = 'not this'
-        os.environ['DNF_VARSMALFORMED'] = 'not this'
-        os.environ['DNF_VARS_MALFORMED '] = 'not this'
+        os.environ['DNF_VAR_GENRE'] = 'opera'
+        os.environ['DNF_VAR_EMPTY'] = ''
+        os.environ['DNF_VAR_MAL$FORMED'] = 'not this'
+        os.environ['DNF_VARMALFORMED'] = 'not this'
+        os.environ['DNF_VAR_MALFORMED '] = 'not this'
         conf = dnf.conf.Conf()
         os.environ = env
         self.assertItemsEqual(
             conf.substitutions.keys(),
-            ['basearch', 'arch', 'DNF_VARS_GENRE', 'DNF_VARS_EMPTY'])
-        self.assertEqual('opera', conf.substitutions['DNF_VARS_GENRE'])
+            ['basearch', 'arch', 'DNF_VAR_GENRE', 'DNF_VAR_EMPTY'])
+        self.assertEqual('opera', conf.substitutions['DNF_VAR_GENRE'])

--- a/tests/conf/test_substitutions.py
+++ b/tests/conf/test_substitutions.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import os
+
+import dnf.conf
+
+import tests.support
+
+
+FN = tests.support.resource_path('etc/repos.conf')
+
+
+class SubstitutionsFromEnvironmentTest(tests.support.TestCase):
+    def test_numeric(self):
+        env = os.environ
+        os.environ['DNF0'] = 'the_zero'
+        conf = dnf.conf.Conf()
+        os.environ = env
+        self.assertIn('DNF0', conf.substitutions)
+        self.assertEqual('the_zero', conf.substitutions['DNF0'])
+
+    def test_named(self):
+        env = os.environ
+        os.environ['DNF_VARS_GENRE'] = 'opera'
+        os.environ['DNF_VARS_EMPTY'] = ''
+        os.environ['DNF_VARS_MAL$FORMED'] = 'not this'
+        os.environ['DNF_VARSMALFORMED'] = 'not this'
+        os.environ['DNF_VARS_MALFORMED '] = 'not this'
+        conf = dnf.conf.Conf()
+        os.environ = env
+        self.assertItemsEqual(
+            conf.substitutions.keys(),
+            ['basearch', 'arch', 'DNF_VARS_GENRE', 'DNF_VARS_EMPTY'])
+        self.assertEqual('opera', conf.substitutions['DNF_VARS_GENRE'])


### PR DESCRIPTION
DNF now can use environment variables in form DNF[0-9] as substitutions.
But these names do not say much about their meaning.
This commit adds ability to use environment variables prefixed with DNF_VARS_ to substitutions.