### PR TITLE
Do not wrap output when no terminal (RhBug:1577889)

### DIFF
--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -251,7 +251,7 @@ def main(args):
             if not trans:
                 return 0
 
-            lst = output.list_transaction(trans)
+            lst = output.list_transaction(trans, total_width=80)
             emitters = build_emitters(conf)
             emitters.notify_available(lst)
             if not conf.commands.download_updates:

--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -35,7 +35,7 @@ import time
 
 from dnf.cli.format import format_number, format_time
 from dnf.i18n import _, C_, P_, ucd, fill_exact_width, textwrap_fill, exact_width, select_short_long
-from dnf.pycomp import xrange, basestring, long, unicode
+from dnf.pycomp import xrange, basestring, long, unicode, sys_maxsize
 from dnf.yum.rpmtrans import LoggingTransactionDisplay
 from dnf.db.history import MergedTransactionWrapper
 import dnf.base
@@ -442,7 +442,11 @@ class Output(object):
         :return: the key value pair formatted in two columns for output
         """
         keylen = exact_width(key)
-        cols = self.term.columns
+        cols = self.term.real_columns
+        if not cols:
+            cols = sys_maxsize
+        elif cols < 20:
+            cols = 20
         nxt = ' ' * (keylen - 2) + ': '
         if not val:
             # textwrap.fill in case of empty val returns empty string

--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -1072,7 +1072,7 @@ class Output(object):
         problem_dependency = set(ng.problem_broken_dependency(available=True)) - problem_conflicts
         return problem_conflicts, problem_dependency
 
-    def list_transaction(self, transaction):
+    def list_transaction(self, transaction, total_width=None):
         """Return a string representation of the transaction in an
         easy-to-read format.
         """
@@ -1281,7 +1281,7 @@ class Output(object):
             data = [data['n'], {}, data['v'], data['r'], {}]
             columns = [1, a_wid, 1, 1, 5]
             columns = self.calcColumns(data, indent="  ", columns=columns,
-                                       remainder_column=2)
+                                       remainder_column=2, total_width=total_width)
             (n_wid, a_wid, v_wid, r_wid, s_wid) = columns
 
             # Do not use 'Package' without context. Using context resolves

--- a/dnf/pycomp.py
+++ b/dnf/pycomp.py
@@ -25,6 +25,7 @@ import email.mime.text
 import gettext
 import itertools
 import locale
+import sys
 import types
 
 PY3 = version_info.major >= 3
@@ -49,6 +50,7 @@ if PY3:
     urlparse = urllib.parse
     urllib_quote = urlparse.quote
     shlex_quote = shlex.quote
+    sys_maxsize = sys.maxsize
 
 
     def gettext_setup(t):
@@ -86,6 +88,7 @@ else:
     base64_decodebytes = base64.decodestring
     urllib_quote = urllib.quote
     shlex_quote = pipes.quote
+    sys_maxsize = sys.maxint
 
     def gettext_setup(t):
         _ = t.ugettext


### PR DESCRIPTION
The patch should change behavior of commands: search, repolist, and
info. Formally lines were cut if size of terminal was undetectable to
80. Now it should use very large lanes instead to allow a better output
with grep is used.

https://bugzilla.redhat.com/show_bug.cgi?id=1577889