### PR TITLE
CMake: Actually install aliases

### DIFF
--- a/etc/dnf/CMakeLists.txt
+++ b/etc/dnf/CMakeLists.txt
@@ -1,2 +1,3 @@
 INSTALL (FILES "dnf.conf" "automatic.conf" DESTINATION ${SYSCONFDIR}/dnf)
+ADD_SUBDIRECTORY (aliases.d)
 ADD_SUBDIRECTORY (protected.d)


### PR DESCRIPTION
With the introduction of a default set of aliases in da52d0ee8ec53fc67477a448ef9da73e32ce2cf2,
we are supposed to install the alias files. However, the change was incomplete.

This fixes the installation of those aliases.