### PR TITLE
Remove usage of goal.erase(selector=selector) (RhBug:1700529)

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1479,9 +1479,8 @@ class Base(object):
 
         remove_packages = query.intersection(unneeded_pkgs)
         if remove_packages:
-            sltr = dnf.selector.Selector(self.sack)
-            sltr.set(pkg=remove_packages)
-            self._goal.erase(select=sltr, clean_deps=self.conf.clean_requirements_on_remove)
+            for pkg in remove_packages:
+                self._goal.erase(pkg, clean_deps=self.conf.clean_requirements_on_remove)
 
     def _finalize_comps_trans(self):
         trans = self._comps_trans
@@ -2221,12 +2220,12 @@ class Base(object):
                     failed = True
                     continue
 
-            selector = dnf.selector.Selector(self.sack)
-            selector.set(pkg=query)
-
             if action == libdnf.transaction.TransactionItemAction_REMOVE:
-                self._goal.erase(select=selector)
+                for pkg in query:
+                    self._goal.erase(pkg)
             else:
+                selector = dnf.selector.Selector(self.sack)
+                selector.set(pkg=query)
                 self._goal.install(select=selector, optional=(not strict))
 
         if strict and failed:


### PR DESCRIPTION
It looks lite that in case goal.erase(selector=selector) with dependent
packages solver tries to reinstall package that has to be removed.

https://bugzilla.redhat.com/show_bug.cgi?id=1700529