### PR TITLE
[doc] Change description of skip_if_unavailable option

### DIFF
--- a/doc/api_conf.rst
+++ b/doc/api_conf.rst
@@ -182,6 +182,12 @@ Configurable settings of the :class:`dnf.Base` object are stored into a :class:`
 
     Number of times any attempt to retrieve a file should retry before returning an error. Setting this to `0` makes it try forever. Defaults to `10`.
 
+  .. attribute:: skip_if_unavailable
+
+    If enabled, DNF will continue running and disable the repository that couldn't be synchronized
+    for any reason. This option doesn't affect skipping of unavailable packages after dependency
+    resolution. The default is ``False``.
+
   .. attribute:: sslcacert
 
     Path to the directory or file containing the certificate authorities to verify SSL certificates.

--- a/doc/api_repos.rst
+++ b/doc/api_repos.rst
@@ -164,7 +164,9 @@ Repository Configuration
 
   .. attribute:: skip_if_unavailable
 
-    If enabled, DNF will continue running and disable the repository that couldn't be contacted for any reason when downloading metadata. This option doesn't affect skipping of unavailable packages after dependency resolution. The default is ``True``.
+    If enabled, DNF will continue running and disable the repository that couldn't be synchronized
+    for any reason. This option doesn't affect skipping of unavailable packages after dependency
+    resolution. The default is inherited from :attr:`dnf.conf.Conf.skip_if_unavailable`.
 
   .. attribute:: sslcacert
 

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -357,13 +357,6 @@ or :ref:`mirrorlist <mirrorlist-label>` option definition.
 
     Overrides the retries option from the [main] section for this repository.
 
-.. _skip_if_unavailable-label:
-
-``skip_if_unavailable``
-    :ref:`boolean <boolean-label>`
-
-    If enabled, DNF will continue running and disable the repository that couldn't be contacted for any reason when downloading metadata. This option doesn't affect skipping of unavailable packages after dependency resolution. To check inaccessibility of repository use it in combination with :ref:`refresh command line option <refresh_command-label>`. The default is True.
-
 .. _strict-label:
 
 ``strict``
@@ -543,6 +536,16 @@ configuration.
     :ref:`integer <integer-label>`
 
     Set the number of times any attempt to retrieve a file should retry before returning an error. Setting this to `0` makes dnf try forever. Default is `10`.
+
+.. _skip_if_unavailable-label:
+
+``skip_if_unavailable``
+    :ref:`boolean <boolean-label>`
+
+    If enabled, DNF will continue running and disable the repository that couldn't be synchronized
+    for any reason. This option doesn't affect skipping of unavailable packages after dependency
+    resolution. To check inaccessibility of repository use it in combination with
+    :ref:`refresh command line option <refresh_command-label>`. The default is ``False``.
 
 .. _sslcacert-label:
 


### PR DESCRIPTION
skip_if_unavailable option is now not only repo option but also option
an main config. option. The commit provides a description.

Additionally there is a change in default. Formally it was
skip_if_unavailable=true, but it was changed to False to provide a
better security to users. The commit also change the description
according to new default.