### PR TITLE
2 character encoding fixes

### DIFF
--- a/dnf/cli/main.py
+++ b/dnf/cli/main.py
@@ -60,6 +60,7 @@ def ex_Error(e):
 
 def main(args, conf_class=Conf, cli_class=Cli, option_parser_class=OptionParser):
     try:
+        dnf.i18n.setup_stdout()
         with dnf.cli.cli.BaseCli(conf_class()) as base:
             return _main(base, args, cli_class, option_parser_class)
     except dnf.exceptions.ProcessLockError as e:
@@ -82,8 +83,6 @@ def main(args, conf_class=Conf, cli_class=Cli, option_parser_class=OptionParser)
 
 def _main(base, args, cli_class, option_parser):
     """Run the dnf program from a command line interface."""
-
-    dnf.i18n.setup_stdout()
 
     # our core object for the cli
     base._logging._presetup()

--- a/dnf/i18n.py
+++ b/dnf/i18n.py
@@ -17,16 +17,19 @@
 # Red Hat, Inc.
 #
 
+from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 from dnf.pycomp import unicode
 
 import dnf
 import locale
+import codecs
 import os
 import signal
 import sys
 import unicodedata
+import logging
 
 """
 Centralize i18n stuff here. Must be unittested.
@@ -104,6 +107,12 @@ def setup_stdout():
         sys.stdout = UnicodeStream(stdout, _guess_encoding())
         return False
     return True
+
+# This feature is tested in test_logging.py
+def logging_handler(logfile):
+    encoding = _guess_encoding()
+    stream = codecs.open(logfile, 'a', encoding=encoding, errors='replace')
+    return logging.StreamHandler(stream)
 
 
 def ucd_input(ucstring):

--- a/dnf/logging.py
+++ b/dnf/logging.py
@@ -23,6 +23,7 @@ from __future__ import unicode_literals
 import dnf.exceptions
 import dnf.const
 import dnf.util
+import dnf.i18n
 import libdnf.repo
 import logging
 import os
@@ -94,7 +95,8 @@ def _create_filehandler(logfile):
         # By default, make logfiles readable by the user (so the reporting ABRT
         # user can attach root logfiles).
         os.chmod(logfile, 0o644)
-    handler = logging.FileHandler(logfile)
+
+    handler = dnf.i18n.logging_handler(logfile)
     formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s",
                                   "%Y-%m-%dT%H:%M:%SZ")
     formatter.converter = time.gmtime


### PR DESCRIPTION
1. Small fix.  Don't print any translated messages before we set up the stdout encoding.
2. Set the log file encoding similar to stdout.
     * log file will benefit from upgrading ASCII to UTF-8
     * log file will replace un-encodable characters, instead of skipping the entire message.
     * side effect: log file on PY2 will now start using the locale encoding, instead of UTF-8 always.