### PR TITLE
Remove redundant arguments during parsing (RhBug:1687286)

### DIFF
--- a/dnf/util.py
+++ b/dnf/util.py
@@ -66,13 +66,18 @@ def _parse_specs(namespace, values):
     for value in values:
         schemes = dnf.pycomp.urlparse.urlparse(value)[0]
         if value.endswith('.rpm'):
-            namespace.filenames.append(value)
+            if value not in namespace.filenames:
+                namespace.filenames.append(value)
         elif schemes and schemes in ('http', 'ftp', 'file', 'https'):
-            namespace.filenames.append(value)
+            if value not in namespace.filenames:
+                namespace.filenames.append(value)
         elif value.startswith('@'):
-            namespace.grp_specs.append(value[1:])
+            stripped_value = value[1:]
+            if stripped_value not in namespace.grp_specs:
+                namespace.grp_specs.append(stripped_value)
         else:
-            namespace.pkg_specs.append(value)
+            if value not in namespace.pkg_specs:
+                namespace.pkg_specs.append(value)
 
 
 def _urlopen_progress(url, conf, progress=None):

--- a/dnf/util.py
+++ b/dnf/util.py
@@ -63,21 +63,20 @@ def _parse_specs(namespace, values):
     setattr(namespace, "filenames", [])
     setattr(namespace, "grp_specs", [])
     setattr(namespace, "pkg_specs", [])
+    tmp_set = set()
     for value in values:
+        if value in tmp_set:
+            continue
+        tmp_set.add(value)
         schemes = dnf.pycomp.urlparse.urlparse(value)[0]
         if value.endswith('.rpm'):
-            if value not in namespace.filenames:
-                namespace.filenames.append(value)
+            namespace.filenames.append(value)
         elif schemes and schemes in ('http', 'ftp', 'file', 'https'):
-            if value not in namespace.filenames:
-                namespace.filenames.append(value)
+            namespace.filenames.append(value)
         elif value.startswith('@'):
-            stripped_value = value[1:]
-            if stripped_value not in namespace.grp_specs:
-                namespace.grp_specs.append(stripped_value)
+            namespace.grp_specs.append(value[1:])
         else:
-            if value not in namespace.pkg_specs:
-                namespace.pkg_specs.append(value)
+            namespace.pkg_specs.append(value)
 
 
 def _urlopen_progress(url, conf, progress=None):


### PR DESCRIPTION
Removal of duplicates has not only positive impact on performance, but
also prevents import of a same local rpm to the sack. If the same rpm
file is loaded multiple times it would result in transaction error.

https://bugzilla.redhat.com/show_bug.cgi?id=1687286