### PR TITLE
Remove _moduleContainer attribute from sack

### DIFF
--- a/dnf/sack.py
+++ b/dnf/sack.py
@@ -31,7 +31,6 @@ from dnf.pycomp import basestring
 class Sack(hawkey.Sack):
     def __init__(self, *args, **kwargs):
         super(Sack, self).__init__(*args, **kwargs)
-        self._moduleContainer = None
 
     def _configure(self, installonly=None, installonly_limit=0):
         if installonly:


### PR DESCRIPTION
It is replaced by attribute from hawkey object. It allows to set
ModuleContainar also for C sack and then use it in queries. This is a
temporary solution before sack is provided by swig binding.