### PR TITLE
[bash completion] Avoid potential hangs in _dnf_show_packages

### DIFF
--- a/etc/bash_completion.d/dnf
+++ b/etc/bash_completion.d/dnf
@@ -149,9 +149,7 @@ _dnf_show_packages()
     shift
 
     if ! _dnf_is_path "$cur"; then
-        COMPREPLY+=( $(compgen -W '$( ${__dnf_python_exec} -c \
-            "import sys; from dnf.cli import completion_helper as ch;ch.main(sys.argv[1:])" \
-            $cmd "$@" "$cur" -d 0 -q -C 2>/dev/null )') )
+        COMPREPLY+=( $(compgen -W "$( _dnf_commands_helper $cmd "$@" "$cur" )") )
     fi
 
     [[ $COMPREPLY ]] && return


### PR DESCRIPTION
This is basically reusing fixes introduced in commit
36bf3730b6e431e6d6ba19bbdeee444f385e529f
on another place where the bash completion might get stuck.

https://bugzilla.redhat.com/show_bug.cgi?id=1702854