### PR TITLE
Remove "Unknown configuration option:" msg for comments

### DIFF
--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -144,7 +144,7 @@ class Config(object):
     def populate(self, parser, section, filename, priority):
         """Set option values from an INI file section."""
         if parser.hasSection(section):
-            for name in parser.getData()[section]:
+            for name in parser.options(section):
                 value = parser.getValue(section, name)
                 if not value or value == 'None':
                     value = ''

--- a/dnf/cli/aliases.py
+++ b/dnf/cli/aliases.py
@@ -59,7 +59,7 @@ class AliasesConfig(object):
         section = "aliases"
         if not self._parser.hasSection(section):
             return result
-        for key in self._parser.getData()[section]:
+        for key in self._parser.options(section):
             value = self._parser.getValue(section, key)
             if not value:
                 continue

--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -138,7 +138,7 @@ class BaseConfig(object):
     def _populate(self, parser, section, filename, priority=PRIO_DEFAULT):
         """Set option values from an INI file section."""
         if parser.hasSection(section):
-            for name in parser.getData()[section]:
+            for name in parser.options(section):
                 value = parser.getSubstitutedValue(section, name)
                 if not value or value == 'None':
                     value = ''


### PR DESCRIPTION
Comments should be ignored and not logged.
Original logged message:
Unknown configuration option: #<number> = #commented text
Unknown configuration option: #2 = #metadata_expire=7d