### PR TITLE
Allow plugin to terminate dnf (RhBug:1701807)

### DIFF
--- a/dnf/plugin.py
+++ b/dnf/plugin.py
@@ -102,6 +102,8 @@ class Plugins(object):
         for plugin in self.plugins:
             try:
                 getattr(plugin, method)()
+            except dnf.exceptions.Error:
+                raise
             except Exception:
                 exc_type, exc_value, exc_traceback = sys.exc_info()
                 except_list = traceback.format_exception(exc_type, exc_value, exc_traceback)


### PR DESCRIPTION
Dnf run plugins safely. But in case that plugins raise a dnf exception,
dnf should terminate, because it is expected behavior and only way how
dnf plugin could terminate DNF.

https://bugzilla.redhat.com/show_bug.cgi?id=1701807