### PR TITLE
Name dnf-automatic man page consistently with the command name (RhBug:1703609)

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -483,7 +483,7 @@ ln -sr  %{buildroot}%{confdir}/vars %{buildroot}%{_sysconfdir}/yum/vars
 %files automatic
 %{_bindir}/%{name}-automatic
 %config(noreplace) %{confdir}/automatic.conf
-%{_mandir}/man8/%{name}.automatic.8*
+%{_mandir}/man8/%{name}-automatic.8*
 %{_unitdir}/%{name}-automatic.service
 %{_unitdir}/%{name}-automatic.timer
 %{_unitdir}/%{name}-automatic-notifyonly.service

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -21,7 +21,7 @@ ADD_DEPENDENCIES (doc doc-html doc-man)
 
 if (NOT WITH_MAN EQUAL 0)
     INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/dnf.8
-              ${CMAKE_CURRENT_BINARY_DIR}/dnf.automatic.8
+              ${CMAKE_CURRENT_BINARY_DIR}/dnf-automatic.8
               ${CMAKE_CURRENT_BINARY_DIR}/yum2dnf.8
               ${CMAKE_CURRENT_BINARY_DIR}/yum.8
               ${CMAKE_CURRENT_BINARY_DIR}/yum-shell.8

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -232,7 +232,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('automatic', 'dnf.automatic', u'DNF Automatic',
+    ('automatic', 'dnf-automatic', u'DNF Automatic',
      AUTHORS, 8),
     ('command_ref', 'dnf', u'DNF Command Reference',
      AUTHORS, 8),


### PR DESCRIPTION
Rename dnf.automatic.8 -> dnf-automatic.8

https://bugzilla.redhat.com/show_bug.cgi?id=1703609