### PR TITLE
[docs] Document yum-cron replacement (RhBug:1670835)

### DIFF
--- a/doc/cli_vs_yum.rst
+++ b/doc/cli_vs_yum.rst
@@ -391,11 +391,11 @@ Detailed table for ``package-cleanup`` replacement:
 ``package-cleanup --oldkernels``         ``dnf remove --oldinstallonly``
 ==================================       =====================================
 
-================
-yum-updateonboot
-================
+=============================
+yum-updateonboot and yum-cron
+=============================
 
-DNF does not have a direct replacement of yum-updateonboot command.
+DNF does not have a direct replacement of yum-updateonboot and yum-cron commands.
 However, the similar result can be achieved by ``dnf automatic`` command (see :doc:`automatic`).
 
 You can either use the shortcut::


### PR DESCRIPTION
dnf-automatic replaces not just yum-updateonboot, but also yum-cron
Fixes the last part of bug: https://bugzilla.redhat.com/show_bug.cgi?id=1670835