### PR TITLE
Provide a hint if no platform module available (RhBug:1678596)

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -1,5 +1,5 @@
 # default dependencies
-%global hawkey_version 0.28.0
+%global hawkey_version 0.29.0
 %global libcomps_version 0.1.8
 %global libmodulemd_version 1.4.0
 %global rpm_version 4.14.0

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -813,6 +813,14 @@ class Cli(object):
             self.base.fill_sack(
                 load_system_repo='auto' if self.demands.load_system_repo else False,
                 load_available_repos=self.demands.available_repos)
+            if dnf.base.WITH_MODULES:
+                moduleContainer = self.base._moduleContainer
+                if not moduleContainer.empty() and not moduleContainer.isPlatformPresent():
+                    msg = _("Unable to detect a platform module (use "
+                            "'--setopt=module_platform_id=<platform_name>:<platform_stream>' "
+                            "to specify the platform module)")
+                    logger.warning(msg)
+
 
     def _parse_commands(self, opts, args):
         """Check that the requested CLI command exists."""


### PR DESCRIPTION
It provides a similar hint like if releasever not detected.

https://bugzilla.redhat.com/show_bug.cgi?id=1678596

Requires: https://github.com/rpm-software-management/libdnf/pull/699