### PR TITLE
Add support /bin and /sbin search for provide command (RhBug:1657993)

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -2170,7 +2170,8 @@ class Base(object):
         providers = dnf.query._by_provides(self.sack, provides_spec)
         if providers:
             return providers, [provides_spec]
-        binary_provides = [prefix + provides_spec for prefix in ['/usr/bin/', '/usr/sbin/']]
+        binary_provides = [prefix + provides_spec for prefix in [
+            '/usr/bin/', '/usr/sbin/', '/bin/', '/sbin/']]
         return self.sack.query().filterm(file__glob=binary_provides), binary_provides
 
     def _history_undo_operations(self, operations, first_trans, rollback=False, strict=True):

--- a/doc/cli_vs_yum.rst
+++ b/doc/cli_vs_yum.rst
@@ -93,9 +93,9 @@ following will work::
 
 ``include`` directive name of [main] and Repo configuration is a more logical and better named counterpart of ``exclude`` in DNF.
 
-=====================================================================
-``dnf provides /bin/<file>`` does not find any packages on Fedora
-=====================================================================
+===================================================
+``dnf provides /bin/<file>`` is not fully supported
+===================================================
 
 After `UsrMove <https://fedoraproject.org/wiki/Features/UsrMove>`_ there's no
 directory ``/bin`` on Fedora systems and no files get installed there,


### PR DESCRIPTION
There are still some packages that incorrectly provides and install file
into /sbin directory, therefore adding a support for provide command is
good way how to cover transition period.

https://bugzilla.redhat.com/show_bug.cgi?id=1657993