### PR TITLE
[cli] call setup_stdout() ASAP

### DIFF
--- a/dnf/cli/main.py
+++ b/dnf/cli/main.py
@@ -60,6 +60,7 @@ def ex_Error(e):
 
 def main(args, conf_class=Conf, cli_class=Cli, option_parser_class=OptionParser):
     try:
+        dnf.i18n.setup_stdout()
         with dnf.cli.cli.BaseCli(conf_class()) as base:
             return _main(base, args, cli_class, option_parser_class)
     except dnf.exceptions.ProcessLockError as e:
@@ -82,8 +83,6 @@ def main(args, conf_class=Conf, cli_class=Cli, option_parser_class=OptionParser)
 
 def _main(base, args, cli_class, option_parser):
     """Run the dnf program from a command line interface."""
-
-    dnf.i18n.setup_stdout()
 
     # our core object for the cli
     base._logging._presetup()


### PR DESCRIPTION
Move the call to dnf.i18n.setup_stdout(), so it comes before anything
that prints a translated message.  Like dnf.conf.Conf().

This was a problem for py2 only.  setup_stdout() exists because py2 does
not automatically use the locale encoding for stdout, if stdout is not a
tty.

I notice that "import dnf.i18n" automatically calls setup_locale(),
because it loads translations at import time.  If any other module was
similarly crass, and it triggered a translated error message when imported,
it would be inviting a UnicodeEncodeError.  Happily, it looks like there is
no such code path in dnf.  I could have wedged a call to setup_stdout()
within the import lists, to be on the safe side, but that looks unclean to
me.

---

This was originally part of #1380.  However it is independent.  We were not yet ready to merge the other commit in #1380, partly because

> we are considering using RotatingFileHandler in the near future.  However, I cannot find any way to enforce the errors='replace' using the other handlers, so I get why you used the StreamHandler. Let me think about it a bit more.

@pkratoch thanks for your review.  I reworked the commit message for clarity.  It now uses the past tense when referencing the problem that it solves :-).
