### PR TITLE
 Add the exception message to plugin loading error text 

### DIFF
--- a/dnf/plugin.py
+++ b/dnf/plugin.py
@@ -194,7 +194,7 @@ def _import_modules(package, py_files):
         try:
             module = importlib.import_module(name)
         except Exception as e:
-            logger.error(_('Failed loading plugin: %s'), module)
+            logger.error(_('Failed loading plugin "%s": %s'), module, e)
             logger.log(dnf.logging.SUBDEBUG, '', exc_info=True)
 
 

--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -3,7 +3,7 @@
 file (RELATIVE_PATH SRCDIR ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/dnf)
 ADD_CUSTOM_TARGET (gettext-export
                    find ${SRCDIR} -iname "*.py" |
-                   xargs xgettext --from-code=UTF-8 --keyword=P_:1,2 --keyword=C_:1c,2 -c --output=dnf.pot &&
+                   xargs xgettext -F --from-code=UTF-8 --keyword=P_:1,2 --keyword=C_:1c,2 -c --output=dnf.pot &&
                    zanata push -f
                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                    COMMENT "Pushing translation source file to zanata")

--- a/po/dnf.pot
+++ b/po/dnf.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-25 16:56+0100\n"
+"POT-Creation-Date: 2019-03-25 17:12+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3418,7 +3418,7 @@ msgstr ""
 
 #: ../dnf/plugin.py:197
 #, python-format
-msgid "Failed loading plugin: %s"
+msgid "Failed loading plugin \"%s\": %s"
 msgstr ""
 
 #: ../dnf/repo.py:83

--- a/po/dnf.pot
+++ b/po/dnf.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-11 10:38+0100\n"
+"POT-Creation-Date: 2019-03-25 16:56+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,79 +18,2332 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#. TRANSLATORS: This is for a single package currently being downgraded.
-#: ../dnf/transaction.py:79
-msgctxt "currently"
-msgid "Downgrading"
-msgstr ""
-
-#: ../dnf/transaction.py:80 ../dnf/transaction.py:87 ../dnf/transaction.py:92
-#: ../dnf/transaction.py:94
-msgid "Cleanup"
-msgstr ""
-
-#. TRANSLATORS: This is for a single package currently being installed.
-#: ../dnf/transaction.py:82
-msgctxt "currently"
-msgid "Installing"
-msgstr ""
-
-#: ../dnf/transaction.py:83 ../dnf/transaction.py:84 ../dnf/cli/output.py:1952
-msgid "Obsoleting"
-msgstr ""
-
-#. TRANSLATORS: This is for a single package currently being reinstalled.
-#: ../dnf/transaction.py:86
-msgctxt "currently"
-msgid "Reinstalling"
-msgstr ""
-
-#. TODO: 'Removing'?
-#: ../dnf/transaction.py:89
-msgid "Erasing"
-msgstr ""
-
-#. TRANSLATORS: This is for a single package currently being upgraded.
-#: ../dnf/transaction.py:91
-msgctxt "currently"
-msgid "Upgrading"
-msgstr ""
-
-#: ../dnf/transaction.py:95
-msgid "Verifying"
-msgstr ""
-
-#: ../dnf/transaction.py:96
-msgid "Running scriptlet"
-msgstr ""
-
-#: ../dnf/transaction.py:98
-msgid "Preparing"
-msgstr ""
-
-#: ../dnf/plugin.py:63
+#: ../dnf/automatic/emitter.py:31
 #, python-format
-msgid "Parsing file failed: %s"
+msgid "The following updates have been applied on '%s':"
 msgstr ""
 
-#: ../dnf/plugin.py:139
+#: ../dnf/automatic/emitter.py:32
 #, python-format
-msgid "Loaded plugins: %s"
+msgid "The following updates are available on '%s':"
 msgstr ""
 
-#: ../dnf/plugin.py:197
+#: ../dnf/automatic/emitter.py:33
 #, python-format
-msgid "Failed loading plugin: %s"
+msgid "The following updates were downloaded on '%s':"
 msgstr ""
 
-#: ../dnf/repodict.py:58
+#: ../dnf/automatic/emitter.py:80
 #, python-format
-msgid "enabling %s repository"
+msgid "Updates applied on '%s'."
 msgstr ""
 
-#: ../dnf/repodict.py:94
+#: ../dnf/automatic/emitter.py:82
 #, python-format
-msgid "Added %s repo from %s"
+msgid "Updates downloaded on '%s'."
+msgstr ""
+
+#: ../dnf/automatic/emitter.py:84
+#, python-format
+msgid "Updates available on '%s'."
+msgstr ""
+
+#: ../dnf/automatic/emitter.py:107
+#, python-format
+msgid "Failed to send an email via '%s': %s"
+msgstr ""
+
+#: ../dnf/automatic/emitter.py:137
+#, python-format
+msgid "Failed to execute command '%s': returned %d"
+msgstr ""
+
+#: ../dnf/automatic/main.py:156 ../dnf/conf/config.py:149
+#, python-format
+msgid "Unknown configuration value: %s=%s in %s; %s"
+msgstr ""
+
+#: ../dnf/automatic/main.py:160 ../dnf/conf/config.py:156
+#, python-format
+msgid "Unknown configuration option: %s = %s in %s"
+msgstr ""
+
+#: ../dnf/automatic/main.py:231
+msgid "Started dnf-automatic."
+msgstr ""
+
+#: ../dnf/automatic/main.py:235
+#, python-format
+msgid "Sleep for %s seconds"
+msgstr ""
+
+#: ../dnf/automatic/main.py:266 ../dnf/cli/main.py:57
+#, python-format
+msgid "Error: %s"
+msgstr ""
+
+#: ../dnf/base.py:146
+msgid "loading repo '{}' failure: {}"
+msgstr ""
+
+#: ../dnf/base.py:148
+msgid "Loading repository '{}' has failed"
+msgstr ""
+
+#: ../dnf/base.py:335
+msgid "Metadata timer caching disabled when running on metered connection."
+msgstr ""
+
+#: ../dnf/base.py:340
+msgid "Metadata timer caching disabled when running on a battery."
+msgstr ""
+
+#: ../dnf/base.py:345
+msgid "Metadata timer caching disabled."
+msgstr ""
+
+#: ../dnf/base.py:350
+msgid "Metadata cache refreshed recently."
+msgstr ""
+
+#: ../dnf/base.py:356 ../dnf/cli/commands/__init__.py:101
+msgid "There are no enabled repos."
+msgstr ""
+
+#: ../dnf/base.py:362
+#, python-format
+msgid "%s: will never be expired and will not be refreshed."
+msgstr ""
+
+#: ../dnf/base.py:364
+#, python-format
+msgid "%s: has expired and will be refreshed."
+msgstr ""
+
+#. expires within the checking period:
+#: ../dnf/base.py:368
+#, python-format
+msgid "%s: metadata will expire after %d seconds and will be refreshed now"
+msgstr ""
+
+#: ../dnf/base.py:372
+#, python-format
+msgid "%s: will expire after %d seconds."
+msgstr ""
+
+#. performs the md sync
+#: ../dnf/base.py:378
+msgid "Metadata cache created."
+msgstr ""
+
+#: ../dnf/base.py:414
+#, python-format
+msgid "%s: using metadata from %s."
+msgstr ""
+
+#: ../dnf/base.py:425
+#, python-format
+msgid "Ignoring repositories: %s"
+msgstr ""
+
+#: ../dnf/base.py:428
+#, python-format
+msgid "Last metadata expiration check: %s ago on %s."
+msgstr ""
+
+#: ../dnf/base.py:458
+msgid ""
+"The downloaded packages were saved in cache until the next successful "
+"transaction."
+msgstr ""
+
+#: ../dnf/base.py:460
+#, python-format
+msgid "You can remove cached packages by executing '%s'."
+msgstr ""
+
+#: ../dnf/base.py:552
+#, python-format
+msgid "Invalid tsflag in config file: %s"
+msgstr ""
+
+#: ../dnf/base.py:608
+#, python-format
+msgid "Failed to add groups file for repository: %s - %s"
+msgstr ""
+
+#: ../dnf/base.py:829
+msgid "Running transaction check"
+msgstr ""
+
+#: ../dnf/base.py:840
+msgid "Error: transaction check vs depsolve:"
+msgstr ""
+
+#: ../dnf/base.py:846
+msgid "Transaction check succeeded."
+msgstr ""
+
+#: ../dnf/base.py:849
+msgid "Running transaction test"
+msgstr ""
+
+#: ../dnf/base.py:859
+msgid "Transaction check error:"
+msgstr ""
+
+#: ../dnf/base.py:866
+msgid "Transaction test succeeded."
+msgstr ""
+
+#: ../dnf/base.py:881
+msgid "Running transaction"
+msgstr ""
+
+#: ../dnf/base.py:907
+msgid "Disk Requirements:"
+msgstr ""
+
+#: ../dnf/base.py:910
+#, python-format
+msgid "At least %dMB more space needed on the %s filesystem."
+msgid_plural "At least %dMB more space needed on the %s filesystem."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../dnf/base.py:914
+msgid "Error Summary"
+msgstr ""
+
+#: ../dnf/base.py:940
+msgid "RPMDB altered outside of DNF."
+msgstr ""
+
+#: ../dnf/base.py:997
+msgid "Errors occurred during transaction."
+msgstr ""
+
+#: ../dnf/base.py:1001
+#, python-format
+msgid "Failed to obtain the transaction lock (logged in as: %s)."
+msgstr ""
+
+#. should this be 'to_unicoded'?
+#: ../dnf/base.py:1004 ../dnf/base.py:1014
+msgid "Could not run transaction."
+msgstr ""
+
+#: ../dnf/base.py:1011
+msgid "Transaction couldn't start:"
+msgstr ""
+
+#: ../dnf/base.py:1023
+#, python-format
+msgid "Failed to remove transaction file %s"
+msgstr ""
+
+#: ../dnf/base.py:1102
+msgid "Some packages were not downloaded. Retrying."
+msgstr ""
+
+#: ../dnf/base.py:1132
+#, python-format
+msgid "Delta RPMs reduced %.1f MB of updates to %.1f MB (%d.1%% saved)"
+msgstr ""
+
+#: ../dnf/base.py:1135
+#, python-format
+msgid ""
+"Failed Delta RPMs increased %.1f MB of updates to %.1f MB (%d.1%% wasted)"
+msgstr ""
+
+#: ../dnf/base.py:1184
+msgid "Could not open: {}"
+msgstr ""
+
+#: ../dnf/base.py:1222
+#, python-format
+msgid "Public key for %s is not installed"
+msgstr ""
+
+#: ../dnf/base.py:1226
+#, python-format
+msgid "Problem opening package %s"
+msgstr ""
+
+#: ../dnf/base.py:1234
+#, python-format
+msgid "Public key for %s is not trusted"
+msgstr ""
+
+#: ../dnf/base.py:1238
+#, python-format
+msgid "Package %s is not signed"
+msgstr ""
+
+#: ../dnf/base.py:1253
+#, python-format
+msgid "Cannot remove %s"
+msgstr ""
+
+#: ../dnf/base.py:1257
+#, python-format
+msgid "%s removed"
+msgstr ""
+
+#: ../dnf/base.py:1529
+msgid "No match for group package \"{}\""
+msgstr ""
+
+#: ../dnf/base.py:1614
+#, python-format
+msgid "Adding packages from group '%s': %s"
+msgstr ""
+
+#: ../dnf/base.py:1638 ../dnf/cli/cli.py:200
+#: ../dnf/cli/commands/__init__.py:445 ../dnf/cli/commands/__init__.py:502
+#: ../dnf/cli/commands/__init__.py:595 ../dnf/cli/commands/__init__.py:644
+#: ../dnf/cli/commands/install.py:80 ../dnf/cli/commands/install.py:103
+#: ../dnf/cli/commands/install.py:110
+msgid "Nothing to do."
+msgstr ""
+
+#: ../dnf/base.py:1655
+msgid "No groups marked for removal."
+msgstr ""
+
+#: ../dnf/base.py:1674
+msgid "No group marked for upgrade."
+msgstr ""
+
+#: ../dnf/base.py:1812 ../dnf/base.py:1887 ../dnf/base.py:1906
+#: ../dnf/base.py:1919 ../dnf/base.py:1940 ../dnf/base.py:1990
+#: ../dnf/base.py:1998 ../dnf/base.py:2047 ../dnf/base.py:2136
+#: ../dnf/cli/cli.py:393 ../dnf/cli/commands/__init__.py:428
+#: ../dnf/cli/commands/__init__.py:485 ../dnf/cli/commands/__init__.py:589
+#: ../dnf/cli/commands/__init__.py:636 ../dnf/cli/commands/__init__.py:679
+#: ../dnf/cli/commands/__init__.py:714 ../dnf/cli/commands/install.py:147
+#: ../dnf/cli/commands/install.py:179 ../dnf/cli/commands/reinstall.py:70
+#: ../dnf/cli/commands/reinstall.py:84 ../dnf/cli/commands/remove.py:150
+#: ../dnf/cli/commands/upgrade.py:110 ../dnf/cli/commands/upgrade.py:121
+#, python-format
+msgid "No match for argument: %s"
+msgstr ""
+
+#: ../dnf/base.py:1859 ../dnf/base.py:1870 ../dnf/base.py:2224
+msgid "no package matched"
+msgstr ""
+
+#: ../dnf/base.py:1885
+#, python-format
+msgid "Package %s not installed, cannot downgrade it."
+msgstr ""
+
+#: ../dnf/base.py:1894
+#, python-format
+msgid "Package %s of lower version already installed, cannot downgrade it."
+msgstr ""
+
+#: ../dnf/base.py:1917
+#, python-format
+msgid "Package %s not installed, cannot reinstall it."
+msgstr ""
+
+#: ../dnf/base.py:1932
+#, python-format
+msgid "File %s is a source package and cannot be updated, ignoring."
+msgstr ""
+
+#: ../dnf/base.py:1938
+#, python-format
+msgid "Package %s not installed, cannot update it."
+msgstr ""
+
+#: ../dnf/base.py:1947
+#, python-format
+msgid "Package %s of higher version already installed, cannot update it."
+msgstr ""
+
+#: ../dnf/base.py:1987 ../dnf/cli/commands/reinstall.py:81
+#, python-format
+msgid "Package %s available, but not installed."
+msgstr ""
+
+#: ../dnf/base.py:1993
+#, python-format
+msgid "Package %s available, but installed for different architecture."
+msgstr ""
+
+#: ../dnf/base.py:2018 ../dnf/base.py:2205 ../dnf/cli/cli.py:651
+#: ../dnf/cli/cli.py:682
+#, python-format
+msgid "No package %s installed."
+msgstr ""
+
+#: ../dnf/base.py:2036 ../dnf/cli/commands/install.py:136
+#: ../dnf/cli/commands/remove.py:126
+#, python-format
+msgid "Not a valid form: %s"
+msgstr ""
+
+#: ../dnf/base.py:2053 ../dnf/cli/commands/__init__.py:684
+#: ../dnf/cli/commands/remove.py:156
+msgid "No packages marked for removal."
+msgstr ""
+
+#: ../dnf/base.py:2143 ../dnf/cli/cli.py:405
+#, python-format
+msgid "Packages for argument %s available, but not installed."
+msgstr ""
+
+#: ../dnf/base.py:2148
+#, python-format
+msgid "Package %s of lowest version already installed, cannot downgrade it."
+msgstr ""
+
+#: ../dnf/base.py:2197
+msgid "Action not handled: {}"
+msgstr ""
+
+#: ../dnf/base.py:2211 ../dnf/cli/cli.py:402 ../dnf/cli/cli.py:656
+#: ../dnf/cli/cli.py:686 ../dnf/cli/commands/__init__.py:373
+#: ../dnf/cli/commands/__init__.py:890 ../dnf/cli/commands/group.py:386
+#, python-format
+msgid "No package %s available."
+msgstr ""
+
+#: ../dnf/base.py:2245
+msgid "No security updates needed, but {} update available"
+msgstr ""
+
+#: ../dnf/base.py:2247
+msgid "No security updates needed, but {} updates available"
+msgstr ""
+
+#: ../dnf/base.py:2251
+msgid "No security updates needed for \"{}\", but {} update available"
+msgstr ""
+
+#: ../dnf/base.py:2253
+msgid "No security updates needed for \"{}\", but {} updates available"
+msgstr ""
+
+#: ../dnf/base.py:2277
+#, python-format
+msgid ". Failing package is: %s"
+msgstr ""
+
+#: ../dnf/base.py:2278
+#, python-format
+msgid "GPG Keys are configured as: %s"
+msgstr ""
+
+#: ../dnf/base.py:2290
+#, python-format
+msgid "GPG key at %s (0x%s) is already installed"
+msgstr ""
+
+#: ../dnf/base.py:2323
+msgid "The key has been approved."
+msgstr ""
+
+#: ../dnf/base.py:2326
+msgid "The key has been rejected."
+msgstr ""
+
+#: ../dnf/base.py:2354
+#, python-format
+msgid "Key import failed (code %d)"
+msgstr ""
+
+#: ../dnf/base.py:2356
+msgid "Key imported successfully"
+msgstr ""
+
+#: ../dnf/base.py:2360
+msgid "Didn't install any keys"
+msgstr ""
+
+#: ../dnf/base.py:2363
+#, python-format
+msgid ""
+"The GPG keys listed for the \"%s\" repository are already installed but they "
+"are not correct for this package.\n"
+"Check that the correct key URLs are configured for this repository."
+msgstr ""
+
+#: ../dnf/base.py:2374
+msgid "Import of key(s) didn't help, wrong key(s)?"
+msgstr ""
+
+#: ../dnf/base.py:2410
+msgid "  * Maybe you meant: {}"
+msgstr ""
+
+#: ../dnf/base.py:2442
+msgid "Package \"{}\" from local repository \"{}\" has incorrect checksum"
+msgstr ""
+
+#: ../dnf/base.py:2445
+msgid "Some packages from local repository have incorrect checksum"
+msgstr ""
+
+#: ../dnf/base.py:2448
+msgid "Package \"{}\" from repository \"{}\" has incorrect checksum"
+msgstr ""
+
+#: ../dnf/base.py:2451
+msgid ""
+"Some packages have invalid cache, but cannot be downloaded due to \"--"
+"cacheonly\" option"
+msgstr ""
+
+#: ../dnf/base.py:2463
+#, python-format
+msgid "Package %s is already installed."
+msgstr ""
+
+#: ../dnf/cli/aliases.py:96
+#, python-format
+msgid "Unexpected value of environment variable: DNF_DISABLE_ALIASES=%s"
+msgstr ""
+
+#: ../dnf/cli/aliases.py:105 ../dnf/conf/config.py:412 ../dnf/conf/read.py:83
+#, python-format
+msgid "Parsing file \"%s\" failed: %s"
+msgstr ""
+
+#: ../dnf/cli/aliases.py:108
+#, python-format
+msgid "Cannot read file \"%s\": %s"
+msgstr ""
+
+#: ../dnf/cli/aliases.py:115 ../dnf/cli/aliases.py:128 ../dnf/cli/cli.py:876
+#: ../dnf/cli/cli.py:880 ../dnf/cli/commands/alias.py:105
+#, python-format
+msgid "Config error: %s"
+msgstr ""
+
+#: ../dnf/cli/aliases.py:185
+msgid "Aliases contain infinite recursion"
+msgstr ""
+
+#: ../dnf/cli/aliases.py:203
+#, python-format
+msgid "%s, using original arguments."
+msgstr ""
+
+#: ../dnf/cli/cli.py:136
+#, python-format
+msgid "  Installed: %s-%s at %s"
+msgstr ""
+
+#: ../dnf/cli/cli.py:138
+#, python-format
+msgid "  Built    : %s at %s"
+msgstr ""
+
+#: ../dnf/cli/cli.py:192
+msgid "DNF will only download packages for the transaction."
+msgstr ""
+
+#: ../dnf/cli/cli.py:194
+msgid ""
+"DNF will only download packages, install gpg keys, and check the transaction."
+msgstr ""
+
+#: ../dnf/cli/cli.py:198
+msgid "Operation aborted."
+msgstr ""
+
+#: ../dnf/cli/cli.py:205
+msgid "Downloading Packages:"
+msgstr ""
+
+#: ../dnf/cli/cli.py:211
+msgid "Error downloading packages:"
+msgstr ""
+
+#: ../dnf/cli/cli.py:239
+msgid "Transaction failed"
+msgstr ""
+
+#: ../dnf/cli/cli.py:262
+msgid ""
+"Refusing to automatically import keys when running unattended.\n"
+"Use \"-y\" to override."
+msgstr ""
+
+#: ../dnf/cli/cli.py:280
+msgid "GPG check FAILED"
+msgstr ""
+
+#: ../dnf/cli/cli.py:312
+msgid "Changelogs for {}"
+msgstr ""
+
+#: ../dnf/cli/cli.py:345 ../dnf/cli/cli.py:488 ../dnf/cli/cli.py:494
+msgid "Obsoleting Packages"
+msgstr ""
+
+#: ../dnf/cli/cli.py:374
+msgid "No packages marked for distribution synchronization."
+msgstr ""
+
+#: ../dnf/cli/cli.py:411
+msgid "No packages marked for downgrade."
+msgstr ""
+
+#: ../dnf/cli/cli.py:462
+msgid "Installed Packages"
+msgstr ""
+
+#: ../dnf/cli/cli.py:470
+msgid "Available Packages"
+msgstr ""
+
+#: ../dnf/cli/cli.py:474
+msgid "Autoremove Packages"
+msgstr ""
+
+#: ../dnf/cli/cli.py:476
+msgid "Extra Packages"
+msgstr ""
+
+#: ../dnf/cli/cli.py:480
+msgid "Available Upgrades"
+msgstr ""
+
+#: ../dnf/cli/cli.py:496
+msgid "Recently Added Packages"
+msgstr ""
+
+#: ../dnf/cli/cli.py:501
+msgid "No matching Packages to list"
+msgstr ""
+
+#: ../dnf/cli/cli.py:582
+msgid "No Matches found"
+msgstr ""
+
+#: ../dnf/cli/cli.py:592
+msgid "No transaction ID given"
+msgstr ""
+
+#: ../dnf/cli/cli.py:597
+msgid "Not found given transaction ID"
+msgstr ""
+
+#: ../dnf/cli/cli.py:606
+msgid "Found more than one transaction ID!"
+msgstr ""
+
+#: ../dnf/cli/cli.py:623
+#, python-format
+msgid "Transaction history is incomplete, before %u."
+msgstr ""
+
+#: ../dnf/cli/cli.py:625
+#, python-format
+msgid "Transaction history is incomplete, after %u."
+msgstr ""
+
+#: ../dnf/cli/cli.py:672
+msgid "Undoing transaction {}, from {}"
+msgstr ""
+
+#: ../dnf/cli/cli.py:751 ../dnf/cli/commands/shell.py:230
+#, python-format
+msgid "Unknown repo: '%s'"
+msgstr ""
+
+#: ../dnf/cli/cli.py:765
+#, python-format
+msgid "No repository match: %s"
+msgstr ""
+
+#: ../dnf/cli/cli.py:794
+msgid "This command has to be run under the root user."
+msgstr ""
+
+#: ../dnf/cli/cli.py:823
+#, python-format
+msgid "No such command: %s. Please use %s --help"
+msgstr ""
+
+#: ../dnf/cli/cli.py:826
+#, python-format
+msgid ""
+"It could be a DNF plugin command, try: \"dnf install 'dnf-command(%s)'\""
+msgstr ""
+
+#: ../dnf/cli/cli.py:829
+msgid ""
+"It could be a DNF plugin command, but loading of plugins is currently "
+"disabled."
+msgstr ""
+
+#: ../dnf/cli/cli.py:886
+msgid ""
+"--destdir or --downloaddir must be used with --downloadonly or download or "
+"system-upgrade command."
+msgstr ""
+
+#: ../dnf/cli/cli.py:892
+msgid ""
+"--enable, --set-enabled and --disable, --set-disabled must be used with "
+"config-manager command."
+msgstr ""
+
+#: ../dnf/cli/cli.py:974
+msgid ""
+"Warning: Enforcing GPG signature check globally as per active RPM security "
+"policy (see 'gpgcheck' in dnf.conf(5) for how to squelch this message)"
+msgstr ""
+
+#: ../dnf/cli/cli.py:1003
+msgid ""
+"Unable to detect release version (use '--releasever' to specify release "
+"version)"
+msgstr ""
+
+#: ../dnf/cli/cli.py:1089 ../dnf/cli/commands/repoquery.py:413
+msgid "argument {}: not allowed with argument {}"
+msgstr ""
+
+#: ../dnf/cli/cli.py:1096
+#, python-format
+msgid "Command \"%s\" already defined"
+msgstr ""
+
+#: ../dnf/cli/cli.py:1116
+msgid "Excludes in dnf.conf: "
+msgstr ""
+
+#: ../dnf/cli/cli.py:1119
+msgid "Includes in dnf.conf: "
+msgstr ""
+
+#: ../dnf/cli/cli.py:1122
+msgid "Excludes in repo "
+msgstr ""
+
+#: ../dnf/cli/cli.py:1125
+msgid "Includes in repo "
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:47
+#, python-format
+msgid "To diagnose the problem, try running: '%s'."
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:49
+#, python-format
+msgid "You probably have corrupted RPMDB, running '%s' might fix the issue."
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:53
+msgid ""
+"You have enabled checking of packages via GPG keys. This is a good thing.\n"
+"However, you do not have any GPG public keys installed. You need to "
+"download\n"
+"the keys for packages you wish to install and install them.\n"
+"You can do that by running the command:\n"
+"    rpm --import public.gpg.key\n"
+"\n"
+"\n"
+"Alternatively you can specify the url to the key you would like to use\n"
+"for a repository in the 'gpgkey' option in a repository section and DNF\n"
+"will install it for you.\n"
+"\n"
+"For more information contact your distribution or package provider."
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:80
+#, python-format
+msgid "Problem repository: %s"
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:164
+msgid "display details about a package or group of packages"
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:174 ../dnf/cli/commands/__init__.py:753
+msgid "show all packages (default)"
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:177 ../dnf/cli/commands/__init__.py:756
+msgid "show only available packages"
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:180 ../dnf/cli/commands/__init__.py:759
+msgid "show only installed packages"
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:183 ../dnf/cli/commands/__init__.py:762
+msgid "show only extras packages"
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:186 ../dnf/cli/commands/__init__.py:189
+#: ../dnf/cli/commands/__init__.py:765 ../dnf/cli/commands/__init__.py:768
+msgid "show only upgrades packages"
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:192 ../dnf/cli/commands/__init__.py:771
+msgid "show only autoremove packages"
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:195 ../dnf/cli/commands/__init__.py:774
+msgid "show only recently changed packages"
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:196 ../dnf/cli/commands/__init__.py:269
+#: ../dnf/cli/commands/__init__.py:775 ../dnf/cli/commands/autoremove.py:48
+#: ../dnf/cli/commands/install.py:51 ../dnf/cli/commands/reinstall.py:44
+#: ../dnf/cli/commands/remove.py:61 ../dnf/cli/commands/upgrade.py:46
+msgid "PACKAGE"
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:226
+msgid "list a package or groups of packages"
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:240
+msgid "find what package provides the given value"
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:244
+msgid "SOME_STRING"
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:253 ../dnf/cli/commands/search.py:151
+msgid "Searching Packages: "
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:262
+msgid "check for available package upgrades"
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:268
+msgid "show changelogs before update"
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:364 ../dnf/cli/commands/__init__.py:417
+#: ../dnf/cli/commands/__init__.py:473
+msgid "No package available."
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:379
+msgid "No packages marked for install."
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:415
+msgid "No package installed."
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:435 ../dnf/cli/commands/__init__.py:492
+#: ../dnf/cli/commands/reinstall.py:91
+#, python-format
+msgid " (from %s)"
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:436 ../dnf/cli/commands/__init__.py:493
+#: ../dnf/cli/commands/reinstall.py:92 ../dnf/cli/commands/remove.py:104
+#, python-format
+msgid "Installed package %s%s not available."
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:470 ../dnf/cli/commands/__init__.py:579
+#: ../dnf/cli/commands/__init__.py:622 ../dnf/cli/commands/__init__.py:669
+msgid "No package installed from the repository."
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:533 ../dnf/cli/commands/reinstall.py:101
+msgid "No packages marked for reinstall."
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:719 ../dnf/cli/commands/upgrade.py:89
+msgid "No packages marked for upgrade."
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:729
+msgid "run commands on top of all packages in given repository"
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:743
+msgid "REPO"
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:801
+msgid "display a helpful usage message"
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:805
+msgid "COMMAND"
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:821
+msgid "display, or use, the transaction history"
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:836
+msgid ""
+"Found more than one transaction ID.\n"
+"'{}' requires one transaction ID or package name."
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:843
+msgid "No transaction ID or package name given."
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:856
+msgid "You don't have access to the history DB."
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:868
+#, python-format
+msgid ""
+"Cannot undo transaction %s, doing so would result in an inconsistent package "
+"database."
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:873
+#, python-format
+msgid ""
+"Cannot rollback transaction %s, doing so would result in an inconsistent "
+"package database."
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:943
+msgid ""
+"Invalid transaction ID range definition '{}'.\n"
+"Use '<transaction-id>..<transaction-id>'."
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:947
+msgid ""
+"Can't convert '{}' to transaction ID.\n"
+"Use '<integer>', 'last', 'last-<positive-integer>'."
+msgstr ""
+
+#: ../dnf/cli/commands/__init__.py:976
+msgid "No transaction which manipulates package '{}' was found."
+msgstr ""
+
+#: ../dnf/cli/commands/alias.py:39
+msgid "List or create command aliases"
+msgstr ""
+
+#: ../dnf/cli/commands/alias.py:49
+msgid "enable aliases resolving"
+msgstr ""
+
+#: ../dnf/cli/commands/alias.py:52
+msgid "disable aliases resolving"
+msgstr ""
+
+#: ../dnf/cli/commands/alias.py:67
+msgid "Aliases are now enabled"
+msgstr ""
+
+#: ../dnf/cli/commands/alias.py:70
+msgid "Aliases are now disabled"
+msgstr ""
+
+#: ../dnf/cli/commands/alias.py:87 ../dnf/cli/commands/alias.py:90
+#, python-format
+msgid "Invalid alias key: %s"
+msgstr ""
+
+#: ../dnf/cli/commands/alias.py:93
+#, python-format
+msgid "Alias argument has no value: %s"
+msgstr ""
+
+#: ../dnf/cli/commands/alias.py:127
+#, python-format
+msgid "Aliases added: %s"
+msgstr ""
+
+#: ../dnf/cli/commands/alias.py:141
+#, python-format
+msgid "Alias not found: %s"
+msgstr ""
+
+#: ../dnf/cli/commands/alias.py:144
+#, python-format
+msgid "Aliases deleted: %s"
+msgstr ""
+
+#: ../dnf/cli/commands/alias.py:151
+#, python-format
+msgid "%s, alias %s"
+msgstr ""
+
+#: ../dnf/cli/commands/alias.py:153
+#, python-format
+msgid "Alias %s='%s'"
+msgstr ""
+
+#: ../dnf/cli/commands/alias.py:157
+msgid "Aliases resolving is disabled."
+msgstr ""
+
+#: ../dnf/cli/commands/alias.py:162
+msgid "No aliases specified."
+msgstr ""
+
+#: ../dnf/cli/commands/alias.py:169
+msgid "No alias specified."
+msgstr ""
+
+#: ../dnf/cli/commands/alias.py:175
+msgid "No aliases defined."
+msgstr ""
+
+#: ../dnf/cli/commands/alias.py:182
+#, python-format
+msgid "No match for alias: %s"
+msgstr ""
+
+#: ../dnf/cli/commands/autoremove.py:41
+msgid ""
+"remove all unneeded packages that were originally installed as dependencies"
+msgstr ""
+
+#: ../dnf/cli/commands/autoremove.py:46 ../dnf/cli/commands/remove.py:59
+msgid "Package to remove"
+msgstr ""
+
+#: ../dnf/cli/commands/check.py:34
+msgid "check for problems in the packagedb"
+msgstr ""
+
+#: ../dnf/cli/commands/check.py:40
+msgid "show all problems; default"
+msgstr ""
+
+#: ../dnf/cli/commands/check.py:43
+msgid "show dependency problems"
+msgstr ""
+
+#: ../dnf/cli/commands/check.py:46
+msgid "show duplicate problems"
+msgstr ""
+
+#: ../dnf/cli/commands/check.py:49
+msgid "show obsoleted packages"
+msgstr ""
+
+#: ../dnf/cli/commands/check.py:52
+msgid "show problems with provides"
+msgstr ""
+
+#: ../dnf/cli/commands/check.py:97
+msgid "{} has missing requires of {}"
+msgstr ""
+
+#: ../dnf/cli/commands/check.py:117
+msgid "{} is a duplicate with {}"
+msgstr ""
+
+#: ../dnf/cli/commands/check.py:128
+msgid "{} is obsoleted by {}"
+msgstr ""
+
+#: ../dnf/cli/commands/check.py:137
+msgid "{} provides {} but it cannot be found"
+msgstr ""
+
+#: ../dnf/cli/commands/clean.py:68
+#, python-format
+msgid "Removing file %s"
+msgstr ""
+
+#: ../dnf/cli/commands/clean.py:87
+msgid "remove cached data"
+msgstr ""
+
+#: ../dnf/cli/commands/clean.py:93
+msgid "Metadata type to clean"
+msgstr ""
+
+#: ../dnf/cli/commands/clean.py:105
+msgid "Cleaning data:  "
+msgstr ""
+
+#: ../dnf/cli/commands/clean.py:111
+msgid "Cache was expired"
+msgstr ""
+
+#: ../dnf/cli/commands/clean.py:115
+#, python-format
+msgid "%d file removed"
+msgid_plural "%d files removed"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../dnf/cli/commands/clean.py:119 ../dnf/lock.py:139
+#, python-format
+msgid "Waiting for process with pid %d to finish."
+msgstr ""
+
+#: ../dnf/cli/commands/deplist.py:32
+msgid "List package's dependencies and what packages provide them"
+msgstr ""
+
+#: ../dnf/cli/commands/distrosync.py:32
+msgid "synchronize installed packages to the latest available versions"
+msgstr ""
+
+#: ../dnf/cli/commands/distrosync.py:36
+msgid "Package to synchronize"
+msgstr ""
+
+#: ../dnf/cli/commands/downgrade.py:34
+msgid "Downgrade a package"
+msgstr ""
+
+#: ../dnf/cli/commands/downgrade.py:38
+msgid "Package to downgrade"
+msgstr ""
+
+#: ../dnf/cli/commands/group.py:45
+msgid "display, or use, the groups information"
+msgstr ""
+
+#: ../dnf/cli/commands/group.py:70
+msgid "No group data available for configured repositories."
+msgstr ""
+
+#: ../dnf/cli/commands/group.py:127
+#, python-format
+msgid "Warning: Group %s does not exist."
+msgstr ""
+
+#: ../dnf/cli/commands/group.py:161
+msgid "Warning: No groups match:"
+msgstr ""
+
+#: ../dnf/cli/commands/group.py:190
+msgid "Available Environment Groups:"
+msgstr ""
+
+#: ../dnf/cli/commands/group.py:192
+msgid "Installed Environment Groups:"
+msgstr ""
+
+#: ../dnf/cli/commands/group.py:199 ../dnf/cli/commands/group.py:285
+msgid "Installed Groups:"
+msgstr ""
+
+#: ../dnf/cli/commands/group.py:206 ../dnf/cli/commands/group.py:292
+msgid "Installed Language Groups:"
+msgstr ""
+
+#: ../dnf/cli/commands/group.py:216 ../dnf/cli/commands/group.py:299
+msgid "Available Groups:"
+msgstr ""
+
+#: ../dnf/cli/commands/group.py:223 ../dnf/cli/commands/group.py:306
+msgid "Available Language Groups:"
+msgstr ""
+
+#: ../dnf/cli/commands/group.py:313
+msgid "include optional packages from group"
+msgstr ""
+
+#: ../dnf/cli/commands/group.py:316
+msgid "show also hidden groups"
+msgstr ""
+
+#: ../dnf/cli/commands/group.py:318
+msgid "show only installed groups"
+msgstr ""
+
+#: ../dnf/cli/commands/group.py:320
+msgid "show only available groups"
+msgstr ""
+
+#: ../dnf/cli/commands/group.py:332
+#, python-format
+msgid "Invalid groups sub-command, use: %s."
+msgstr ""
+
+#: ../dnf/cli/commands/group.py:389
+msgid "Unable to find a mandatory group package."
+msgstr ""
+
+#: ../dnf/cli/commands/install.py:47
+msgid "install a package or packages on your system"
+msgstr ""
+
+#: ../dnf/cli/commands/install.py:53
+msgid "Package to install"
+msgstr ""
+
+#: ../dnf/cli/commands/install.py:118
+msgid "Unable to find a match"
+msgstr ""
+
+#: ../dnf/cli/commands/install.py:131
+#, python-format
+msgid "Not a valid rpm file path: %s"
+msgstr ""
+
+#: ../dnf/cli/commands/install.py:167
+#, python-brace-format
+msgid "There are following alternatives for \"{0}\": {1}"
+msgstr ""
+
+#: ../dnf/cli/commands/makecache.py:37
+msgid "generate the metadata cache"
+msgstr ""
+
+#: ../dnf/cli/commands/makecache.py:48
+msgid "Making cache files for all metadata files."
+msgstr ""
+
+#: ../dnf/cli/commands/mark.py:39
+msgid "mark or unmark installed packages as installed by user."
+msgstr ""
+
+#: ../dnf/cli/commands/mark.py:49
+#, python-format
+msgid "%s marked as user installed."
+msgstr ""
+
+#: ../dnf/cli/commands/mark.py:53
+#, python-format
+msgid "%s unmarked as user installed."
+msgstr ""
+
+#: ../dnf/cli/commands/mark.py:57
+#, python-format
+msgid "%s marked as group installed."
+msgstr ""
+
+#: ../dnf/cli/commands/mark.py:82 ../dnf/cli/commands/shell.py:121
+#: ../dnf/cli/commands/shell.py:230
+msgid "Error:"
+msgstr ""
+
+#: ../dnf/cli/commands/mark.py:84
+#, python-format
+msgid "Package %s is not installed."
+msgstr ""
+
+#: ../dnf/cli/commands/module.py:36
+#, python-brace-format
+msgid ""
+"The operation would result in switching of module '{0}' stream '{1}' to "
+"stream '{2}'"
+msgstr ""
+
+#: ../dnf/cli/commands/module.py:79 ../dnf/cli/commands/module.py:101
+msgid "No matching Modules to list"
+msgstr ""
+
+#: ../dnf/cli/commands/module.py:128
+msgid ""
+"It is not possible to switch enabled streams of a module.\n"
+"It is recommended to remove all installed content from the module, and reset "
+"the module using 'dnf module reset <module_name>' command. After you reset "
+"the module, you can enable the other stream."
+msgstr ""
+
+#: ../dnf/cli/commands/module.py:199
+msgid ""
+"It is not possible to switch enabled streams of a module.\n"
+"It is recommended to remove all installed content from the module, and reset "
+"the module using 'dnf module reset <module_name>' command. After you reset "
+"the module, you can install the other stream."
+msgstr ""
+
+#: ../dnf/cli/commands/module.py:262
+msgid "Interact with Modules."
+msgstr ""
+
+#: ../dnf/cli/commands/module.py:279
+msgid "show only enabled modules"
+msgstr ""
+
+#: ../dnf/cli/commands/module.py:282
+msgid "show only disabled modules"
+msgstr ""
+
+#: ../dnf/cli/commands/module.py:285
+msgid "show only installed modules"
+msgstr ""
+
+#: ../dnf/cli/commands/module.py:288
+msgid "show profile content"
+msgstr ""
+
+#: ../dnf/cli/commands/reinstall.py:38
+msgid "reinstall a package"
+msgstr ""
+
+#: ../dnf/cli/commands/reinstall.py:42
+msgid "Package to reinstall"
+msgstr ""
+
+#: ../dnf/cli/commands/remove.py:46
+msgid "remove a package or packages from your system"
+msgstr ""
+
+#: ../dnf/cli/commands/remove.py:53
+msgid "remove duplicated packages"
+msgstr ""
+
+#: ../dnf/cli/commands/remove.py:58
+msgid "remove installonly packages over the limit"
+msgstr ""
+
+#: ../dnf/cli/commands/remove.py:94
+msgid "No duplicated packages found for removal."
+msgstr ""
+
+#: ../dnf/cli/commands/remove.py:120
+msgid "No old installonly packages found for removal."
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:37 ../dnf/cli/commands/updateinfo.py:45
+#: ../dnf/cli/commands/updateinfo.py:279 ../dnf/cli/commands/updateinfo.py:311
+msgid "unknown"
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:39
+#, python-format
+msgid "Never (last: %s)"
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:41
+#, python-format
+msgid "Instant (last: %s)"
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:44
+#, python-format
+msgid "%s second(s) (last: %s)"
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:75
+msgid "display the configured software repositories"
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:82
+msgid "show all repos"
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:85
+msgid "show enabled repos (default)"
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:88
+msgid "show disabled repos"
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:123
+msgid "No repositories available"
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:145 ../dnf/cli/commands/repolist.py:146
+msgid "enabled"
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:163 ../dnf/cli/commands/repolist.py:164
+msgid "disabled"
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:179
+msgid "Repo-id      : "
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:180
+msgid "Repo-name    : "
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:183
+msgid "Repo-status  : "
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:186
+msgid "Repo-revision: "
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:190
+msgid "Repo-tags    : "
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:197
+msgid "Repo-distro-tags: "
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:203
+msgid "Repo-updated : "
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:205
+msgid "Repo-pkgs    : "
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:206
+msgid "Repo-size    : "
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:209
+msgid "Repo-metalink: "
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:214
+msgid "  Updated    : "
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:216
+msgid "Repo-mirrors : "
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:220 ../dnf/cli/commands/repolist.py:226
+msgid "Repo-baseurl : "
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:229
+msgid "Repo-expire  : "
+msgstr ""
+
+#. TRANSLATORS: Packages that are excluded - their names like (dnf systemd)
+#: ../dnf/cli/commands/repolist.py:233
+msgid "Repo-exclude : "
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:237
+msgid "Repo-include : "
+msgstr ""
+
+#. TRANSLATORS: Number of packages that where excluded (5)
+#: ../dnf/cli/commands/repolist.py:242
+msgid "Repo-excluded: "
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:246
+msgid "Repo-filename: "
+msgstr ""
+
+#. Work out the first (id) and last (enabled/disalbed/count),
+#. then chop the middle (name)...
+#: ../dnf/cli/commands/repolist.py:254 ../dnf/cli/commands/repolist.py:283
+msgid "repo id"
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:271 ../dnf/cli/commands/repolist.py:272
+#: ../dnf/cli/commands/repolist.py:288
+msgid "status"
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:284
+msgid "repo name"
+msgstr ""
+
+#: ../dnf/cli/commands/repolist.py:300
+#, python-format
+msgid "Total packages: %s"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:104
+msgid "search for packages matching keyword"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:118
+msgid "the key to search for"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:120
+msgid ""
+"Query all packages (shorthand for repoquery '*' or repoquery without "
+"argument)"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:123
+msgid "Query all versions of packages (default)"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:126
+msgid "show only results from this ARCH"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:128
+msgid "show only results that owns FILE"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:130
+msgid "show only results that conflict REQ"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:132
+msgid ""
+"shows results that requires, suggests, supplements, enhances,or recommends "
+"package provides and files REQ"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:135
+msgid "show only results that obsolete REQ"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:137
+msgid "show only results that provide REQ"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:139
+msgid "shows results that requires package provides and files REQ"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:141
+msgid "show only results that recommend REQ"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:143
+msgid "show only results that enhance REQ"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:145
+msgid "show only results that suggest REQ"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:147
+msgid "show only results that supplement REQ"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:150
+msgid "check non-explicit dependencies (files and Provides); default"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:152
+msgid "check dependencies exactly as given, opposite of --alldeps"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:154
+msgid ""
+"used with --whatrequires, and --requires --resolve, query packages "
+"recursively."
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:156
+msgid "show a list of all dependencies and what packages provide them"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:158
+msgid "show available tags to use with --queryformat"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:161
+msgid "resolve capabilities to originating package(s)"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:163
+msgid "show recursive tree for package(s)"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:165
+msgid "operate on corresponding source RPM"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:167
+msgid ""
+"show N latest packages for a given name.arch (or latest but N if N is "
+"negative)"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:173
+msgid "show detailed information about the package"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:176
+msgid "show list of files in the package"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:179
+msgid "show package source RPM name"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:182
+msgid "show changelogs of the package"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:185
+msgid "format for displaying found packages"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:188
+msgid ""
+"use name-epoch:version-release.architecture format for displaying found "
+"packages (default)"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:191
+msgid ""
+"use name-version-release format for displaying found packages (rpm query "
+"default)"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:197
+msgid ""
+"use epoch:name-version-release.architecture format for displaying found "
+"packages"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:200
+msgid "Display in which comps groups are presented selected packages"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:204
+msgid "limit the query to installed duplicate packages"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:211
+msgid "limit the query to installed installonly packages"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:214
+msgid "limit the query to installed packages with unsatisfied dependencies"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:216
+msgid "show a location from where packages can be downloaded"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:219
+msgid "Display capabilities that the package conflicts with."
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:220
+msgid ""
+"Display capabilities that the package can depend on, enhance, recommend, "
+"suggest, and supplement."
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:222
+msgid "Display capabilities that the package can enhance."
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:223
+msgid "Display capabilities provided by the package."
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:224
+msgid "Display capabilities that the package recommends."
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:225
+msgid "Display capabilities that the package depends on."
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:226
+#, python-format
+msgid ""
+"Display capabilities that the package depends on for running a %%pre script."
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:227
+msgid "Display capabilities that the package suggests."
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:228
+msgid "Display capabilities that the package can supplement."
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:234
+msgid "Display only available packages."
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:237
+msgid "Display only installed packages."
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:238
+msgid ""
+"Display only packages that are not present in any of available repositories."
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:239
+msgid ""
+"Display only packages that provide an upgrade for some already installed "
+"package."
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:240
+msgid ""
+"Display only packages that can be removed by \"dnf autoremove\" command."
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:241
+msgid "Display only packages that were installed by user."
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:253
+msgid "Display only recently edited packages"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:275
+msgid ""
+"Option '--resolve' has to be used together with one of the '--conflicts', '--"
+"depends', '--enhances', '--provides', '--recommends', '--requires', '--"
+"requires-pre', '--suggests' or '--supplements' options"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:285
+msgid ""
+"Option '--recursive' has to be used with '--whatrequires <REQ>' (optionaly "
+"with '--alldeps', but not with '--exactdeps'), or with '--requires <REQ> --"
+"resolve'"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:318
+msgid "Package {} contains no files"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:387
+#, python-brace-format
+msgid "Available query-tags: use --queryformat \".. %{tag} ..\""
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:456
+msgid "argument {} requires --whatrequires or --whatdepends option"
+msgstr ""
+
+#: ../dnf/cli/commands/repoquery.py:501
+msgid ""
+"No valid switch specified\n"
+"usage: dnf repoquery [--conflicts|--enhances|--obsoletes|--provides|--"
+"recommends|--requires|--suggest|--supplements|--whatrequires] [key] [--"
+"tree]\n"
+"\n"
+"description:\n"
+"  For the given packages print a tree of the packages."
+msgstr ""
+
+#: ../dnf/cli/commands/search.py:46
+msgid "search package details for the given string"
+msgstr ""
+
+#: ../dnf/cli/commands/search.py:51
+msgid "search also package description and URL"
+msgstr ""
+
+#: ../dnf/cli/commands/search.py:52
+msgid "QUERY_STRING"
+msgstr ""
+
+#: ../dnf/cli/commands/search.py:60 ../dnf/cli/output.py:497
+msgctxt "long"
+msgid "Name"
+msgstr ""
+
+#: ../dnf/cli/commands/search.py:61 ../dnf/cli/output.py:550
+msgctxt "long"
+msgid "Summary"
+msgstr ""
+
+#: ../dnf/cli/commands/search.py:62 ../dnf/cli/output.py:560
+msgctxt "long"
+msgid "Description"
+msgstr ""
+
+#: ../dnf/cli/commands/search.py:63 ../dnf/cli/output.py:553
+msgid "URL"
+msgstr ""
+
+#. TRANSLATORS: separator used between package attributes (eg. Name & Summary & URL)
+#: ../dnf/cli/commands/search.py:75
+msgid " & "
+msgstr ""
+
+#. TRANSLATORS: %s  - translated package attributes,
+#. %%s - found keys (in listed attributes)
+#: ../dnf/cli/commands/search.py:79
+#, python-format
+msgid "%s Exactly Matched: %%s"
+msgstr ""
+
+#. TRANSLATORS: %s  - translated package attributes,
+#. %%s - found keys (in listed attributes)
+#: ../dnf/cli/commands/search.py:83
+#, python-format
+msgid "%s Matched: %%s"
+msgstr ""
+
+#: ../dnf/cli/commands/search.py:126
+msgid "No matches found."
+msgstr ""
+
+#: ../dnf/cli/commands/shell.py:47
+msgid "run an interactive DNF shell"
+msgstr ""
+
+#: ../dnf/cli/commands/shell.py:68
+msgid "SCRIPT"
+msgstr ""
+
+#: ../dnf/cli/commands/shell.py:69
+msgid "Script to run in DNF shell"
+msgstr ""
+
+#: ../dnf/cli/commands/shell.py:135
+msgid "Unsupported key value."
+msgstr ""
+
+#: ../dnf/cli/commands/shell.py:151
+#, python-format
+msgid "Could not find repository: %s"
+msgstr ""
+
+#: ../dnf/cli/commands/shell.py:167
+msgid ""
+"{} arg [value]\n"
+"  arg: debuglevel, errorlevel, obsoletes, gpgcheck, assumeyes, exclude,\n"
+"        repo_id.gpgcheck, repo_id.exclude\n"
+"    If no value is given it prints the current value.\n"
+"    If value is given it sets that value."
+msgstr ""
+
+#: ../dnf/cli/commands/shell.py:174
+msgid ""
+"{} [command]\n"
+"    print help"
+msgstr ""
+
+#: ../dnf/cli/commands/shell.py:178
+msgid ""
+"{} arg [option]\n"
+"  list: lists repositories and their status. option = [all | id | glob]\n"
+"  enable: enable repositories. option = repository id\n"
+"  disable: disable repositories. option = repository id"
+msgstr ""
+
+#: ../dnf/cli/commands/shell.py:184
+msgid ""
+"{}\n"
+"    resolve the transaction set"
+msgstr ""
+
+#: ../dnf/cli/commands/shell.py:188
+msgid ""
+"{} arg\n"
+"  list: lists the contents of the transaction\n"
+"  reset: reset (zero-out) the transaction\n"
+"  run: run the transaction"
+msgstr ""
+
+#: ../dnf/cli/commands/shell.py:194
+msgid ""
+"{}\n"
+"    run the transaction"
+msgstr ""
+
+#: ../dnf/cli/commands/shell.py:198
+msgid ""
+"{}\n"
+"    exit the shell"
+msgstr ""
+
+#: ../dnf/cli/commands/shell.py:203
+msgid ""
+"Shell specific arguments:\n"
+"\n"
+"config                   set config options\n"
+"help                     print help\n"
+"repository (or repo)     enable, disable or list repositories\n"
+"resolvedep               resolve the transaction set\n"
+"transaction (or ts)      list, reset or run the transaction set\n"
+"run                      resolve and run the transaction set\n"
+"exit (or quit)           exit the shell"
+msgstr ""
+
+#: ../dnf/cli/commands/shell.py:253
+#, python-format
+msgid "Error: Cannot open %s for reading"
+msgstr ""
+
+#: ../dnf/cli/commands/shell.py:283
+msgid "Leaving Shell"
+msgstr ""
+
+#: ../dnf/cli/commands/swap.py:33
+msgid "run an interactive dnf mod for remove and install one spec"
+msgstr ""
+
+#: ../dnf/cli/commands/swap.py:37
+msgid "The specs that will be removed"
+msgstr ""
+
+#: ../dnf/cli/commands/swap.py:39
+msgid "The specs that will be installed"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:42
+msgid "bugfix"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:43
+msgid "enhancement"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:44
+msgid "security"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:46
+msgid "newpackage"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:48
+msgid "Critical/Sec."
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:49
+msgid "Important/Sec."
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:50
+msgid "Moderate/Sec."
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:51
+msgid "Low/Sec."
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:61
+msgid "display advisories about packages"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:75
+msgid "advisories about newer versions of installed packages (default)"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:78
+msgid "advisories about equal and older versions of installed packages"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:81
+msgid ""
+"advisories about newer versions of those installed packages for which a "
+"newer version is available"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:85
+msgid "advisories about any versions of installed packages"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:90
+msgid "show summary of advisories (default)"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:93
+msgid "show list of advisories"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:96
+msgid "show info of advisories"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:126
+msgid "installed"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:129
+msgid "updates"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:133
+msgid "all"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:136
+msgid "available"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:239
+msgid "Updates Information Summary: "
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:242
+msgid "New Package notice(s)"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:243
+msgid "Security notice(s)"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:244
+msgid "Critical Security notice(s)"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:246
+msgid "Important Security notice(s)"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:248
+msgid "Moderate Security notice(s)"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:250
+msgid "Low Security notice(s)"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:252
+msgid "Unknown Security notice(s)"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:254
+msgid "Bugfix notice(s)"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:255
+msgid "Enhancement notice(s)"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:256
+msgid "other notice(s)"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:277
+msgid "Unknown/Sec."
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:304
+msgid "Bugs"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:304
+msgid "Type"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:304
+msgid "Update ID"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:304
+msgid "Updated"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:305
+msgid "CVEs"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:305
+msgid "Description"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:305
+msgid "Rights"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:305
+msgid "Severity"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:306
+msgid "Files"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:306 ../dnf/cli/output.py:1438
+#: ../dnf/cli/output.py:1789 ../dnf/cli/output.py:1791
+msgid "Installed"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:332
+msgid "false"
+msgstr ""
+
+#: ../dnf/cli/commands/updateinfo.py:332
+msgid "true"
+msgstr ""
+
+#: ../dnf/cli/commands/upgrade.py:40
+msgid "upgrade a package or packages on your system"
+msgstr ""
+
+#: ../dnf/cli/commands/upgrade.py:44
+msgid "Package to upgrade"
+msgstr ""
+
+#: ../dnf/cli/commands/upgrademinimal.py:31
+msgid ""
+"upgrade, but only 'newest' package match which fixes a problem that affects "
+"your system"
+msgstr ""
+
+#: ../dnf/cli/main.py:79
+msgid "Terminated."
+msgstr ""
+
+#: ../dnf/cli/main.py:109
+msgid "No read/execute access in current directory, moving to /"
+msgstr ""
+
+#: ../dnf/cli/main.py:128
+msgid "try to add '{}' to command line to replace conflicting packages"
+msgstr ""
+
+#: ../dnf/cli/main.py:132
+msgid "try to add '{}' to skip uninstallable packages"
+msgstr ""
+
+#: ../dnf/cli/main.py:135
+msgid " or '{}' to skip uninstallable packages"
+msgstr ""
+
+#: ../dnf/cli/main.py:140
+msgid "try to add '{}' to use not only best candidate packages"
+msgstr ""
+
+#: ../dnf/cli/main.py:143
+msgid " or '{}' to use not only best candidate packages"
+msgstr ""
+
+#: ../dnf/cli/main.py:160
+msgid "Dependencies resolved."
+msgstr ""
+
+#: ../dnf/cli/main.py:178
+msgid "Complete!"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:54
+#, python-format
+msgid "Command line error: %s"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:85
+#, python-format
+msgid "bad format: %s"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:96
+#, python-format
+msgid "Setopt argument has multiple values: %s"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:99
+#, python-format
+msgid "Setopt argument has no value: %s"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:156
+msgid "Optional arguments"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:159
+msgid "config file location"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:162
+msgid "quiet operation"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:164
+msgid "verbose operation"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:166
+msgid "show DNF version and exit"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:167
+msgid "set install root"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:170
+msgid "do not install documentations"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:173
+msgid "disable all plugins"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:176
+msgid "enable plugins by name"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:180
+msgid "disable plugins by name"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:183
+msgid "override the value of $releasever in config and repo files"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:187
+msgid "set arbitrary config and repo options"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:190
+msgid "resolve depsolve problems by skipping packages"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:193
+msgid "show command help"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:197
+msgid "allow erasing of installed packages to resolve dependencies"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:201
+msgid "try the best available package versions in transactions."
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:203
+msgid "do not limit the transaction to the best candidate"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:206
+msgid "run entirely from system cache, don't update cache"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:210
+msgid "maximum command wait time"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:213
+msgid "debugging output level"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:216
+msgid "dumps detailed solving results into files"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:220
+msgid "show duplicates, in repos, in list/search commands"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:223
+msgid "error output level"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:226
+msgid ""
+"enables dnf's obsoletes processing logic for upgrade or display capabilities "
+"that the package obsoletes for info, list and repoquery"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:230
+msgid "debugging output level for rpm"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:233
+msgid "automatically answer yes for all questions"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:236
+msgid "automatically answer no for all questions"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:247
+msgid ""
+"enable just specific repositories by an id or a glob, can be specified "
+"multiple times"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:252
+msgid "enable repos with config-manager command (automatically saves)"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:256
+msgid "disable repos with config-manager command (automatically saves)"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:260
+msgid "exclude packages by name or glob"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:265
+msgid "disable excludepkgs"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:270
+msgid ""
+"label and path to additional repository, can be specified multiple times."
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:274
+msgid "disable removal of dependencies that are no longer used"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:277
+msgid "disable gpg signature checking (if RPM policy allows)"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:279
+msgid "control whether color is used"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:282
+msgid "set metadata as expired before running the command"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:285
+msgid "resolve to IPv4 addresses only"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:288
+msgid "resolve to IPv6 addresses only"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:291
+msgid "set directory to copy packages to"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:294
+msgid "only download packages"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:296
+msgid "add a comment to transaction"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:299
+msgid "Include bugfix relevant packages, in updates"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:302
+msgid "Include enhancement relevant packages, in updates"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:305
+msgid "Include newpackage relevant packages, in updates"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:308
+msgid "Include security relevant packages, in updates"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:312
+msgid "Include packages needed to fix the given advisory, in updates"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:316
+msgid "Include packages needed to fix the given BZ, in updates"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:319
+msgid "Include packages needed to fix the given CVE, in updates"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:324
+msgid "Include security relevant packages matching the severity, in updates"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:330
+msgid "Force the use of an architecture"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:365
+msgid "List of Main Commands:"
+msgstr ""
+
+#: ../dnf/cli/option_parser.py:366
+msgid "List of Plugin Commands:"
 msgstr ""
 
 #. Translators: This is abbreviated 'Name'. Should be no longer
@@ -98,11 +2351,6 @@ msgstr ""
 #. enough in your language.
 #: ../dnf/cli/output.py:496
 msgctxt "short"
-msgid "Name"
-msgstr ""
-
-#: ../dnf/cli/output.py:497 ../dnf/cli/commands/search.py:60
-msgctxt "long"
 msgid "Name"
 msgstr ""
 
@@ -145,18 +2393,18 @@ msgctxt "long"
 msgid "Architecture"
 msgstr ""
 
+#. Translators: This is the full (unabbreviated) term 'Size'.
+#: ../dnf/cli/output.py:511 ../dnf/cli/output.py:1307
+msgctxt "long"
+msgid "Size"
+msgstr ""
+
 #. Translators: This is the short version of 'Size'. It should
 #. not be longer than 5 characters. If the term 'Size' in your
 #. language is not longer than 5 characters then you can use it
 #. unabbreviated.
 #: ../dnf/cli/output.py:511 ../dnf/cli/output.py:1305
 msgctxt "short"
-msgid "Size"
-msgstr ""
-
-#. Translators: This is the full (unabbreviated) term 'Size'.
-#: ../dnf/cli/output.py:511 ../dnf/cli/output.py:1307
-msgctxt "long"
 msgid "Size"
 msgstr ""
 
@@ -215,15 +2463,6 @@ msgctxt "short"
 msgid "Summary"
 msgstr ""
 
-#: ../dnf/cli/output.py:550 ../dnf/cli/commands/search.py:61
-msgctxt "long"
-msgid "Summary"
-msgstr ""
-
-#: ../dnf/cli/output.py:553 ../dnf/cli/commands/search.py:63
-msgid "URL"
-msgstr ""
-
 #. Translators: This message should be no longer than 12 characters.
 #: ../dnf/cli/output.py:555
 msgid "License"
@@ -234,11 +2473,6 @@ msgstr ""
 #. enough in your language.
 #: ../dnf/cli/output.py:559
 msgctxt "short"
-msgid "Description"
-msgstr ""
-
-#: ../dnf/cli/output.py:560 ../dnf/cli/commands/search.py:62
-msgctxt "long"
 msgid "Description"
 msgstr ""
 
@@ -595,11 +2829,6 @@ msgstr ""
 msgid "Downgraded"
 msgstr ""
 
-#: ../dnf/cli/output.py:1438 ../dnf/cli/output.py:1789
-#: ../dnf/cli/output.py:1791 ../dnf/cli/commands/updateinfo.py:306
-msgid "Installed"
-msgstr ""
-
 #: ../dnf/cli/output.py:1442
 msgid "Reinstalled"
 msgstr ""
@@ -684,11 +2913,11 @@ msgid "Not installed"
 msgstr ""
 
 #: ../dnf/cli/output.py:1792
-msgid "Older"
+msgid "Newer"
 msgstr ""
 
 #: ../dnf/cli/output.py:1792
-msgid "Newer"
+msgid "Older"
 msgstr ""
 
 #: ../dnf/cli/output.py:1840 ../dnf/cli/output.py:1842
@@ -735,14 +2964,14 @@ msgstr ""
 msgid "User           :"
 msgstr ""
 
+#: ../dnf/cli/output.py:1881 ../dnf/cli/output.py:1888
+msgid "Aborted"
+msgstr ""
+
 #: ../dnf/cli/output.py:1881 ../dnf/cli/output.py:1884
 #: ../dnf/cli/output.py:1886 ../dnf/cli/output.py:1888
 #: ../dnf/cli/output.py:1890 ../dnf/cli/output.py:1892
 msgid "Return-Code    :"
-msgstr ""
-
-#: ../dnf/cli/output.py:1881 ../dnf/cli/output.py:1888
-msgid "Aborted"
 msgstr ""
 
 #: ../dnf/cli/output.py:1884 ../dnf/cli/output.py:1892
@@ -791,6 +3020,10 @@ msgstr ""
 
 #: ../dnf/cli/output.py:1951
 msgid "Obsoleted"
+msgstr ""
+
+#: ../dnf/cli/output.py:1952 ../dnf/transaction.py:83 ../dnf/transaction.py:84
+msgid "Obsoleting"
 msgstr ""
 
 #: ../dnf/cli/output.py:1953
@@ -858,553 +3091,6 @@ msgid ""
 " From       : %s"
 msgstr ""
 
-#: ../dnf/cli/option_parser.py:54
-#, python-format
-msgid "Command line error: %s"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:85
-#, python-format
-msgid "bad format: %s"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:96
-#, python-format
-msgid "Setopt argument has multiple values: %s"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:99
-#, python-format
-msgid "Setopt argument has no value: %s"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:156
-msgid "Optional arguments"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:159
-msgid "config file location"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:162
-msgid "quiet operation"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:164
-msgid "verbose operation"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:166
-msgid "show DNF version and exit"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:167
-msgid "set install root"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:170
-msgid "do not install documentations"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:173
-msgid "disable all plugins"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:176
-msgid "enable plugins by name"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:180
-msgid "disable plugins by name"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:183
-msgid "override the value of $releasever in config and repo files"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:187
-msgid "set arbitrary config and repo options"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:190
-msgid "resolve depsolve problems by skipping packages"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:193
-msgid "show command help"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:197
-msgid "allow erasing of installed packages to resolve dependencies"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:201
-msgid "try the best available package versions in transactions."
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:203
-msgid "do not limit the transaction to the best candidate"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:206
-msgid "run entirely from system cache, don't update cache"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:210
-msgid "maximum command wait time"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:213
-msgid "debugging output level"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:216
-msgid "dumps detailed solving results into files"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:220
-msgid "show duplicates, in repos, in list/search commands"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:223
-msgid "error output level"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:226
-msgid ""
-"enables dnf's obsoletes processing logic for upgrade or display capabilities "
-"that the package obsoletes for info, list and repoquery"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:230
-msgid "debugging output level for rpm"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:233
-msgid "automatically answer yes for all questions"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:236
-msgid "automatically answer no for all questions"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:247
-msgid ""
-"enable just specific repositories by an id or a glob, can be specified "
-"multiple times"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:252
-msgid "enable repos with config-manager command (automatically saves)"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:256
-msgid "disable repos with config-manager command (automatically saves)"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:260
-msgid "exclude packages by name or glob"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:265
-msgid "disable excludepkgs"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:270
-msgid ""
-"label and path to additional repository, can be specified multiple times."
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:274
-msgid "disable removal of dependencies that are no longer used"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:277
-msgid "disable gpg signature checking (if RPM policy allows)"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:279
-msgid "control whether color is used"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:282
-msgid "set metadata as expired before running the command"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:285
-msgid "resolve to IPv4 addresses only"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:288
-msgid "resolve to IPv6 addresses only"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:291
-msgid "set directory to copy packages to"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:294
-msgid "only download packages"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:296
-msgid "add a comment to transaction"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:299
-msgid "Include bugfix relevant packages, in updates"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:302
-msgid "Include enhancement relevant packages, in updates"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:305
-msgid "Include newpackage relevant packages, in updates"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:308
-msgid "Include security relevant packages, in updates"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:312
-msgid "Include packages needed to fix the given advisory, in updates"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:316
-msgid "Include packages needed to fix the given BZ, in updates"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:319
-msgid "Include packages needed to fix the given CVE, in updates"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:324
-msgid "Include security relevant packages matching the severity, in updates"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:330
-msgid "Force the use of an architecture"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:365
-msgid "List of Main Commands:"
-msgstr ""
-
-#: ../dnf/cli/option_parser.py:366
-msgid "List of Plugin Commands:"
-msgstr ""
-
-#: ../dnf/cli/main.py:57 ../dnf/automatic/main.py:266
-#, python-format
-msgid "Error: %s"
-msgstr ""
-
-#: ../dnf/cli/main.py:79
-msgid "Terminated."
-msgstr ""
-
-#: ../dnf/cli/main.py:109
-msgid "No read/execute access in current directory, moving to /"
-msgstr ""
-
-#: ../dnf/cli/main.py:128
-msgid "try to add '{}' to command line to replace conflicting packages"
-msgstr ""
-
-#: ../dnf/cli/main.py:132
-msgid "try to add '{}' to skip uninstallable packages"
-msgstr ""
-
-#: ../dnf/cli/main.py:135
-msgid " or '{}' to skip uninstallable packages"
-msgstr ""
-
-#: ../dnf/cli/main.py:140
-msgid "try to add '{}' to use not only best candidate packages"
-msgstr ""
-
-#: ../dnf/cli/main.py:143
-msgid " or '{}' to use not only best candidate packages"
-msgstr ""
-
-#: ../dnf/cli/main.py:160
-msgid "Dependencies resolved."
-msgstr ""
-
-#: ../dnf/cli/main.py:178
-msgid "Complete!"
-msgstr ""
-
-#: ../dnf/cli/cli.py:136
-#, python-format
-msgid "  Installed: %s-%s at %s"
-msgstr ""
-
-#: ../dnf/cli/cli.py:138
-#, python-format
-msgid "  Built    : %s at %s"
-msgstr ""
-
-#: ../dnf/cli/cli.py:192
-msgid "DNF will only download packages for the transaction."
-msgstr ""
-
-#: ../dnf/cli/cli.py:194
-msgid ""
-"DNF will only download packages, install gpg keys, and check the transaction."
-msgstr ""
-
-#: ../dnf/cli/cli.py:198
-msgid "Operation aborted."
-msgstr ""
-
-#: ../dnf/cli/cli.py:200 ../dnf/cli/commands/__init__.py:445
-#: ../dnf/cli/commands/__init__.py:502 ../dnf/cli/commands/__init__.py:595
-#: ../dnf/cli/commands/__init__.py:644 ../dnf/cli/commands/install.py:80
-#: ../dnf/cli/commands/install.py:103 ../dnf/cli/commands/install.py:110
-#: ../dnf/base.py:1638
-msgid "Nothing to do."
-msgstr ""
-
-#: ../dnf/cli/cli.py:205
-msgid "Downloading Packages:"
-msgstr ""
-
-#: ../dnf/cli/cli.py:211
-msgid "Error downloading packages:"
-msgstr ""
-
-#: ../dnf/cli/cli.py:239
-msgid "Transaction failed"
-msgstr ""
-
-#: ../dnf/cli/cli.py:262
-msgid ""
-"Refusing to automatically import keys when running unattended.\n"
-"Use \"-y\" to override."
-msgstr ""
-
-#: ../dnf/cli/cli.py:280
-msgid "GPG check FAILED"
-msgstr ""
-
-#: ../dnf/cli/cli.py:312
-msgid "Changelogs for {}"
-msgstr ""
-
-#: ../dnf/cli/cli.py:345 ../dnf/cli/cli.py:488 ../dnf/cli/cli.py:494
-msgid "Obsoleting Packages"
-msgstr ""
-
-#: ../dnf/cli/cli.py:374
-msgid "No packages marked for distribution synchronization."
-msgstr ""
-
-#: ../dnf/cli/cli.py:393 ../dnf/cli/commands/upgrade.py:110
-#: ../dnf/cli/commands/upgrade.py:121 ../dnf/cli/commands/__init__.py:428
-#: ../dnf/cli/commands/__init__.py:485 ../dnf/cli/commands/__init__.py:589
-#: ../dnf/cli/commands/__init__.py:636 ../dnf/cli/commands/__init__.py:679
-#: ../dnf/cli/commands/__init__.py:714 ../dnf/cli/commands/remove.py:150
-#: ../dnf/cli/commands/install.py:147 ../dnf/cli/commands/install.py:179
-#: ../dnf/cli/commands/reinstall.py:70 ../dnf/cli/commands/reinstall.py:84
-#: ../dnf/base.py:1812 ../dnf/base.py:1887 ../dnf/base.py:1906
-#: ../dnf/base.py:1919 ../dnf/base.py:1940 ../dnf/base.py:1990
-#: ../dnf/base.py:1998 ../dnf/base.py:2047 ../dnf/base.py:2136
-#, python-format
-msgid "No match for argument: %s"
-msgstr ""
-
-#: ../dnf/cli/cli.py:402 ../dnf/cli/cli.py:656 ../dnf/cli/cli.py:686
-#: ../dnf/cli/commands/__init__.py:373 ../dnf/cli/commands/__init__.py:890
-#: ../dnf/cli/commands/group.py:386 ../dnf/base.py:2211
-#, python-format
-msgid "No package %s available."
-msgstr ""
-
-#: ../dnf/cli/cli.py:405 ../dnf/base.py:2143
-#, python-format
-msgid "Packages for argument %s available, but not installed."
-msgstr ""
-
-#: ../dnf/cli/cli.py:411
-msgid "No packages marked for downgrade."
-msgstr ""
-
-#: ../dnf/cli/cli.py:462
-msgid "Installed Packages"
-msgstr ""
-
-#: ../dnf/cli/cli.py:470
-msgid "Available Packages"
-msgstr ""
-
-#: ../dnf/cli/cli.py:474
-msgid "Autoremove Packages"
-msgstr ""
-
-#: ../dnf/cli/cli.py:476
-msgid "Extra Packages"
-msgstr ""
-
-#: ../dnf/cli/cli.py:480
-msgid "Available Upgrades"
-msgstr ""
-
-#: ../dnf/cli/cli.py:496
-msgid "Recently Added Packages"
-msgstr ""
-
-#: ../dnf/cli/cli.py:501
-msgid "No matching Packages to list"
-msgstr ""
-
-#: ../dnf/cli/cli.py:582
-msgid "No Matches found"
-msgstr ""
-
-#: ../dnf/cli/cli.py:592
-msgid "No transaction ID given"
-msgstr ""
-
-#: ../dnf/cli/cli.py:597
-msgid "Not found given transaction ID"
-msgstr ""
-
-#: ../dnf/cli/cli.py:606
-msgid "Found more than one transaction ID!"
-msgstr ""
-
-#: ../dnf/cli/cli.py:623
-#, python-format
-msgid "Transaction history is incomplete, before %u."
-msgstr ""
-
-#: ../dnf/cli/cli.py:625
-#, python-format
-msgid "Transaction history is incomplete, after %u."
-msgstr ""
-
-#: ../dnf/cli/cli.py:651 ../dnf/cli/cli.py:682 ../dnf/base.py:2018
-#: ../dnf/base.py:2205
-#, python-format
-msgid "No package %s installed."
-msgstr ""
-
-#: ../dnf/cli/cli.py:672
-msgid "Undoing transaction {}, from {}"
-msgstr ""
-
-#: ../dnf/cli/cli.py:751 ../dnf/cli/commands/shell.py:230
-#, python-format
-msgid "Unknown repo: '%s'"
-msgstr ""
-
-#: ../dnf/cli/cli.py:765
-#, python-format
-msgid "No repository match: %s"
-msgstr ""
-
-#: ../dnf/cli/cli.py:794
-msgid "This command has to be run under the root user."
-msgstr ""
-
-#: ../dnf/cli/cli.py:823
-#, python-format
-msgid "No such command: %s. Please use %s --help"
-msgstr ""
-
-#: ../dnf/cli/cli.py:826
-#, python-format
-msgid ""
-"It could be a DNF plugin command, try: \"dnf install 'dnf-command(%s)'\""
-msgstr ""
-
-#: ../dnf/cli/cli.py:829
-msgid ""
-"It could be a DNF plugin command, but loading of plugins is currently "
-"disabled."
-msgstr ""
-
-#: ../dnf/cli/cli.py:876 ../dnf/cli/cli.py:880 ../dnf/cli/aliases.py:115
-#: ../dnf/cli/aliases.py:128 ../dnf/cli/commands/alias.py:105
-#, python-format
-msgid "Config error: %s"
-msgstr ""
-
-#: ../dnf/cli/cli.py:886
-msgid ""
-"--destdir or --downloaddir must be used with --downloadonly or download or "
-"system-upgrade command."
-msgstr ""
-
-#: ../dnf/cli/cli.py:892
-msgid ""
-"--enable, --set-enabled and --disable, --set-disabled must be used with "
-"config-manager command."
-msgstr ""
-
-#: ../dnf/cli/cli.py:974
-msgid ""
-"Warning: Enforcing GPG signature check globally as per active RPM security "
-"policy (see 'gpgcheck' in dnf.conf(5) for how to squelch this message)"
-msgstr ""
-
-#: ../dnf/cli/cli.py:1003
-msgid ""
-"Unable to detect release version (use '--releasever' to specify release "
-"version)"
-msgstr ""
-
-#: ../dnf/cli/cli.py:1089 ../dnf/cli/commands/repoquery.py:413
-msgid "argument {}: not allowed with argument {}"
-msgstr ""
-
-#: ../dnf/cli/cli.py:1096
-#, python-format
-msgid "Command \"%s\" already defined"
-msgstr ""
-
-#: ../dnf/cli/cli.py:1116
-msgid "Excludes in dnf.conf: "
-msgstr ""
-
-#: ../dnf/cli/cli.py:1119
-msgid "Includes in dnf.conf: "
-msgstr ""
-
-#: ../dnf/cli/cli.py:1122
-msgid "Excludes in repo "
-msgstr ""
-
-#: ../dnf/cli/cli.py:1125
-msgid "Includes in repo "
-msgstr ""
-
-#: ../dnf/cli/aliases.py:96
-#, python-format
-msgid "Unexpected value of environment variable: DNF_DISABLE_ALIASES=%s"
-msgstr ""
-
-#: ../dnf/cli/aliases.py:105 ../dnf/conf/config.py:412 ../dnf/conf/read.py:83
-#, python-format
-msgid "Parsing file \"%s\" failed: %s"
-msgstr ""
-
-#: ../dnf/cli/aliases.py:108
-#, python-format
-msgid "Cannot read file \"%s\": %s"
-msgstr ""
-
-#: ../dnf/cli/aliases.py:185
-msgid "Aliases contain infinite recursion"
-msgstr ""
-
-#: ../dnf/cli/aliases.py:203
-#, python-format
-msgid "%s, using original arguments."
-msgstr ""
-
 #: ../dnf/cli/utils.py:98
 msgid "Running"
 msgstr ""
@@ -1454,1924 +3140,33 @@ msgstr ""
 msgid "    State  : %s"
 msgstr ""
 
-#: ../dnf/cli/commands/alias.py:39
-msgid "List or create command aliases"
+#: ../dnf/comps.py:95
+msgid "skipping."
 msgstr ""
 
-#: ../dnf/cli/commands/alias.py:49
-msgid "enable aliases resolving"
-msgstr ""
-
-#: ../dnf/cli/commands/alias.py:52
-msgid "disable aliases resolving"
-msgstr ""
-
-#: ../dnf/cli/commands/alias.py:67
-msgid "Aliases are now enabled"
-msgstr ""
-
-#: ../dnf/cli/commands/alias.py:70
-msgid "Aliases are now disabled"
-msgstr ""
-
-#: ../dnf/cli/commands/alias.py:87 ../dnf/cli/commands/alias.py:90
-#, python-format
-msgid "Invalid alias key: %s"
-msgstr ""
-
-#: ../dnf/cli/commands/alias.py:93
-#, python-format
-msgid "Alias argument has no value: %s"
-msgstr ""
-
-#: ../dnf/cli/commands/alias.py:127
-#, python-format
-msgid "Aliases added: %s"
-msgstr ""
-
-#: ../dnf/cli/commands/alias.py:141
-#, python-format
-msgid "Alias not found: %s"
-msgstr ""
-
-#: ../dnf/cli/commands/alias.py:144
-#, python-format
-msgid "Aliases deleted: %s"
-msgstr ""
-
-#: ../dnf/cli/commands/alias.py:151
-#, python-format
-msgid "%s, alias %s"
-msgstr ""
-
-#: ../dnf/cli/commands/alias.py:153
-#, python-format
-msgid "Alias %s='%s'"
-msgstr ""
-
-#: ../dnf/cli/commands/alias.py:157
-msgid "Aliases resolving is disabled."
-msgstr ""
-
-#: ../dnf/cli/commands/alias.py:162
-msgid "No aliases specified."
-msgstr ""
-
-#: ../dnf/cli/commands/alias.py:169
-msgid "No alias specified."
-msgstr ""
-
-#: ../dnf/cli/commands/alias.py:175
-msgid "No aliases defined."
-msgstr ""
-
-#: ../dnf/cli/commands/alias.py:182
-#, python-format
-msgid "No match for alias: %s"
-msgstr ""
-
-#: ../dnf/cli/commands/search.py:46
-msgid "search package details for the given string"
-msgstr ""
-
-#: ../dnf/cli/commands/search.py:51
-msgid "search also package description and URL"
-msgstr ""
-
-#: ../dnf/cli/commands/search.py:52
-msgid "QUERY_STRING"
-msgstr ""
-
-#. TRANSLATORS: separator used between package attributes (eg. Name & Summary & URL)
-#: ../dnf/cli/commands/search.py:75
-msgid " & "
-msgstr ""
-
-#. TRANSLATORS: %s  - translated package attributes,
-#. %%s - found keys (in listed attributes)
-#: ../dnf/cli/commands/search.py:79
-#, python-format
-msgid "%s Exactly Matched: %%s"
-msgstr ""
-
-#. TRANSLATORS: %s  - translated package attributes,
-#. %%s - found keys (in listed attributes)
-#: ../dnf/cli/commands/search.py:83
-#, python-format
-msgid "%s Matched: %%s"
-msgstr ""
-
-#: ../dnf/cli/commands/search.py:126
-msgid "No matches found."
-msgstr ""
-
-#: ../dnf/cli/commands/search.py:151 ../dnf/cli/commands/__init__.py:253
-msgid "Searching Packages: "
-msgstr ""
-
-#: ../dnf/cli/commands/check.py:34
-msgid "check for problems in the packagedb"
-msgstr ""
-
-#: ../dnf/cli/commands/check.py:40
-msgid "show all problems; default"
-msgstr ""
-
-#: ../dnf/cli/commands/check.py:43
-msgid "show dependency problems"
-msgstr ""
-
-#: ../dnf/cli/commands/check.py:46
-msgid "show duplicate problems"
-msgstr ""
-
-#: ../dnf/cli/commands/check.py:49
-msgid "show obsoleted packages"
-msgstr ""
-
-#: ../dnf/cli/commands/check.py:52
-msgid "show problems with provides"
-msgstr ""
-
-#: ../dnf/cli/commands/check.py:97
-msgid "{} has missing requires of {}"
-msgstr ""
-
-#: ../dnf/cli/commands/check.py:117
-msgid "{} is a duplicate with {}"
-msgstr ""
-
-#: ../dnf/cli/commands/check.py:128
-msgid "{} is obsoleted by {}"
-msgstr ""
-
-#: ../dnf/cli/commands/check.py:137
-msgid "{} provides {} but it cannot be found"
-msgstr ""
-
-#: ../dnf/cli/commands/distrosync.py:32
-msgid "synchronize installed packages to the latest available versions"
-msgstr ""
-
-#: ../dnf/cli/commands/distrosync.py:36
-msgid "Package to synchronize"
-msgstr ""
-
-#: ../dnf/cli/commands/upgrade.py:40
-msgid "upgrade a package or packages on your system"
-msgstr ""
-
-#: ../dnf/cli/commands/upgrade.py:44
-msgid "Package to upgrade"
-msgstr ""
-
-#: ../dnf/cli/commands/upgrade.py:46 ../dnf/cli/commands/autoremove.py:48
-#: ../dnf/cli/commands/__init__.py:196 ../dnf/cli/commands/__init__.py:269
-#: ../dnf/cli/commands/__init__.py:775 ../dnf/cli/commands/remove.py:61
-#: ../dnf/cli/commands/install.py:51 ../dnf/cli/commands/reinstall.py:44
-msgid "PACKAGE"
-msgstr ""
-
-#: ../dnf/cli/commands/upgrade.py:89 ../dnf/cli/commands/__init__.py:719
-msgid "No packages marked for upgrade."
-msgstr ""
-
-#: ../dnf/cli/commands/autoremove.py:41
-msgid ""
-"remove all unneeded packages that were originally installed as dependencies"
-msgstr ""
-
-#: ../dnf/cli/commands/autoremove.py:46 ../dnf/cli/commands/remove.py:59
-msgid "Package to remove"
-msgstr ""
-
-#: ../dnf/cli/commands/makecache.py:37
-msgid "generate the metadata cache"
-msgstr ""
-
-#: ../dnf/cli/commands/makecache.py:48
-msgid "Making cache files for all metadata files."
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:47
-#, python-format
-msgid "To diagnose the problem, try running: '%s'."
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:49
-#, python-format
-msgid "You probably have corrupted RPMDB, running '%s' might fix the issue."
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:53
-msgid ""
-"You have enabled checking of packages via GPG keys. This is a good thing.\n"
-"However, you do not have any GPG public keys installed. You need to "
-"download\n"
-"the keys for packages you wish to install and install them.\n"
-"You can do that by running the command:\n"
-"    rpm --import public.gpg.key\n"
-"\n"
-"\n"
-"Alternatively you can specify the url to the key you would like to use\n"
-"for a repository in the 'gpgkey' option in a repository section and DNF\n"
-"will install it for you.\n"
-"\n"
-"For more information contact your distribution or package provider."
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:80
-#, python-format
-msgid "Problem repository: %s"
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:101 ../dnf/base.py:356
-msgid "There are no enabled repos."
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:164
-msgid "display details about a package or group of packages"
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:174 ../dnf/cli/commands/__init__.py:753
-msgid "show all packages (default)"
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:177 ../dnf/cli/commands/__init__.py:756
-msgid "show only available packages"
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:180 ../dnf/cli/commands/__init__.py:759
-msgid "show only installed packages"
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:183 ../dnf/cli/commands/__init__.py:762
-msgid "show only extras packages"
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:186 ../dnf/cli/commands/__init__.py:189
-#: ../dnf/cli/commands/__init__.py:765 ../dnf/cli/commands/__init__.py:768
-msgid "show only upgrades packages"
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:192 ../dnf/cli/commands/__init__.py:771
-msgid "show only autoremove packages"
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:195 ../dnf/cli/commands/__init__.py:774
-msgid "show only recently changed packages"
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:226
-msgid "list a package or groups of packages"
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:240
-msgid "find what package provides the given value"
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:244
-msgid "SOME_STRING"
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:262
-msgid "check for available package upgrades"
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:268
-msgid "show changelogs before update"
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:364 ../dnf/cli/commands/__init__.py:417
-#: ../dnf/cli/commands/__init__.py:473
-msgid "No package available."
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:379
-msgid "No packages marked for install."
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:415
-msgid "No package installed."
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:435 ../dnf/cli/commands/__init__.py:492
-#: ../dnf/cli/commands/reinstall.py:91
-#, python-format
-msgid " (from %s)"
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:436 ../dnf/cli/commands/__init__.py:493
-#: ../dnf/cli/commands/remove.py:104 ../dnf/cli/commands/reinstall.py:92
-#, python-format
-msgid "Installed package %s%s not available."
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:470 ../dnf/cli/commands/__init__.py:579
-#: ../dnf/cli/commands/__init__.py:622 ../dnf/cli/commands/__init__.py:669
-msgid "No package installed from the repository."
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:533 ../dnf/cli/commands/reinstall.py:101
-msgid "No packages marked for reinstall."
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:684 ../dnf/cli/commands/remove.py:156
-#: ../dnf/base.py:2053
-msgid "No packages marked for removal."
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:729
-msgid "run commands on top of all packages in given repository"
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:743
-msgid "REPO"
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:801
-msgid "display a helpful usage message"
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:805
-msgid "COMMAND"
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:821
-msgid "display, or use, the transaction history"
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:836
-msgid ""
-"Found more than one transaction ID.\n"
-"'{}' requires one transaction ID or package name."
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:843
-msgid "No transaction ID or package name given."
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:856
-msgid "You don't have access to the history DB."
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:868
-#, python-format
-msgid ""
-"Cannot undo transaction %s, doing so would result in an inconsistent package "
-"database."
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:873
-#, python-format
-msgid ""
-"Cannot rollback transaction %s, doing so would result in an inconsistent "
-"package database."
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:943
-msgid ""
-"Invalid transaction ID range definition '{}'.\n"
-"Use '<transaction-id>..<transaction-id>'."
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:947
-msgid ""
-"Can't convert '{}' to transaction ID.\n"
-"Use '<integer>', 'last', 'last-<positive-integer>'."
-msgstr ""
-
-#: ../dnf/cli/commands/__init__.py:976
-msgid "No transaction which manipulates package '{}' was found."
-msgstr ""
-
-#: ../dnf/cli/commands/downgrade.py:34
-msgid "Downgrade a package"
-msgstr ""
-
-#: ../dnf/cli/commands/downgrade.py:38
-msgid "Package to downgrade"
-msgstr ""
-
-#: ../dnf/cli/commands/upgrademinimal.py:31
-msgid ""
-"upgrade, but only 'newest' package match which fixes a problem that affects "
-"your system"
-msgstr ""
-
-#: ../dnf/cli/commands/module.py:36
-#, python-brace-format
-msgid ""
-"The operation would result in switching of module '{0}' stream '{1}' to "
-"stream '{2}'"
-msgstr ""
-
-#: ../dnf/cli/commands/module.py:79 ../dnf/cli/commands/module.py:101
-msgid "No matching Modules to list"
-msgstr ""
-
-#: ../dnf/cli/commands/module.py:128
-msgid ""
-"It is not possible to switch enabled streams of a module.\n"
-"It is recommended to remove all installed content from the module, and reset "
-"the module using 'dnf module reset <module_name>' command. After you reset "
-"the module, you can enable the other stream."
-msgstr ""
-
-#: ../dnf/cli/commands/module.py:199
-msgid ""
-"It is not possible to switch enabled streams of a module.\n"
-"It is recommended to remove all installed content from the module, and reset "
-"the module using 'dnf module reset <module_name>' command. After you reset "
-"the module, you can install the other stream."
-msgstr ""
-
-#: ../dnf/cli/commands/module.py:262
-msgid "Interact with Modules."
-msgstr ""
-
-#: ../dnf/cli/commands/module.py:279
-msgid "show only enabled modules"
-msgstr ""
-
-#: ../dnf/cli/commands/module.py:282
-msgid "show only disabled modules"
-msgstr ""
-
-#: ../dnf/cli/commands/module.py:285
-msgid "show only installed modules"
-msgstr ""
-
-#: ../dnf/cli/commands/module.py:288
-msgid "show profile content"
-msgstr ""
-
-#: ../dnf/cli/commands/remove.py:46
-msgid "remove a package or packages from your system"
-msgstr ""
-
-#: ../dnf/cli/commands/remove.py:53
-msgid "remove duplicated packages"
-msgstr ""
-
-#: ../dnf/cli/commands/remove.py:58
-msgid "remove installonly packages over the limit"
-msgstr ""
-
-#: ../dnf/cli/commands/remove.py:94
-msgid "No duplicated packages found for removal."
-msgstr ""
-
-#: ../dnf/cli/commands/remove.py:120
-msgid "No old installonly packages found for removal."
-msgstr ""
-
-#: ../dnf/cli/commands/remove.py:126 ../dnf/cli/commands/install.py:136
-#: ../dnf/base.py:2036
-#, python-format
-msgid "Not a valid form: %s"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:42
-msgid "bugfix"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:43
-msgid "enhancement"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:44
-msgid "security"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:45 ../dnf/cli/commands/updateinfo.py:279
-#: ../dnf/cli/commands/updateinfo.py:311 ../dnf/cli/commands/repolist.py:37
-msgid "unknown"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:46
-msgid "newpackage"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:48
-msgid "Critical/Sec."
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:49
-msgid "Important/Sec."
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:50
-msgid "Moderate/Sec."
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:51
-msgid "Low/Sec."
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:61
-msgid "display advisories about packages"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:75
-msgid "advisories about newer versions of installed packages (default)"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:78
-msgid "advisories about equal and older versions of installed packages"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:81
-msgid ""
-"advisories about newer versions of those installed packages for which a "
-"newer version is available"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:85
-msgid "advisories about any versions of installed packages"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:90
-msgid "show summary of advisories (default)"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:93
-msgid "show list of advisories"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:96
-msgid "show info of advisories"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:126
-msgid "installed"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:129
-msgid "updates"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:133
-msgid "all"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:136
-msgid "available"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:239
-msgid "Updates Information Summary: "
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:242
-msgid "New Package notice(s)"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:243
-msgid "Security notice(s)"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:244
-msgid "Critical Security notice(s)"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:246
-msgid "Important Security notice(s)"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:248
-msgid "Moderate Security notice(s)"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:250
-msgid "Low Security notice(s)"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:252
-msgid "Unknown Security notice(s)"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:254
-msgid "Bugfix notice(s)"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:255
-msgid "Enhancement notice(s)"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:256
-msgid "other notice(s)"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:277
-msgid "Unknown/Sec."
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:304
-msgid "Update ID"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:304
-msgid "Type"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:304
-msgid "Updated"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:304
-msgid "Bugs"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:305
-msgid "CVEs"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:305
-msgid "Description"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:305
-msgid "Severity"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:305
-msgid "Rights"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:306
-msgid "Files"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:332
-msgid "true"
-msgstr ""
-
-#: ../dnf/cli/commands/updateinfo.py:332
-msgid "false"
-msgstr ""
-
-#: ../dnf/cli/commands/mark.py:39
-msgid "mark or unmark installed packages as installed by user."
-msgstr ""
-
-#: ../dnf/cli/commands/mark.py:49
-#, python-format
-msgid "%s marked as user installed."
-msgstr ""
-
-#: ../dnf/cli/commands/mark.py:53
-#, python-format
-msgid "%s unmarked as user installed."
-msgstr ""
-
-#: ../dnf/cli/commands/mark.py:57
-#, python-format
-msgid "%s marked as group installed."
-msgstr ""
-
-#: ../dnf/cli/commands/mark.py:82 ../dnf/cli/commands/shell.py:121
-#: ../dnf/cli/commands/shell.py:230
-msgid "Error:"
-msgstr ""
-
-#: ../dnf/cli/commands/mark.py:84
-#, python-format
-msgid "Package %s is not installed."
-msgstr ""
-
-#: ../dnf/cli/commands/deplist.py:32
-msgid "List package's dependencies and what packages provide them"
-msgstr ""
-
-#: ../dnf/cli/commands/clean.py:68
-#, python-format
-msgid "Removing file %s"
-msgstr ""
-
-#: ../dnf/cli/commands/clean.py:87
-msgid "remove cached data"
-msgstr ""
-
-#: ../dnf/cli/commands/clean.py:93
-msgid "Metadata type to clean"
-msgstr ""
-
-#: ../dnf/cli/commands/clean.py:105
-msgid "Cleaning data:  "
-msgstr ""
-
-#: ../dnf/cli/commands/clean.py:111
-msgid "Cache was expired"
-msgstr ""
-
-#: ../dnf/cli/commands/clean.py:115
-#, python-format
-msgid "%d file removed"
-msgid_plural "%d files removed"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../dnf/cli/commands/clean.py:119 ../dnf/lock.py:139
-#, python-format
-msgid "Waiting for process with pid %d to finish."
-msgstr ""
-
-#: ../dnf/cli/commands/install.py:47
-msgid "install a package or packages on your system"
-msgstr ""
-
-#: ../dnf/cli/commands/install.py:53
-msgid "Package to install"
-msgstr ""
-
-#: ../dnf/cli/commands/install.py:118
-msgid "Unable to find a match"
-msgstr ""
-
-#: ../dnf/cli/commands/install.py:131
-#, python-format
-msgid "Not a valid rpm file path: %s"
-msgstr ""
-
-#: ../dnf/cli/commands/install.py:167
-#, python-brace-format
-msgid "There are following alternatives for \"{0}\": {1}"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:104
-msgid "search for packages matching keyword"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:118
-msgid "the key to search for"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:120
-msgid ""
-"Query all packages (shorthand for repoquery '*' or repoquery without "
-"argument)"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:123
-msgid "Query all versions of packages (default)"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:126
-msgid "show only results from this ARCH"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:128
-msgid "show only results that owns FILE"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:130
-msgid "show only results that conflict REQ"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:132
-msgid ""
-"shows results that requires, suggests, supplements, enhances,or recommends "
-"package provides and files REQ"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:135
-msgid "show only results that obsolete REQ"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:137
-msgid "show only results that provide REQ"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:139
-msgid "shows results that requires package provides and files REQ"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:141
-msgid "show only results that recommend REQ"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:143
-msgid "show only results that enhance REQ"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:145
-msgid "show only results that suggest REQ"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:147
-msgid "show only results that supplement REQ"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:150
-msgid "check non-explicit dependencies (files and Provides); default"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:152
-msgid "check dependencies exactly as given, opposite of --alldeps"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:154
-msgid ""
-"used with --whatrequires, and --requires --resolve, query packages "
-"recursively."
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:156
-msgid "show a list of all dependencies and what packages provide them"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:158
-msgid "show available tags to use with --queryformat"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:161
-msgid "resolve capabilities to originating package(s)"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:163
-msgid "show recursive tree for package(s)"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:165
-msgid "operate on corresponding source RPM"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:167
-msgid ""
-"show N latest packages for a given name.arch (or latest but N if N is "
-"negative)"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:173
-msgid "show detailed information about the package"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:176
-msgid "show list of files in the package"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:179
-msgid "show package source RPM name"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:182
-msgid "show changelogs of the package"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:185
-msgid "format for displaying found packages"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:188
-msgid ""
-"use name-epoch:version-release.architecture format for displaying found "
-"packages (default)"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:191
-msgid ""
-"use name-version-release format for displaying found packages (rpm query "
-"default)"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:197
-msgid ""
-"use epoch:name-version-release.architecture format for displaying found "
-"packages"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:200
-msgid "Display in which comps groups are presented selected packages"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:204
-msgid "limit the query to installed duplicate packages"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:211
-msgid "limit the query to installed installonly packages"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:214
-msgid "limit the query to installed packages with unsatisfied dependencies"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:216
-msgid "show a location from where packages can be downloaded"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:219
-msgid "Display capabilities that the package conflicts with."
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:220
-msgid ""
-"Display capabilities that the package can depend on, enhance, recommend, "
-"suggest, and supplement."
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:222
-msgid "Display capabilities that the package can enhance."
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:223
-msgid "Display capabilities provided by the package."
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:224
-msgid "Display capabilities that the package recommends."
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:225
-msgid "Display capabilities that the package depends on."
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:226
-#, python-format
-msgid ""
-"Display capabilities that the package depends on for running a %%pre script."
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:227
-msgid "Display capabilities that the package suggests."
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:228
-msgid "Display capabilities that the package can supplement."
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:234
-msgid "Display only available packages."
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:237
-msgid "Display only installed packages."
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:238
-msgid ""
-"Display only packages that are not present in any of available repositories."
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:239
-msgid ""
-"Display only packages that provide an upgrade for some already installed "
-"package."
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:240
-msgid ""
-"Display only packages that can be removed by \"dnf autoremove\" command."
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:241
-msgid "Display only packages that were installed by user."
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:253
-msgid "Display only recently edited packages"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:275
-msgid ""
-"Option '--resolve' has to be used together with one of the '--conflicts', '--"
-"depends', '--enhances', '--provides', '--recommends', '--requires', '--"
-"requires-pre', '--suggests' or '--supplements' options"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:285
-msgid ""
-"Option '--recursive' has to be used with '--whatrequires <REQ>' (optionaly "
-"with '--alldeps', but not with '--exactdeps'), or with '--requires <REQ> --"
-"resolve'"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:318
-msgid "Package {} contains no files"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:387
-#, python-brace-format
-msgid "Available query-tags: use --queryformat \".. %{tag} ..\""
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:456
-msgid "argument {} requires --whatrequires or --whatdepends option"
-msgstr ""
-
-#: ../dnf/cli/commands/repoquery.py:501
-msgid ""
-"No valid switch specified\n"
-"usage: dnf repoquery [--conflicts|--enhances|--obsoletes|--provides|--"
-"recommends|--requires|--suggest|--supplements|--whatrequires] [key] [--"
-"tree]\n"
-"\n"
-"description:\n"
-"  For the given packages print a tree of the packages."
-msgstr ""
-
-#: ../dnf/cli/commands/repolist.py:39
-#, python-format
-msgid "Never (last: %s)"
-msgstr ""
-
-#: ../dnf/cli/commands/repolist.py:41
-#, python-format
-msgid "Instant (last: %s)"
-msgstr ""
-
-#: ../dnf/cli/commands/repolist.py:44
-#, python-format
-msgid "%s second(s) (last: %s)"
-msgstr ""
-
-#: ../dnf/cli/commands/repolist.py:75
-msgid "display the configured software repositories"
-msgstr ""
-
-#: ../dnf/cli/commands/repolist.py:82
-msgid "show all repos"
-msgstr ""
-
-#: ../dnf/cli/commands/repolist.py:85
-msgid "show enabled repos (default)"
-msgstr ""
-
-#: ../dnf/cli/commands/repolist.py:88
-msgid "show disabled repos"
-msgstr ""
-
-#: ../dnf/cli/commands/repolist.py:123
-msgid "No repositories available"
-msgstr ""
-
-#: ../dnf/cli/commands/repolist.py:145 ../dnf/cli/commands/repolist.py:146
-msgid "enabled"
-msgstr ""
-
-#: ../dnf/cli/commands/repolist.py:163 ../dnf/cli/commands/repolist.py:164
-msgid "disabled"
-msgstr ""
-
-#: ../dnf/cli/commands/repolist.py:179
-msgid "Repo-id      : "
-msgstr ""
-
-#: ../dnf/cli/commands/repolist.py:180
-msgid "Repo-name    : "
-msgstr ""
-
-#: ../dnf/cli/commands/repolist.py:183
-msgid "Repo-status  : "
-msgstr ""
-
-#: ../dnf/cli/commands/repolist.py:186
-msgid "Repo-revision: "
-msgstr ""
-
-#: ../dnf/cli/commands/repolist.py:190
-msgid "Repo-tags    : "
-msgstr ""
-
-#: ../dnf/cli/commands/repolist.py:197
-msgid "Repo-distro-tags: "
-msgstr ""
-
-#: ../dnf/cli/commands/repolist.py:203
-msgid "Repo-updated : "
-msgstr ""
-
-#: ../dnf/cli/commands/repolist.py:205
-msgid "Repo-pkgs    : "
-msgstr ""
-
-#: ../dnf/cli/commands/repolist.py:206
-msgid "Repo-size    : "
-msgstr ""
-
-#: ../dnf/cli/commands/repolist.py:209
-msgid "Repo-metalink: "
-msgstr ""
-
-#: ../dnf/cli/commands/repolist.py:214
-msgid "  Updated    : "
-msgstr ""
-
-#: ../dnf/cli/commands/repolist.py:216
-msgid "Repo-mirrors : "
-msgstr ""
-
-#: ../dnf/cli/commands/repolist.py:220 ../dnf/cli/commands/repolist.py:226
-msgid "Repo-baseurl : "
-msgstr ""
-
-#: ../dnf/cli/commands/repolist.py:229
-msgid "Repo-expire  : "
-msgstr ""
-
-#. TRANSLATORS: Packages that are excluded - their names like (dnf systemd)
-#: ../dnf/cli/commands/repolist.py:233
-msgid "Repo-exclude : "
-msgstr ""
-
-#: ../dnf/cli/commands/repolist.py:237
-msgid "Repo-include : "
-msgstr ""
-
-#. TRANSLATORS: Number of packages that where excluded (5)
-#: ../dnf/cli/commands/repolist.py:242
-msgid "Repo-excluded: "
-msgstr ""
-
-#: ../dnf/cli/commands/repolist.py:246
-msgid "Repo-filename: "
-msgstr ""
-
-#. Work out the first (id) and last (enabled/disalbed/count),
-#. then chop the middle (name)...
-#: ../dnf/cli/commands/repolist.py:254 ../dnf/cli/commands/repolist.py:283
-msgid "repo id"
-msgstr ""
-
-#: ../dnf/cli/commands/repolist.py:271 ../dnf/cli/commands/repolist.py:272
-#: ../dnf/cli/commands/repolist.py:288
-msgid "status"
-msgstr ""
-
-#: ../dnf/cli/commands/repolist.py:284
-msgid "repo name"
-msgstr ""
-
-#: ../dnf/cli/commands/repolist.py:300
-#, python-format
-msgid "Total packages: %s"
-msgstr ""
-
-#: ../dnf/cli/commands/shell.py:47
-msgid "run an interactive DNF shell"
-msgstr ""
-
-#: ../dnf/cli/commands/shell.py:68
-msgid "SCRIPT"
-msgstr ""
-
-#: ../dnf/cli/commands/shell.py:69
-msgid "Script to run in DNF shell"
-msgstr ""
-
-#: ../dnf/cli/commands/shell.py:135
-msgid "Unsupported key value."
-msgstr ""
-
-#: ../dnf/cli/commands/shell.py:151
-#, python-format
-msgid "Could not find repository: %s"
-msgstr ""
-
-#: ../dnf/cli/commands/shell.py:167
-msgid ""
-"{} arg [value]\n"
-"  arg: debuglevel, errorlevel, obsoletes, gpgcheck, assumeyes, exclude,\n"
-"        repo_id.gpgcheck, repo_id.exclude\n"
-"    If no value is given it prints the current value.\n"
-"    If value is given it sets that value."
-msgstr ""
-
-#: ../dnf/cli/commands/shell.py:174
-msgid ""
-"{} [command]\n"
-"    print help"
-msgstr ""
-
-#: ../dnf/cli/commands/shell.py:178
-msgid ""
-"{} arg [option]\n"
-"  list: lists repositories and their status. option = [all | id | glob]\n"
-"  enable: enable repositories. option = repository id\n"
-"  disable: disable repositories. option = repository id"
-msgstr ""
-
-#: ../dnf/cli/commands/shell.py:184
-msgid ""
-"{}\n"
-"    resolve the transaction set"
-msgstr ""
-
-#: ../dnf/cli/commands/shell.py:188
-msgid ""
-"{} arg\n"
-"  list: lists the contents of the transaction\n"
-"  reset: reset (zero-out) the transaction\n"
-"  run: run the transaction"
-msgstr ""
-
-#: ../dnf/cli/commands/shell.py:194
-msgid ""
-"{}\n"
-"    run the transaction"
-msgstr ""
-
-#: ../dnf/cli/commands/shell.py:198
-msgid ""
-"{}\n"
-"    exit the shell"
-msgstr ""
-
-#: ../dnf/cli/commands/shell.py:203
-msgid ""
-"Shell specific arguments:\n"
-"\n"
-"config                   set config options\n"
-"help                     print help\n"
-"repository (or repo)     enable, disable or list repositories\n"
-"resolvedep               resolve the transaction set\n"
-"transaction (or ts)      list, reset or run the transaction set\n"
-"run                      resolve and run the transaction set\n"
-"exit (or quit)           exit the shell"
-msgstr ""
-
-#: ../dnf/cli/commands/shell.py:253
-#, python-format
-msgid "Error: Cannot open %s for reading"
-msgstr ""
-
-#: ../dnf/cli/commands/shell.py:283
-msgid "Leaving Shell"
-msgstr ""
-
-#: ../dnf/cli/commands/reinstall.py:38
-msgid "reinstall a package"
-msgstr ""
-
-#: ../dnf/cli/commands/reinstall.py:42
-msgid "Package to reinstall"
-msgstr ""
-
-#: ../dnf/cli/commands/reinstall.py:81 ../dnf/base.py:1987
-#, python-format
-msgid "Package %s available, but not installed."
-msgstr ""
-
-#: ../dnf/cli/commands/swap.py:33
-msgid "run an interactive dnf mod for remove and install one spec"
-msgstr ""
-
-#: ../dnf/cli/commands/swap.py:37
-msgid "The specs that will be removed"
-msgstr ""
-
-#: ../dnf/cli/commands/swap.py:39
-msgid "The specs that will be installed"
-msgstr ""
-
-#: ../dnf/cli/commands/group.py:45
-msgid "display, or use, the groups information"
-msgstr ""
-
-#: ../dnf/cli/commands/group.py:70
-msgid "No group data available for configured repositories."
-msgstr ""
-
-#: ../dnf/cli/commands/group.py:127
-#, python-format
-msgid "Warning: Group %s does not exist."
-msgstr ""
-
-#: ../dnf/cli/commands/group.py:161
-msgid "Warning: No groups match:"
-msgstr ""
-
-#: ../dnf/cli/commands/group.py:190
-msgid "Available Environment Groups:"
-msgstr ""
-
-#: ../dnf/cli/commands/group.py:192
-msgid "Installed Environment Groups:"
-msgstr ""
-
-#: ../dnf/cli/commands/group.py:199 ../dnf/cli/commands/group.py:285
-msgid "Installed Groups:"
-msgstr ""
-
-#: ../dnf/cli/commands/group.py:206 ../dnf/cli/commands/group.py:292
-msgid "Installed Language Groups:"
-msgstr ""
-
-#: ../dnf/cli/commands/group.py:216 ../dnf/cli/commands/group.py:299
-msgid "Available Groups:"
-msgstr ""
-
-#: ../dnf/cli/commands/group.py:223 ../dnf/cli/commands/group.py:306
-msgid "Available Language Groups:"
-msgstr ""
-
-#: ../dnf/cli/commands/group.py:313
-msgid "include optional packages from group"
-msgstr ""
-
-#: ../dnf/cli/commands/group.py:316
-msgid "show also hidden groups"
-msgstr ""
-
-#: ../dnf/cli/commands/group.py:318
-msgid "show only installed groups"
-msgstr ""
-
-#: ../dnf/cli/commands/group.py:320
-msgid "show only available groups"
-msgstr ""
-
-#: ../dnf/cli/commands/group.py:332
-#, python-format
-msgid "Invalid groups sub-command, use: %s."
-msgstr ""
-
-#: ../dnf/cli/commands/group.py:389
-msgid "Unable to find a mandatory group package."
-msgstr ""
-
-#: ../dnf/db/group.py:344
-#, python-format
-msgid "Will not install a source rpm package (%s)."
-msgstr ""
-
-#: ../dnf/repo.py:83
-#, python-format
-msgid "no matching payload factory for %s"
-msgstr ""
-
-#: ../dnf/repo.py:110
-msgid "Already downloaded"
-msgstr ""
-
-#: ../dnf/repo.py:267 ../dnf/drpm.py:62
-#, python-format
-msgid "unsupported checksum type: %s"
-msgstr ""
-
-#. pinging mirrors, this might take a while
-#: ../dnf/repo.py:345
-#, python-format
-msgid "determining the fastest mirror (%s hosts).. "
-msgstr ""
-
-#: ../dnf/module/module_base.py:33
-msgid ""
-"\n"
-"\n"
-"Hint: [d]efault, [e]nabled, [x]disabled, [i]nstalled"
-msgstr ""
-
-#: ../dnf/module/module_base.py:34
-msgid ""
-"\n"
-"\n"
-"Hint: [d]efault, [e]nabled, [x]disabled, [i]nstalled, [a]ctive"
-msgstr ""
-
-#: ../dnf/module/module_base.py:46 ../dnf/module/module_base.py:362
-#: ../dnf/module/module_base.py:418 ../dnf/module/module_base.py:476
-msgid "Ignoring unnecessary profile: '{}/{}'"
-msgstr ""
-
-#: ../dnf/module/module_base.py:79 ../dnf/module/module_base.py:173
-#: ../dnf/module/module_base.py:197
-msgid "Unable to match profile in argument {}"
-msgstr ""
-
-#: ../dnf/module/module_base.py:86
-msgid "No default profiles for module {}:{}"
-msgstr ""
-
-#: ../dnf/module/module_base.py:92
-msgid "Profile {} not matched for module {}:{}"
-msgstr ""
-
-#: ../dnf/module/module_base.py:118 ../dnf/module/module_base.py:148
-#: ../dnf/module/module_base.py:278 ../dnf/module/module_base.py:296
-#: ../dnf/module/module_base.py:304 ../dnf/module/module_base.py:358
-#: ../dnf/module/module_base.py:414 ../dnf/module/module_base.py:472
-msgid "Unable to resolve argument {}"
-msgstr ""
-
-#: ../dnf/module/module_base.py:119
-msgid "No match for package {}"
-msgstr ""
-
-#: ../dnf/module/module_base.py:308
-msgid ""
-"Only module name required. Ignoring unneeded information in argument: '{}'"
-msgstr ""
-
-#: ../dnf/module/module_base.py:607 ../dnf/exceptions.py:125
-msgid "Modular dependency problem:"
-msgid_plural "Modular dependency problems:"
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../dnf/module/__init__.py:26
-msgid "Enabling different stream for '{}'."
-msgstr ""
-
-#: ../dnf/module/__init__.py:27
-msgid "Nothing to show."
-msgstr ""
-
-#: ../dnf/module/__init__.py:28
-msgid "Installing newer version of '{}' than specified. Reason: {}"
-msgstr ""
-
-#: ../dnf/module/__init__.py:29
-msgid "Enabled modules: {}."
-msgstr ""
-
-#: ../dnf/module/__init__.py:30
-msgid "No profile specified for '{}', please specify profile."
-msgstr ""
-
-#: ../dnf/dnssec.py:239
-msgid "DNSSEC extension: Key for user "
-msgstr ""
-
-#: ../dnf/dnssec.py:241
-msgid "is valid."
-msgstr ""
-
-#: ../dnf/dnssec.py:243
-msgid "has unknown status."
-msgstr ""
-
-#: ../dnf/dnssec.py:251
-msgid "DNSSEC extension: "
-msgstr ""
-
-#: ../dnf/dnssec.py:283
-msgid "Testing already imported keys for their validity."
-msgstr ""
-
-#: ../dnf/automatic/main.py:156 ../dnf/conf/config.py:149
-#, python-format
-msgid "Unknown configuration value: %s=%s in %s; %s"
-msgstr ""
-
-#: ../dnf/automatic/main.py:160 ../dnf/conf/config.py:156
-#, python-format
-msgid "Unknown configuration option: %s = %s in %s"
-msgstr ""
-
-#: ../dnf/automatic/main.py:231
-msgid "Started dnf-automatic."
-msgstr ""
-
-#: ../dnf/automatic/main.py:235
-#, python-format
-msgid "Sleep for %s seconds"
-msgstr ""
-
-#: ../dnf/automatic/emitter.py:31
-#, python-format
-msgid "The following updates have been applied on '%s':"
-msgstr ""
-
-#: ../dnf/automatic/emitter.py:32
-#, python-format
-msgid "The following updates are available on '%s':"
-msgstr ""
-
-#: ../dnf/automatic/emitter.py:33
-#, python-format
-msgid "The following updates were downloaded on '%s':"
-msgstr ""
-
-#: ../dnf/automatic/emitter.py:80
-#, python-format
-msgid "Updates applied on '%s'."
-msgstr ""
-
-#: ../dnf/automatic/emitter.py:82
-#, python-format
-msgid "Updates downloaded on '%s'."
-msgstr ""
-
-#: ../dnf/automatic/emitter.py:84
-#, python-format
-msgid "Updates available on '%s'."
-msgstr ""
-
-#: ../dnf/automatic/emitter.py:107
-#, python-format
-msgid "Failed to send an email via '%s': %s"
-msgstr ""
-
-#: ../dnf/automatic/emitter.py:137
-#, python-format
-msgid "Failed to execute command '%s': returned %d"
-msgstr ""
-
-#: ../dnf/exceptions.py:107
-msgid "Problems in request:"
-msgstr ""
-
-#: ../dnf/exceptions.py:109
-msgid "missing packages: "
-msgstr ""
-
-#: ../dnf/exceptions.py:111
-msgid "broken packages: "
-msgstr ""
-
-#: ../dnf/exceptions.py:113
-msgid "missing groups or modules: "
-msgstr ""
-
-#: ../dnf/exceptions.py:115
-msgid "broken groups or modules: "
-msgstr ""
-
-#: ../dnf/exceptions.py:120
-msgid "Modular dependency problem with Defaults:"
-msgid_plural "Modular dependency problems with Defaults:"
-msgstr[0] ""
-msgstr[1] ""
-
-#. empty file is invalid json format
-#: ../dnf/persistor.py:54
-#, python-format
-msgid "%s is empty file"
-msgstr ""
-
-#: ../dnf/persistor.py:98
-msgid "Failed storing last makecache time."
-msgstr ""
-
-#: ../dnf/persistor.py:105
-msgid "Failed determining last makecache time."
-msgstr ""
-
-#: ../dnf/util.py:381 ../dnf/util.py:383
-msgid "Problem"
-msgstr ""
-
-#: ../dnf/base.py:146
-msgid "loading repo '{}' failure: {}"
-msgstr ""
-
-#: ../dnf/base.py:148
-msgid "Loading repository '{}' has failed"
-msgstr ""
-
-#: ../dnf/base.py:335
-msgid "Metadata timer caching disabled when running on metered connection."
-msgstr ""
-
-#: ../dnf/base.py:340
-msgid "Metadata timer caching disabled when running on a battery."
-msgstr ""
-
-#: ../dnf/base.py:345
-msgid "Metadata timer caching disabled."
-msgstr ""
-
-#: ../dnf/base.py:350
-msgid "Metadata cache refreshed recently."
-msgstr ""
-
-#: ../dnf/base.py:362
-#, python-format
-msgid "%s: will never be expired and will not be refreshed."
-msgstr ""
-
-#: ../dnf/base.py:364
-#, python-format
-msgid "%s: has expired and will be refreshed."
-msgstr ""
-
-#. expires within the checking period:
-#: ../dnf/base.py:368
-#, python-format
-msgid "%s: metadata will expire after %d seconds and will be refreshed now"
-msgstr ""
-
-#: ../dnf/base.py:372
-#, python-format
-msgid "%s: will expire after %d seconds."
-msgstr ""
-
-#. performs the md sync
-#: ../dnf/base.py:378
-msgid "Metadata cache created."
-msgstr ""
-
-#: ../dnf/base.py:414
-#, python-format
-msgid "%s: using metadata from %s."
-msgstr ""
-
-#: ../dnf/base.py:425
-#, python-format
-msgid "Ignoring repositories: %s"
-msgstr ""
-
-#: ../dnf/base.py:428
-#, python-format
-msgid "Last metadata expiration check: %s ago on %s."
-msgstr ""
-
-#: ../dnf/base.py:458
-msgid ""
-"The downloaded packages were saved in cache until the next successful "
-"transaction."
-msgstr ""
-
-#: ../dnf/base.py:460
-#, python-format
-msgid "You can remove cached packages by executing '%s'."
-msgstr ""
-
-#: ../dnf/base.py:552
-#, python-format
-msgid "Invalid tsflag in config file: %s"
-msgstr ""
-
-#: ../dnf/base.py:608
-#, python-format
-msgid "Failed to add groups file for repository: %s - %s"
-msgstr ""
-
-#: ../dnf/base.py:829
-msgid "Running transaction check"
-msgstr ""
-
-#: ../dnf/base.py:840
-msgid "Error: transaction check vs depsolve:"
-msgstr ""
-
-#: ../dnf/base.py:846
-msgid "Transaction check succeeded."
-msgstr ""
-
-#: ../dnf/base.py:849
-msgid "Running transaction test"
-msgstr ""
-
-#: ../dnf/base.py:859
-msgid "Transaction check error:"
-msgstr ""
-
-#: ../dnf/base.py:866
-msgid "Transaction test succeeded."
-msgstr ""
-
-#: ../dnf/base.py:881
-msgid "Running transaction"
-msgstr ""
-
-#: ../dnf/base.py:907
-msgid "Disk Requirements:"
-msgstr ""
-
-#: ../dnf/base.py:910
-#, python-format
-msgid "At least %dMB more space needed on the %s filesystem."
-msgid_plural "At least %dMB more space needed on the %s filesystem."
-msgstr[0] ""
-msgstr[1] ""
-
-#: ../dnf/base.py:914
-msgid "Error Summary"
-msgstr ""
-
-#: ../dnf/base.py:940
-msgid "RPMDB altered outside of DNF."
-msgstr ""
-
-#: ../dnf/base.py:997
-msgid "Errors occurred during transaction."
-msgstr ""
-
-#: ../dnf/base.py:1001
-#, python-format
-msgid "Failed to obtain the transaction lock (logged in as: %s)."
-msgstr ""
-
-#. should this be 'to_unicoded'?
-#: ../dnf/base.py:1004 ../dnf/base.py:1014
-msgid "Could not run transaction."
-msgstr ""
-
-#: ../dnf/base.py:1011
-msgid "Transaction couldn't start:"
-msgstr ""
-
-#: ../dnf/base.py:1023
-#, python-format
-msgid "Failed to remove transaction file %s"
-msgstr ""
-
-#: ../dnf/base.py:1102
-msgid "Some packages were not downloaded. Retrying."
-msgstr ""
-
-#: ../dnf/base.py:1132
-#, python-format
-msgid "Delta RPMs reduced %.1f MB of updates to %.1f MB (%d.1%% saved)"
-msgstr ""
-
-#: ../dnf/base.py:1135
-#, python-format
-msgid ""
-"Failed Delta RPMs increased %.1f MB of updates to %.1f MB (%d.1%% wasted)"
-msgstr ""
-
-#: ../dnf/base.py:1184
-msgid "Could not open: {}"
-msgstr ""
-
-#: ../dnf/base.py:1222
-#, python-format
-msgid "Public key for %s is not installed"
-msgstr ""
-
-#: ../dnf/base.py:1226
-#, python-format
-msgid "Problem opening package %s"
-msgstr ""
-
-#: ../dnf/base.py:1234
-#, python-format
-msgid "Public key for %s is not trusted"
-msgstr ""
-
-#: ../dnf/base.py:1238
-#, python-format
-msgid "Package %s is not signed"
-msgstr ""
-
-#: ../dnf/base.py:1253
-#, python-format
-msgid "Cannot remove %s"
-msgstr ""
-
-#: ../dnf/base.py:1257
-#, python-format
-msgid "%s removed"
-msgstr ""
-
-#: ../dnf/base.py:1529
-msgid "No match for group package \"{}\""
-msgstr ""
-
-#: ../dnf/base.py:1614
-#, python-format
-msgid "Adding packages from group '%s': %s"
-msgstr ""
-
-#: ../dnf/base.py:1655
-msgid "No groups marked for removal."
-msgstr ""
-
-#: ../dnf/base.py:1674
-msgid "No group marked for upgrade."
-msgstr ""
-
-#: ../dnf/base.py:1859 ../dnf/base.py:1870 ../dnf/base.py:2224
-msgid "no package matched"
-msgstr ""
-
-#: ../dnf/base.py:1885
-#, python-format
-msgid "Package %s not installed, cannot downgrade it."
-msgstr ""
-
-#: ../dnf/base.py:1894
-#, python-format
-msgid "Package %s of lower version already installed, cannot downgrade it."
-msgstr ""
-
-#: ../dnf/base.py:1917
-#, python-format
-msgid "Package %s not installed, cannot reinstall it."
-msgstr ""
-
-#: ../dnf/base.py:1932
-#, python-format
-msgid "File %s is a source package and cannot be updated, ignoring."
-msgstr ""
-
-#: ../dnf/base.py:1938
-#, python-format
-msgid "Package %s not installed, cannot update it."
-msgstr ""
-
-#: ../dnf/base.py:1947
-#, python-format
-msgid "Package %s of higher version already installed, cannot update it."
-msgstr ""
-
-#: ../dnf/base.py:1993
-#, python-format
-msgid "Package %s available, but installed for different architecture."
-msgstr ""
-
-#: ../dnf/base.py:2148
-#, python-format
-msgid "Package %s of lowest version already installed, cannot downgrade it."
-msgstr ""
-
-#: ../dnf/base.py:2197
-msgid "Action not handled: {}"
-msgstr ""
-
-#: ../dnf/base.py:2245
-msgid "No security updates needed, but {} update available"
-msgstr ""
-
-#: ../dnf/base.py:2247
-msgid "No security updates needed, but {} updates available"
-msgstr ""
-
-#: ../dnf/base.py:2251
-msgid "No security updates needed for \"{}\", but {} update available"
-msgstr ""
-
-#: ../dnf/base.py:2253
-msgid "No security updates needed for \"{}\", but {} updates available"
-msgstr ""
-
-#: ../dnf/base.py:2277
-#, python-format
-msgid ". Failing package is: %s"
-msgstr ""
-
-#: ../dnf/base.py:2278
+#: ../dnf/comps.py:187
 #, python-format
-msgid "GPG Keys are configured as: %s"
+msgid "Group '%s' is not installed."
 msgstr ""
 
-#: ../dnf/base.py:2290
+#: ../dnf/comps.py:189
 #, python-format
-msgid "GPG key at %s (0x%s) is already installed"
-msgstr ""
-
-#: ../dnf/base.py:2323
-msgid "The key has been approved."
-msgstr ""
-
-#: ../dnf/base.py:2326
-msgid "The key has been rejected."
+msgid "Group '%s' does not exist."
 msgstr ""
 
-#: ../dnf/base.py:2354
+#: ../dnf/comps.py:608 ../dnf/comps.py:625
 #, python-format
-msgid "Key import failed (code %d)"
-msgstr ""
-
-#: ../dnf/base.py:2356
-msgid "Key imported successfully"
-msgstr ""
-
-#: ../dnf/base.py:2360
-msgid "Didn't install any keys"
+msgid "Environment '%s' is not installed."
 msgstr ""
 
-#: ../dnf/base.py:2363
+#: ../dnf/comps.py:653
 #, python-format
-msgid ""
-"The GPG keys listed for the \"%s\" repository are already installed but they "
-"are not correct for this package.\n"
-"Check that the correct key URLs are configured for this repository."
-msgstr ""
-
-#: ../dnf/base.py:2374
-msgid "Import of key(s) didn't help, wrong key(s)?"
-msgstr ""
-
-#: ../dnf/base.py:2410
-msgid "  * Maybe you meant: {}"
-msgstr ""
-
-#: ../dnf/base.py:2442
-msgid "Package \"{}\" from local repository \"{}\" has incorrect checksum"
-msgstr ""
-
-#: ../dnf/base.py:2445
-msgid "Some packages from local repository have incorrect checksum"
-msgstr ""
-
-#: ../dnf/base.py:2448
-msgid "Package \"{}\" from repository \"{}\" has incorrect checksum"
-msgstr ""
-
-#: ../dnf/base.py:2451
-msgid ""
-"Some packages have invalid cache, but cannot be downloaded due to \"--"
-"cacheonly\" option"
+msgid "Group_id '%s' does not exist."
 msgstr ""
 
-#: ../dnf/base.py:2463
+#: ../dnf/comps.py:684
 #, python-format
-msgid "Package %s is already installed."
+msgid "Group '%s' not installed."
 msgstr ""
 
 #: ../dnf/conf/config.py:134
@@ -3432,11 +3227,6 @@ msgstr ""
 msgid "Bad id for repo: %s, byte = %s %d"
 msgstr ""
 
-#: ../dnf/package.py:273
-#, python-format
-msgid "%s: %s check failed: %s vs %s"
-msgstr ""
-
 #: ../dnf/crypto.py:108
 #, python-format
 msgid "repo %s: 0x%s already imported"
@@ -3445,6 +3235,36 @@ msgstr ""
 #: ../dnf/crypto.py:115
 #, python-format
 msgid "repo %s: imported key 0x%s."
+msgstr ""
+
+#: ../dnf/db/group.py:344
+#, python-format
+msgid "Will not install a source rpm package (%s)."
+msgstr ""
+
+#: ../dnf/dnssec.py:239
+msgid "DNSSEC extension: Key for user "
+msgstr ""
+
+#: ../dnf/dnssec.py:241
+msgid "is valid."
+msgstr ""
+
+#: ../dnf/dnssec.py:243
+msgid "has unknown status."
+msgstr ""
+
+#: ../dnf/dnssec.py:251
+msgid "DNSSEC extension: "
+msgstr ""
+
+#: ../dnf/dnssec.py:283
+msgid "Testing already imported keys for their validity."
+msgstr ""
+
+#: ../dnf/drpm.py:62 ../dnf/repo.py:267
+#, python-format
+msgid "unsupported checksum type: %s"
 msgstr ""
 
 #: ../dnf/drpm.py:144
@@ -3459,6 +3279,38 @@ msgstr ""
 msgid "done"
 msgstr ""
 
+#: ../dnf/exceptions.py:107
+msgid "Problems in request:"
+msgstr ""
+
+#: ../dnf/exceptions.py:109
+msgid "missing packages: "
+msgstr ""
+
+#: ../dnf/exceptions.py:111
+msgid "broken packages: "
+msgstr ""
+
+#: ../dnf/exceptions.py:113
+msgid "missing groups or modules: "
+msgstr ""
+
+#: ../dnf/exceptions.py:115
+msgid "broken groups or modules: "
+msgstr ""
+
+#: ../dnf/exceptions.py:120
+msgid "Modular dependency problem with Defaults:"
+msgid_plural "Modular dependency problems with Defaults:"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../dnf/exceptions.py:125 ../dnf/module/module_base.py:607
+msgid "Modular dependency problem:"
+msgid_plural "Modular dependency problems:"
+msgstr[0] ""
+msgstr[1] ""
+
 #: ../dnf/lock.py:100
 #, python-format
 msgid ""
@@ -3467,31 +3319,179 @@ msgid ""
 "run systemd-tmpfiles --remove dnf.conf."
 msgstr ""
 
-#: ../dnf/comps.py:95
-msgid "skipping."
+#: ../dnf/module/__init__.py:26
+msgid "Enabling different stream for '{}'."
 msgstr ""
 
-#: ../dnf/comps.py:187
-#, python-format
-msgid "Group '%s' is not installed."
+#: ../dnf/module/__init__.py:27
+msgid "Nothing to show."
 msgstr ""
 
-#: ../dnf/comps.py:189
-#, python-format
-msgid "Group '%s' does not exist."
+#: ../dnf/module/__init__.py:28
+msgid "Installing newer version of '{}' than specified. Reason: {}"
 msgstr ""
 
-#: ../dnf/comps.py:608 ../dnf/comps.py:625
-#, python-format
-msgid "Environment '%s' is not installed."
+#: ../dnf/module/__init__.py:29
+msgid "Enabled modules: {}."
 msgstr ""
 
-#: ../dnf/comps.py:653
-#, python-format
-msgid "Group_id '%s' does not exist."
+#: ../dnf/module/__init__.py:30
+msgid "No profile specified for '{}', please specify profile."
 msgstr ""
 
-#: ../dnf/comps.py:684
+#: ../dnf/module/module_base.py:33
+msgid ""
+"\n"
+"\n"
+"Hint: [d]efault, [e]nabled, [x]disabled, [i]nstalled"
+msgstr ""
+
+#: ../dnf/module/module_base.py:34
+msgid ""
+"\n"
+"\n"
+"Hint: [d]efault, [e]nabled, [x]disabled, [i]nstalled, [a]ctive"
+msgstr ""
+
+#: ../dnf/module/module_base.py:46 ../dnf/module/module_base.py:362
+#: ../dnf/module/module_base.py:418 ../dnf/module/module_base.py:476
+msgid "Ignoring unnecessary profile: '{}/{}'"
+msgstr ""
+
+#: ../dnf/module/module_base.py:79 ../dnf/module/module_base.py:173
+#: ../dnf/module/module_base.py:197
+msgid "Unable to match profile in argument {}"
+msgstr ""
+
+#: ../dnf/module/module_base.py:86
+msgid "No default profiles for module {}:{}"
+msgstr ""
+
+#: ../dnf/module/module_base.py:92
+msgid "Profile {} not matched for module {}:{}"
+msgstr ""
+
+#: ../dnf/module/module_base.py:118 ../dnf/module/module_base.py:148
+#: ../dnf/module/module_base.py:278 ../dnf/module/module_base.py:296
+#: ../dnf/module/module_base.py:304 ../dnf/module/module_base.py:358
+#: ../dnf/module/module_base.py:414 ../dnf/module/module_base.py:472
+msgid "Unable to resolve argument {}"
+msgstr ""
+
+#: ../dnf/module/module_base.py:119
+msgid "No match for package {}"
+msgstr ""
+
+#: ../dnf/module/module_base.py:308
+msgid ""
+"Only module name required. Ignoring unneeded information in argument: '{}'"
+msgstr ""
+
+#: ../dnf/package.py:273
 #, python-format
-msgid "Group '%s' not installed."
+msgid "%s: %s check failed: %s vs %s"
+msgstr ""
+
+#. empty file is invalid json format
+#: ../dnf/persistor.py:54
+#, python-format
+msgid "%s is empty file"
+msgstr ""
+
+#: ../dnf/persistor.py:98
+msgid "Failed storing last makecache time."
+msgstr ""
+
+#: ../dnf/persistor.py:105
+msgid "Failed determining last makecache time."
+msgstr ""
+
+#: ../dnf/plugin.py:63
+#, python-format
+msgid "Parsing file failed: %s"
+msgstr ""
+
+#: ../dnf/plugin.py:139
+#, python-format
+msgid "Loaded plugins: %s"
+msgstr ""
+
+#: ../dnf/plugin.py:197
+#, python-format
+msgid "Failed loading plugin: %s"
+msgstr ""
+
+#: ../dnf/repo.py:83
+#, python-format
+msgid "no matching payload factory for %s"
+msgstr ""
+
+#: ../dnf/repo.py:110
+msgid "Already downloaded"
+msgstr ""
+
+#. pinging mirrors, this might take a while
+#: ../dnf/repo.py:345
+#, python-format
+msgid "determining the fastest mirror (%s hosts).. "
+msgstr ""
+
+#: ../dnf/repodict.py:58
+#, python-format
+msgid "enabling %s repository"
+msgstr ""
+
+#: ../dnf/repodict.py:94
+#, python-format
+msgid "Added %s repo from %s"
+msgstr ""
+
+#. TRANSLATORS: This is for a single package currently being downgraded.
+#: ../dnf/transaction.py:79
+msgctxt "currently"
+msgid "Downgrading"
+msgstr ""
+
+#: ../dnf/transaction.py:80 ../dnf/transaction.py:87 ../dnf/transaction.py:92
+#: ../dnf/transaction.py:94
+msgid "Cleanup"
+msgstr ""
+
+#. TRANSLATORS: This is for a single package currently being installed.
+#: ../dnf/transaction.py:82
+msgctxt "currently"
+msgid "Installing"
+msgstr ""
+
+#. TRANSLATORS: This is for a single package currently being reinstalled.
+#: ../dnf/transaction.py:86
+msgctxt "currently"
+msgid "Reinstalling"
+msgstr ""
+
+#. TODO: 'Removing'?
+#: ../dnf/transaction.py:89
+msgid "Erasing"
+msgstr ""
+
+#. TRANSLATORS: This is for a single package currently being upgraded.
+#: ../dnf/transaction.py:91
+msgctxt "currently"
+msgid "Upgrading"
+msgstr ""
+
+#: ../dnf/transaction.py:95
+msgid "Verifying"
+msgstr ""
+
+#: ../dnf/transaction.py:96
+msgid "Running scriptlet"
+msgstr ""
+
+#: ../dnf/transaction.py:98
+msgid "Preparing"
+msgstr ""
+
+#: ../dnf/util.py:381 ../dnf/util.py:383
+msgid "Problem"
 msgstr ""


### PR DESCRIPTION
When failing to load a plugin, make the error message more useful by including the exception message.

The first commit also sets a deterministic order for the dnf.pot translation template file to minimize the diffs when the file is updated.