### PR TITLE
[doc] Document different behavior of dnf makecache (RhBug:1667180)

### DIFF
--- a/doc/cli_vs_yum.rst
+++ b/doc/cli_vs_yum.rst
@@ -128,6 +128,13 @@ YUM immediately stops on a repo error, confusing and bothering the user.
 
 See the related `Fedora bug 984483 <https://bugzilla.redhat.com/show_bug.cgi?id=984483>`_.
 
+===============================================================
+ ``dnf makecache`` honors ``skip_if_unavailable`` configuration
+===============================================================
+
+The change unified behavior of DNF for all commands. DNF will not pass "dnf makecache" command if
+a repository with ``skip_if_unavailable=False`` is unreachable.
+
 ============================================================================
  ``overwrite_groups`` dropped, comps functions acting as if always disabled
 ============================================================================


### PR DESCRIPTION
There is a different behavior between YUM and DNF for "makecache"
command.

https://bugzilla.redhat.com/show_bug.cgi?id=1667180