### PR TITLE
Fix the installation of completion_helper.py

### DIFF
--- a/dnf/cli/CMakeLists.txt
+++ b/dnf/cli/CMakeLists.txt
@@ -1,4 +1,6 @@
 FILE(GLOB cli_SRCS *.py)
 INSTALL (FILES ${cli_SRCS} DESTINATION ${PYTHON_INSTALL_DIR}/dnf/cli)
+# completion_helper.py is generated so the glob alone won't see it:
+INSTALL (FILES completion_helper.py DESTINATION ${PYTHON_INSTALL_DIR}/dnf/cli)
 
 ADD_SUBDIRECTORY (commands)


### PR DESCRIPTION
Change introduced in df19a47d672b09683cc03620a41114cd4239e prevents the
installation of completion_helper.py on Fedora 30.

Bug report: https://bugzilla.redhat.com/show_bug.cgi?id=1695853

Tested here: https://koji.fedoraproject.org/koji/taskinfo?taskID=33952661
Notice that python3-dnf-4.2.2-2 contains completion_helper.py now while python3-dnf-4.2.2-1 does not.