### PR TITLE
Accept multiple specs in repoquery options (RhBug:1667898)

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -1,5 +1,5 @@
 # default dependencies
-%global hawkey_version 0.35.1
+%global hawkey_version 0.35.2
 %global libcomps_version 0.1.8
 %global libmodulemd_version 1.4.0
 %global rpm_version 4.14.0

--- a/tests/test_repoquery.py
+++ b/tests/test_repoquery.py
@@ -78,8 +78,8 @@ class ArgParseTest(tests.support.TestCase):
 
     def test_parse(self):
         tests.support.command_configure(self.cmd, ['--whatrequires', 'prudence'])
-        self.assertIsNone(self.cmd.opts.whatprovides)
-        self.assertEqual(self.cmd.opts.whatrequires, 'prudence')
+        self.assertEqual(self.cmd.opts.whatprovides, [])
+        self.assertEqual(self.cmd.opts.whatrequires, ['prudence'])
         self.assertEqual(self.cmd.opts.queryformat,
                          dnf.cli.commands.repoquery.QFORMAT_DEFAULT)
 


### PR DESCRIPTION
It allows with repoquery command to use --what* options multiple times
(append option) or add multiple arguments separated by comma.

https://bugzilla.redhat.com/show_bug.cgi?id=1667898