### PR TITLE
Allow adjustment of repo from --repofrompath (RhBug:1689591)

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -732,7 +732,8 @@ class Cli(object):
         self.base.read_all_repos(opts)
         if opts.repofrompath:
             for label, path in opts.repofrompath.items():
-                self.base.repos.add_new_repo(label, self.base.conf, baseurl=[path])
+                this_repo = self.base.repos.add_new_repo(label, self.base.conf, baseurl=[path])
+                this_repo._configure_from_options(opts)
                 # do not let this repo to be disabled
                 opts.repos_ed.append((label, "enable"))
 

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -323,6 +323,8 @@ Options
     only packages from this repository, combine this with the ``--repo=<repo>``
     or ``--disablerepo="*"`` switches.
     The repository label for the repository is specified by <repo>.
+    The configuration for the repo could be adjusted using \-\
+    :ref:`-setopt <setopt_option-label>`\=<repo>.<option>=<value>\.
 
 ``--repo=<repoid>, --repoid=<repoid>``
     Enable just specific repositories by an id or a glob. Can be used multiple
@@ -341,6 +343,8 @@ Options
 ``--security``
     Includes packages that provide a fix for a security issue. Applicable for the
     upgrade command.
+
+.. _setopt_option-label:
 
 ``--setopt=<option>=<value>``
     Override a configuration option from the configuration file. To override configuration options for repositories, use


### PR DESCRIPTION
The patch allows to adjust a configuration for a repo created from
commandline using --repofrompath option. Additionally it describes the
possibility in manual.

https://bugzilla.redhat.com/show_bug.cgi?id=1689591