### PR TITLE
librepo: Turn on debug logging only if debuglevel is greater than 2

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -1,5 +1,5 @@
 # default dependencies
-%global hawkey_version 0.31.0
+%global hawkey_version 0.32.0
 %global libcomps_version 0.1.8
 %global libmodulemd_version 1.4.0
 %global rpm_version 4.14.0

--- a/dnf/logging.py
+++ b/dnf/logging.py
@@ -152,7 +152,7 @@ class Logging(object):
         logger_warnings.addHandler(handler)
 
         lr_logfile = os.path.join(logdir, dnf.const.LOG_LIBREPO)
-        libdnf.repo.LibrepoLog.addHandler(lr_logfile)
+        libdnf.repo.LibrepoLog.addHandler(lr_logfile, verbose_level <= DEBUG)
 
         # setup RPM callbacks logger
         logger_rpm = logging.getLogger("dnf.rpm")

--- a/dnf/sack.py
+++ b/dnf/sack.py
@@ -50,7 +50,8 @@ def _build_sack(base):
     return Sack(pkgcls=dnf.package.Package, pkginitval=base,
                 arch=base.conf.substitutions["arch"],
                 cachedir=cachedir, rootdir=base.conf.installroot,
-                logfile=os.path.join(base.conf.logdir, dnf.const.LOG_HAWKEY))
+                logfile=os.path.join(base.conf.logdir, dnf.const.LOG_HAWKEY),
+                logdebug=base.conf.debuglevel > 2)
 
 
 def _rpmdb_sack(base):


### PR DESCRIPTION
Turns on debug level logging for the librepo logging handler only if
debuglevel is greater than 2 (2 is the default).

https://bugzilla.redhat.com/show_bug.cgi?id=1678598