### PR TITLE
dnf.plugin.log is not used, remove references to it

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -419,7 +419,6 @@ ln -sr  %{buildroot}%{confdir}/vars %{buildroot}%{_sysconfdir}/yum/vars
 %ghost %attr(644,-,-) %{_localstatedir}/log/%{name}.log
 %ghost %attr(644,-,-) %{_localstatedir}/log/%{name}.librepo.log
 %ghost %attr(644,-,-) %{_localstatedir}/log/%{name}.rpm.log
-%ghost %attr(644,-,-) %{_localstatedir}/log/%{name}.plugin.log
 %ghost %attr(755,-,-) %dir %{_sharedstatedir}/%{name}
 %ghost %attr(644,-,-) %{_sharedstatedir}/%{name}/groups.json
 %ghost %attr(755,-,-) %dir %{_sharedstatedir}/%{name}/yumdb

--- a/etc/logrotate.d/dnf
+++ b/etc/logrotate.d/dnf
@@ -22,14 +22,6 @@
     create 0600 root root
 }
 
-/var/log/dnf.plugin.log {
-    missingok
-    notifempty
-    rotate 4
-    weekly
-    create 0600 root root
-}
-
 /var/log/hawkey.log {
     missingok
     notifempty


### PR DESCRIPTION
dnf.plugin.log is not mentioned anywhere.  This includes the logfile names
in const.py.in.  It is not mentioned in dnfpluginscore either.  I have
used etckeeper-dnf which uses dnfpluginscore.logger on my Fedora 29 system.
I have no such file /var/log/dnf.plugin.log.

Remove it from the RPM spec file and the logrotate configuration file.
It is not mentioned anywhere else in the Git history.

---

I didn't bother to write up a bug report.  Maybe I'm wrong, and the bug is instead that something *should* be setting up `/var/log/dnf.plugin.log`.  But I don't know any reason why we want to change it at this point.