### PR TITLE
Fix checking of return value from test-transaction (RhBug:1690414)

### DIFF
--- a/dnf/rpm/transaction.py
+++ b/dnf/rpm/transaction.py
@@ -11,6 +11,7 @@
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
+from dnf.i18n import _
 import rpm
 
 read_ts = None
@@ -111,9 +112,11 @@ class TransactionWrapper(object):
         self.ts.setFlags(origflags)
 
         reserrors = []
-        if tserrors:
+        if tserrors is not None:
             for (descr, (etype, mount, need)) in tserrors:
                 reserrors.append(descr)
+            if not reserrors:
+                reserrors.append(_('Errors occurred during test transaction.'))
 
         return reserrors
 


### PR DESCRIPTION
Empty list doesn't trigger the if condition but ts.run() can return empty list to indicate error, as described [here](https://github.com/rpm-software-management/dnf/blob/a7bbe787cc16fadb255ad663cf29a5ec347bb4fb/dnf/base.py#L968).
