### PR TITLE
Change a test using empty installroot value

### DIFF
--- a/tests/conf/test_parser.py
+++ b/tests/conf/test_parser.py
@@ -60,4 +60,4 @@ class ParserTest(tests.support.TestCase):
         conf = dnf.conf.Conf()
         conf.config_file_path = FN
         conf.read()
-        self.assertEqual(conf.installroot, '')
+        self.assertEqual(conf.reposdir, '')

--- a/tests/etc/empty_option.conf
+++ b/tests/etc/empty_option.conf
@@ -1,2 +1,2 @@
 [main]
-installroot =
+reposdir =


### PR DESCRIPTION
It reflects change in behavior of installroot configuration option where
only absolute path is accepted. The new behavior restores behavior of
dnf-2.7.5.