### PR TITLE
make footnote "*' literal

### DIFF
--- a/doc/api_queries.rst
+++ b/doc/api_queries.rst
@@ -85,7 +85,7 @@
     upgrades          boolean        see :meth:`upgrades`. Defaults to ``False``.
     ===============   ============== ======================================================
 
-    *The key can also accept a list of values with specified type.
+    \* The key can also accept a list of values with specified type.
 
     The key name can be supplemented with a relation-specifying suffix, separated by ``__``:
 


### PR DESCRIPTION
When building dnf on Fedora 29, I got this error message:
/slow-space/hugh/rpmbuild/BUILD/dnf-4.2.2/doc/api_queries.rst:88: WARNING: Inline emphasis start-string without end-string.
This shows that rst2man interpreted the "*" as a start of emphasis.  We want it to be a literal "*".  We're just lucky that it wasn't taken as a bullet.