### PR TITLE
Better help for command line arguments of dnf commands

### DIFF
--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -830,8 +830,7 @@ class HistoryCommand(Command):
         parser.add_argument('transactions_action', nargs='?', metavar="COMMAND",
                             help="Available commands: {} (default), {}".format(
                                 HistoryCommand._CMDS[0],
-                                ", ".join(HistoryCommand._CMDS[1:]),
-                                ))
+                                ", ".join(HistoryCommand._CMDS[1:])))
         parser.add_argument('transactions', nargs='*', metavar="TRANSACTION",
                             help="Transaction ID (<number>, 'last' or 'last-<number>' "
                                  "for one transaction, <transaction-id>..<transaction-id> "
@@ -852,6 +851,7 @@ class HistoryCommand(Command):
                                            ).format(self.opts.transactions_action)
         demands = self.cli.demands
         if self.opts.transactions_action in ['redo', 'undo', 'rollback']:
+            demands.root_user = True
             require_one_transaction_id = True
             if not self.opts.transactions:
                 msg = _('No transaction ID or package name given.')
@@ -865,7 +865,6 @@ class HistoryCommand(Command):
         else:
             demands.fresh_metadata = False
         demands.sack_activation = True
-        demands.root_user = True
         if not os.access(self.base.history.path, os.R_OK):
             msg = _("You don't have access to the history DB.")
             logger.critical(msg)

--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -194,7 +194,8 @@ class InfoCommand(Command):
                              help=_("show only recently changed packages"))
         parser.add_argument('packages', nargs='*', metavar=_('PACKAGE'),
                             choices=cls.pkgnarrows, default=cls.DEFAULT_PKGNARROW,
-                            action=OptionParser.PkgNarrowCallback)
+                            action=OptionParser.PkgNarrowCallback,
+                            help=_("Package name specification"))
 
     def configure(self):
         demands = self.cli.demands

--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -241,7 +241,8 @@ class ProvidesCommand(Command):
 
     @staticmethod
     def set_argparser(parser):
-        parser.add_argument('dependency', nargs='+', metavar=_('SOME_STRING'))
+        parser.add_argument('dependency', nargs='+', metavar=_('PROVIDE'),
+                            help=_("Provide specification to search for"))
 
     def configure(self):
         demands = self.cli.demands

--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -801,7 +801,8 @@ class HelpCommand(Command):
 
     @staticmethod
     def set_argparser(parser):
-        parser.add_argument('cmd', nargs='?', metavar=_('COMMAND'))
+        parser.add_argument('cmd', nargs='?', metavar=_('COMMAND'),
+                            help="DNF command to get help for")
 
     def run(self):
         if (not self.opts.cmd

--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -738,16 +738,6 @@ class RepoPkgsCommand(Command):
             alias: subcmd for subcmd in subcmd_objs for alias in subcmd.aliases}
 
     def set_argparser(self, parser):
-        subcommand_choices = [subcmd.aliases[0] for subcmd in self.SUBCMDS]
-        super(OptionParser, parser).add_argument(
-            'reponame', nargs=1, action=OptionParser._RepoCallbackEnable,
-            metavar=_('REPO'))
-        parser.add_argument('subcmd', nargs=1, choices=subcommand_choices)
-        DEFAULT_PKGNARROW = 'all'
-        pkgnarrows = {DEFAULT_PKGNARROW, 'installed', 'available',
-                      'autoremove', 'extras', 'obsoletes', 'recent',
-                      'upgrades'}
-
         narrows = parser.add_mutually_exclusive_group()
         narrows.add_argument('--all', dest='_pkg_specs_action',
                              action='store_const', const='all', default=None,
@@ -773,9 +763,21 @@ class RepoPkgsCommand(Command):
         narrows.add_argument('--recent', dest='_pkg_specs_action',
                              action='store_const', const='recent',
                              help=_("show only recently changed packages"))
+
+        parser.add_argument(
+            'reponame', nargs=1, action=OptionParser._RepoCallbackEnable,
+            metavar=_('REPOID'), help=_("Repository ID"))
+        subcommand_choices = [subcmd.aliases[0] for subcmd in self.SUBCMDS]
+        parser.add_argument('subcmd', nargs=1, metavar="SUBCOMMAND",
+                            choices=subcommand_choices, help=", ".join(subcommand_choices))
+        DEFAULT_PKGNARROW = 'all'
+        pkgnarrows = {DEFAULT_PKGNARROW, 'installed', 'available',
+                      'autoremove', 'extras', 'obsoletes', 'recent',
+                      'upgrades'}
         parser.add_argument('pkg_specs', nargs='*', metavar=_('PACKAGE'),
                             choices=pkgnarrows, default=DEFAULT_PKGNARROW,
-                            action=OptionParser.PkgNarrowCallback)
+                            action=OptionParser.PkgNarrowCallback,
+                            help=_("Package specification"))
 
     def configure(self):
         """Verify whether the command can run with given arguments."""

--- a/dnf/cli/commands/alias.py
+++ b/dnf/cli/commands/alias.py
@@ -41,9 +41,6 @@ class AliasCommand(commands.Command):
 
     @staticmethod
     def set_argparser(parser):
-        parser.add_argument("subcommand", nargs='?', default='list',
-                            choices=['add', 'list', 'delete'])
-        parser.add_argument("alias", nargs="*", metavar="command[=result]")
         enable_group = parser.add_mutually_exclusive_group()
         enable_group.add_argument(
             '--enable-resolving', default=False, action='store_true',
@@ -51,6 +48,11 @@ class AliasCommand(commands.Command):
         enable_group.add_argument(
             '--disable-resolving', default=False, action='store_true',
             help=_('disable aliases resolving'))
+        parser.add_argument("subcommand", nargs='?', default='list',
+                            choices=['add', 'list', 'delete'],
+                            help=_("action to do with aliases"))
+        parser.add_argument("alias", nargs="*", metavar="command[=result]",
+                            help=_("alias definition"))
 
     def configure(self):
         demands = self.cli.demands

--- a/dnf/cli/commands/alias.py
+++ b/dnf/cli/commands/alias.py
@@ -21,15 +21,16 @@
 from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
-from dnf.i18n import _
+
+import logging
+import os.path
 
 import dnf.cli
 import dnf.cli.aliases
 from dnf.cli import commands
 import dnf.conf
 import dnf.exceptions
-import logging
-import os.path
+from dnf.i18n import _
 
 logger = logging.getLogger('dnf')
 

--- a/dnf/cli/commands/group.py
+++ b/dnf/cli/commands/group.py
@@ -31,7 +31,6 @@ import logging
 
 logger = logging.getLogger("dnf")
 
-
 class GroupCommand(commands.Command):
     """ Single sub-command interface for most groups interaction. """
 
@@ -47,6 +46,7 @@ class GroupCommand(commands.Command):
     _CMD_ALIASES = {'update'     : 'upgrade',
                     'erase'      : 'remove'}
     _MARK_CMDS = ('install', 'remove')
+    _GROUP_SUBCOMMANDS = ('summary', 'list', 'info', 'remove', 'install', 'upgrade', 'mark')
 
 
     def _canonical(self):
@@ -318,8 +318,12 @@ class GroupCommand(commands.Command):
                                help=_("show only installed groups"))
         grpparser.add_argument('--available', action='store_true',
                                help=_("show only available groups"))
-        parser.add_argument('subcmd', nargs='?', metavar='COMMAND')
-        parser.add_argument('args', nargs='*')
+        parser.add_argument('subcmd', nargs='?', metavar='COMMAND',
+                            help=_('available subcommands: {} (default), {}').format(
+                                GroupCommand._GROUP_SUBCOMMANDS[0],
+                                ', '.join(GroupCommand._GROUP_SUBCOMMANDS[1:])))
+        parser.add_argument('args', nargs='*', metavar='COMMAND_ARG',
+                            help=_('argument for group subcommand'))
 
     def configure(self):
         self._canonical()
@@ -327,10 +331,9 @@ class GroupCommand(commands.Command):
         cmd = self.opts.subcmd
         args = self.opts.args
 
-        cmds = ('list', 'info', 'remove', 'install', 'upgrade', 'summary', 'mark')
-        if cmd not in cmds:
+        if cmd not in self._GROUP_SUBCOMMANDS:
             logger.critical(_('Invalid groups sub-command, use: %s.'),
-                            ", ".join(cmds))
+                            ", ".join(self._GROUP_SUBCOMMANDS))
             raise dnf.cli.CliError
         if cmd in ('install', 'remove', 'mark', 'info') and not args:
             self.cli.optparser.print_help(self)

--- a/dnf/cli/commands/group.py
+++ b/dnf/cli/commands/group.py
@@ -51,7 +51,7 @@ class GroupCommand(commands.Command):
 
     def _canonical(self):
         # were we called with direct command?
-        direct = self.direct_commands.get(self.opts.command[0])
+        direct = self.direct_commands.get(self.opts.command)
         if direct:
             # canonize subcmd and args
             if self.opts.subcmd is not None:

--- a/dnf/cli/commands/mark.py
+++ b/dnf/cli/commands/mark.py
@@ -41,8 +41,11 @@ class MarkCommand(commands.Command):
     @staticmethod
     def set_argparser(parser):
         parser.add_argument('mark', nargs=1, choices=['install', 'remove', 'group'],
-                            metavar='[ install | remove | group ]')
-        parser.add_argument('package', nargs='+')
+                            help=_("install: mark as installed by user, "
+                                   "remove: unmark as installed by user, "
+                                   "group: mark as installed by group"))
+        parser.add_argument('package', nargs='+', metavar="PACKAGE",
+                            help=_("Package specification"))
 
     def _mark_install(self, pkg):
         self.base.history.set_reason(pkg, libdnf.transaction.TransactionItemReason_USER)

--- a/dnf/cli/commands/module.py
+++ b/dnf/cli/commands/module.py
@@ -307,5 +307,5 @@ class ModuleCommand(commands.Command):
         if self.opts.subcmd[0] not in not_required_argument:
             if not self.opts.module_spec:
                 raise CliError(
-                    "dnf {} {}: too few arguments".format(self.opts.command[0],
+                    "dnf {} {}: too few arguments".format(self.opts.command,
                                                           self.opts.subcmd[0]))

--- a/dnf/cli/commands/module.py
+++ b/dnf/cli/commands/module.py
@@ -269,10 +269,6 @@ class ModuleCommand(commands.Command):
             alias: subcmd for subcmd in subcmd_objs for alias in subcmd.aliases}
 
     def set_argparser(self, parser):
-        subcommand_help = [subcmd.aliases[0] for subcmd in self.SUBCMDS]
-        parser.add_argument('subcmd', nargs=1, choices=subcommand_help)
-        parser.add_argument('module_spec', metavar='module-spec', nargs='*')
-
         narrows = parser.add_mutually_exclusive_group()
         narrows.add_argument('--enabled', dest='enabled',
                              action='store_true',
@@ -286,6 +282,12 @@ class ModuleCommand(commands.Command):
         narrows.add_argument('--profile', dest='profile',
                              action='store_true',
                              help=_("show profile content"))
+
+        subcommand_help = [subcmd.aliases[0] for subcmd in self.SUBCMDS]
+        parser.add_argument('subcmd', nargs=1, choices=subcommand_help,
+                            help=_("Modular command"))
+        parser.add_argument('module_spec', metavar='module-spec', nargs='*',
+                            help=_("Module specification"))
 
     def configure(self):
         try:

--- a/dnf/cli/commands/repolist.py
+++ b/dnf/cli/commands/repolist.py
@@ -86,9 +86,10 @@ class RepoListCommand(commands.Command):
         repolimit.add_argument('--disabled', dest='_repos_action',
                                action='store_const', const='disabled',
                                help=_("show disabled repos"))
-        parser.add_argument('repos', nargs='*', default='enabled',
+        parser.add_argument('repos', nargs='*', default='enabled', metavar="REPOSITORY",
                             choices=['all', 'enabled', 'disabled'],
-                            action=OptionParser.PkgNarrowCallback)
+                            action=OptionParser.PkgNarrowCallback,
+                            help=_("Repository specification"))
 
     def pre_configure(self):
         if not self.opts.verbose and not self.opts.quiet:

--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -114,8 +114,6 @@ class RepoQueryCommand(commands.Command):
 
     @staticmethod
     def set_argparser(parser):
-        parser.add_argument('key', nargs='*',
-                            help=_('the key to search for'))
         parser.add_argument('-a', '--all', dest='queryall', action='store_true',
                             help=_("Query all packages (shorthand for repoquery '*' "
                                    "or repoquery without argument)"))
@@ -260,6 +258,9 @@ class RepoQueryCommand(commands.Command):
             '--autoremove', dest='list', action='store_const',
             const="unneeded", help=argparse.SUPPRESS)
         parser.add_argument('--recent', action="store_true", help=_('Display only recently edited packages'))
+
+        parser.add_argument('key', nargs='*', metavar="KEY",
+                            help=_('the key to search for'))
 
     def pre_configure(self):
         if not self.opts.verbose and not self.opts.quiet:

--- a/dnf/cli/commands/search.py
+++ b/dnf/cli/commands/search.py
@@ -49,9 +49,10 @@ class SearchCommand(commands.Command):
     def set_argparser(parser):
         parser.add_argument('--all', action='store_true',
                             help=_("search also package description and URL"))
-        parser.add_argument('query_string', nargs='+', metavar=_('QUERY_STRING'),
+        parser.add_argument('query_string', nargs='+', metavar=_('KEYWORD'),
                             choices=['all'], default=None,
-                            action=OptionParser.PkgNarrowCallback)
+                            action=OptionParser.PkgNarrowCallback,
+                            help=_("Keyword to search for"))
 
     def _search(self, args):
         """Search for simple text tags in a package object."""

--- a/dnf/cli/commands/shell.py
+++ b/dnf/cli/commands/shell.py
@@ -102,6 +102,8 @@ class ShellCommand(commands.Command, cmd.Cmd):
         except:
             self._help()
             return
+        # reset option parser before each command, keep usage information
+        self.cli.optparser.__init__(reset_usage=False)
         opts = self.cli.optparser.parse_main_args(s_line)
         # Disable shell recursion.
         if opts.command == 'shell':

--- a/dnf/cli/commands/updateinfo.py
+++ b/dnf/cli/commands/updateinfo.py
@@ -96,7 +96,8 @@ class UpdateInfoCommand(commands.Command):
                                    help=_('show info of advisories'))
         parser.add_argument('spec', nargs='*', metavar='SPEC',
                             choices=cmds, default=cmds[0],
-                            action=OptionParser.PkgNarrowCallback)
+                            action=OptionParser.PkgNarrowCallback,
+                            help=_("Package specification"))
 
     def configure(self):
         """Do any command-specific configuration based on command arguments."""

--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -36,15 +36,13 @@ logger = logging.getLogger("dnf")
 class OptionParser(argparse.ArgumentParser):
     """ArgumentParser like class to do things the "yum way"."""
 
-    def reset_parser(self):
+    def __init__(self, reset_usage=True):
         super(OptionParser, self).__init__(add_help=False)
         self.command_positional_parser = None
         self._add_general_options()
-
-    def __init__(self):
-        self.reset_parser()
-        self._cmd_usage = {} # names, summary for dnf commands, to build usage
-        self._cmd_groups = set() # cmd groups added (main, plugin)
+        if reset_usage:
+            self._cmd_usage = {}      # names, summary for dnf commands, to build usage
+            self._cmd_groups = set()  # cmd groups added (main, plugin)
 
     def error(self, msg):
         """Output an error message, and exit the program.

--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -36,12 +36,15 @@ logger = logging.getLogger("dnf")
 class OptionParser(argparse.ArgumentParser):
     """ArgumentParser like class to do things the "yum way"."""
 
+    def reset_parser(self):
+        super(OptionParser, self).__init__(add_help=False)
+        self.command_positional_parser = None
+        self._add_general_options()
+
     def __init__(self):
-        super(OptionParser, self).__init__()
+        self.reset_parser()
         self._cmd_usage = {} # names, summary for dnf commands, to build usage
         self._cmd_groups = set() # cmd groups added (main, plugin)
-        self.main_parser = self._main_parser()
-        self.command_arg_parser = None
 
     def error(self, msg):
         """Output an error message, and exit the program.
@@ -148,97 +151,96 @@ class OptionParser(argparse.ArgumentParser):
             namespace.ignorearch = True
             namespace.arch = values
 
-    def _main_parser(self):
+    def _add_general_options(self):
         """ Standard options known to all dnf subcommands. """
         # All defaults need to be a None, so we can always tell whether the user
         # has set something or whether we are getting a default.
-        main_parser = argparse.ArgumentParser(add_help=False)
-        main_parser._optionals.title = _("Optional arguments")
-        main_parser.add_argument("-c", "--config", dest="config_file_path",
+        general_grp = self.add_argument_group('General DNF options')
+        general_grp.add_argument("-c", "--config", dest="config_file_path",
                                  default=None, metavar='[config file]',
                                  help=_("config file location"))
-        main_parser.add_argument("-q", "--quiet", dest="quiet",
+        general_grp.add_argument("-q", "--quiet", dest="quiet",
                                  action="store_true", default=None,
                                  help=_("quiet operation"))
-        main_parser.add_argument("-v", "--verbose", action="store_true",
+        general_grp.add_argument("-v", "--verbose", action="store_true",
                                  default=None, help=_("verbose operation"))
-        main_parser.add_argument("--version", action="store_true", default=None,
+        general_grp.add_argument("--version", action="store_true", default=None,
                                  help=_("show DNF version and exit"))
-        main_parser.add_argument("--installroot", help=_("set install root"),
+        general_grp.add_argument("--installroot", help=_("set install root"),
                                  metavar='[path]')
-        main_parser.add_argument("--nodocs", action="store_const", const=['nodocs'], dest='tsflags',
+        general_grp.add_argument("--nodocs", action="store_const", const=['nodocs'], dest='tsflags',
                                  help=_("do not install documentations"))
-        main_parser.add_argument("--noplugins", action="store_false",
+        general_grp.add_argument("--noplugins", action="store_false",
                                  default=None, dest='plugins',
                                  help=_("disable all plugins"))
-        main_parser.add_argument("--enableplugin", dest="enableplugin",
+        general_grp.add_argument("--enableplugin", dest="enableplugin",
                                  default=[], action=self._SplitCallback,
                                  help=_("enable plugins by name"),
                                  metavar='[plugin]')
-        main_parser.add_argument("--disableplugin", dest="disableplugin",
+        general_grp.add_argument("--disableplugin", dest="disableplugin",
                                  default=[], action=self._SplitCallback,
                                  help=_("disable plugins by name"),
                                  metavar='[plugin]')
-        main_parser.add_argument("--releasever", default=None,
+        general_grp.add_argument("--releasever", default=None,
                                  help=_("override the value of $releasever"
                                         " in config and repo files"))
-        main_parser.add_argument("--setopt", dest="setopts", default=[],
+        general_grp.add_argument("--setopt", dest="setopts", default=[],
                                  action=self._SetoptsCallback,
                                  help=_("set arbitrary config and repo options"))
-        main_parser.add_argument("--skip-broken", dest="skip_broken", action="store_true",
+        general_grp.add_argument("--skip-broken", dest="skip_broken", action="store_true",
                                  default=None,
                                  help=_("resolve depsolve problems by skipping packages"))
-        main_parser.add_argument('-h', '--help', '--help-cmd',
+        general_grp.add_argument('-h', '--help', '--help-cmd',
                                  action="store_true", dest='help',
                                  help=_("show command help"))
 
-        main_parser.add_argument('--allowerasing', action='store_true',
+        general_grp.add_argument('--allowerasing', action='store_true',
                                  default=None,
                                  help=_('allow erasing of installed packages to '
                                         'resolve dependencies'))
-        best_group = main_parser.add_mutually_exclusive_group()
+        best_group = general_grp.add_mutually_exclusive_group()
         best_group.add_argument("-b", "--best", action="store_true", dest='best', default=None,
                                 help=_("try the best available package versions in transactions."))
         best_group.add_argument("--nobest", action="store_false", dest='best',
                                 help=_("do not limit the transaction to the best candidate"))
-        main_parser.add_argument("-C", "--cacheonly", dest="cacheonly",
+        general_grp.add_argument("-C", "--cacheonly", dest="cacheonly",
                                  action="store_true", default=None,
                                  help=_("run entirely from system cache, "
                                         "don't update cache"))
-        main_parser.add_argument("-R", "--randomwait", dest="sleeptime", type=int,
+        general_grp.add_argument("-R", "--randomwait", dest="sleeptime", type=int,
                                  default=None, metavar='[minutes]',
                                  help=_("maximum command wait time"))
-        main_parser.add_argument("-d", "--debuglevel", dest="debuglevel",
+        general_grp.add_argument("-d", "--debuglevel", dest="debuglevel",
                                  metavar='[debug level]', default=None,
                                  help=_("debugging output level"), type=int)
-        main_parser.add_argument("--debugsolver",
+        general_grp.add_argument("--debugsolver",
                                  action="store_true", default=None,
                                  help=_("dumps detailed solving results into"
                                         " files"))
-        main_parser.add_argument("--showduplicates", dest="showdupesfromrepos",
+        general_grp.add_argument("--showduplicates", dest="showdupesfromrepos",
                                  action="store_true", default=None,
                                  help=_("show duplicates, in repos, "
                                         "in list/search commands"))
-        main_parser.add_argument("-e", "--errorlevel", default=None, type=int,
+        general_grp.add_argument("-e", "--errorlevel", default=None, type=int,
                                  help=_("error output level"))
-        main_parser.add_argument("--obsoletes", default=None, dest="obsoletes",
+        general_grp.add_argument("--obsoletes", default=None, dest="obsoletes",
                                  action="store_true",
                                  help=_("enables dnf's obsoletes processing logic "
                                         "for upgrade or display capabilities that "
                                         "the package obsoletes for info, list and repoquery"))
-        main_parser.add_argument("--rpmverbosity", default=None,
+        general_grp.add_argument("--rpmverbosity", default=None,
                                  help=_("debugging output level for rpm"),
                                  metavar='[debug level name]')
-        main_parser.add_argument("-y", "--assumeyes", action="store_true",
+        general_grp.add_argument("-y", "--assumeyes", action="store_true",
                                  default=None, help=_("automatically answer yes"
                                                       " for all questions"))
-        main_parser.add_argument("--assumeno", action="store_true",
+        general_grp.add_argument("--assumeno", action="store_true",
                                  default=None, help=_("automatically answer no"
                                                       " for all questions"))
-        main_parser.add_argument("--enablerepo", action=self._RepoCallback,
+        general_grp.add_argument("--enablerepo", action=self._RepoCallback,
                                  dest='repos_ed', default=[],
                                  metavar='[repo]')
-        repo_group = main_parser.add_mutually_exclusive_group()
+        repo_group = general_grp.add_mutually_exclusive_group()
         repo_group.add_argument("--disablerepo", action=self._RepoCallback,
                                 dest='repos_ed', default=[],
                                 metavar='[repo]')
@@ -246,7 +248,7 @@ class OptionParser(argparse.ArgumentParser):
                                 action=self._SplitCallback, default=[],
                                 help=_('enable just specific repositories by an id or a glob, '
                                        'can be specified multiple times'))
-        enable_group = main_parser.add_mutually_exclusive_group()
+        enable_group = general_grp.add_mutually_exclusive_group()
         enable_group.add_argument("--enable", "--set-enabled", default=False,
                                   dest="set_enabled", action="store_true",
                                   help=_("enable repos with config-manager "
@@ -255,93 +257,80 @@ class OptionParser(argparse.ArgumentParser):
                                   dest="set_disabled", action="store_true",
                                   help=_("disable repos with config-manager "
                                          "command (automatically saves)"))
-        main_parser.add_argument("-x", "--exclude", "--excludepkgs", default=[],
+        general_grp.add_argument("-x", "--exclude", "--excludepkgs", default=[],
                                  dest='excludepkgs', action=self._SplitCallback,
                                  help=_("exclude packages by name or glob"),
                                  metavar='[package]')
-        main_parser.add_argument("--disableexcludes", "--disableexcludepkgs",
+        general_grp.add_argument("--disableexcludes", "--disableexcludepkgs",
                                  default=[], dest="disable_excludes",
                                  action=self._SplitCallback,
                                  help=_("disable excludepkgs"),
                                  metavar='[repo]')
-        main_parser.add_argument("--repofrompath", default={},
+        general_grp.add_argument("--repofrompath", default={},
                                  action=self._SplitExtendDictCallback,
                                  metavar='[repo,path]',
                                  help=_("label and path to additional repository,"
                                         " can be specified multiple times."))
-        main_parser.add_argument("--noautoremove", action="store_false",
+        general_grp.add_argument("--noautoremove", action="store_false",
                                  default=None, dest='clean_requirements_on_remove',
                                  help=_("disable removal of dependencies that are no longer used"))
-        main_parser.add_argument("--nogpgcheck", action="store_false",
+        general_grp.add_argument("--nogpgcheck", action="store_false",
                                  default=None, dest='gpgcheck',
                                  help=_("disable gpg signature checking (if RPM policy allows)"))
-        main_parser.add_argument("--color", dest="color", default=None,
+        general_grp.add_argument("--color", dest="color", default=None,
                                  help=_("control whether color is used"))
-        main_parser.add_argument("--refresh", dest="freshest_metadata",
+        general_grp.add_argument("--refresh", dest="freshest_metadata",
                                  action="store_true",
                                  help=_("set metadata as expired before running"
                                         " the command"))
-        main_parser.add_argument("-4", dest="ip_resolve", default=None,
+        general_grp.add_argument("-4", dest="ip_resolve", default=None,
                                  help=_("resolve to IPv4 addresses only"),
                                  action="store_const", const='ipv4')
-        main_parser.add_argument("-6", dest="ip_resolve", default=None,
+        general_grp.add_argument("-6", dest="ip_resolve", default=None,
                                  help=_("resolve to IPv6 addresses only"),
                                  action="store_const", const='ipv6')
-        main_parser.add_argument("--destdir", "--downloaddir", dest="destdir", default=None,
+        general_grp.add_argument("--destdir", "--downloaddir", dest="destdir", default=None,
                                  help=_("set directory to copy packages to"))
-        main_parser.add_argument("--downloadonly", dest="downloadonly",
+        general_grp.add_argument("--downloadonly", dest="downloadonly",
                                  action="store_true", default=False,
                                  help=_("only download packages"))
-        main_parser.add_argument("--comment", dest="comment", default=None,
+        general_grp.add_argument("--comment", dest="comment", default=None,
                                  help=_("add a comment to transaction"))
         # Updateinfo options...
-        main_parser.add_argument("--bugfix", action="store_true",
+        general_grp.add_argument("--bugfix", action="store_true",
                                  help=_("Include bugfix relevant packages, "
                                         "in updates"))
-        main_parser.add_argument("--enhancement", action="store_true",
+        general_grp.add_argument("--enhancement", action="store_true",
                                  help=_("Include enhancement relevant packages,"
                                         " in updates"))
-        main_parser.add_argument("--newpackage", action="store_true",
+        general_grp.add_argument("--newpackage", action="store_true",
                                  help=_("Include newpackage relevant packages,"
                                         " in updates"))
-        main_parser.add_argument("--security", action="store_true",
+        general_grp.add_argument("--security", action="store_true",
                                  help=_("Include security relevant packages, "
                                         "in updates"))
-        main_parser.add_argument("--advisory", "--advisories", dest="advisory",
+        general_grp.add_argument("--advisory", "--advisories", dest="advisory",
                                  default=[], action=self._SplitCallback,
                                  help=_("Include packages needed to fix the "
                                         "given advisory, in updates"))
-        main_parser.add_argument("--bz", "--bzs", default=[], dest="bugzilla",
+        general_grp.add_argument("--bz", "--bzs", default=[], dest="bugzilla",
                                  action=self._SplitCallback, help=_(
                 "Include packages needed to fix the given BZ, in updates"))
-        main_parser.add_argument("--cve", "--cves", default=[], dest="cves",
+        general_grp.add_argument("--cve", "--cves", default=[], dest="cves",
                                  action=self._SplitCallback,
                                  help=_("Include packages needed to fix the given CVE, in updates"))
-        main_parser.add_argument(
+        general_grp.add_argument(
             "--sec-severity", "--secseverity",
             choices=['Critical', 'Important', 'Moderate', 'Low'], default=[],
             dest="severity", action=self._SplitCallback, help=_(
                 "Include security relevant packages matching the severity, "
                 "in updates"))
-        main_parser.add_argument("--forcearch", metavar="ARCH",
+        general_grp.add_argument("--forcearch", metavar="ARCH",
                                  dest=argparse.SUPPRESS,
                                  action=self.ForceArchAction,
                                  choices=sorted(dnf.rpm._BASEARCH_MAP.keys()),
                                  help=_("Force the use of an architecture"))
-        return main_parser
-
-    def _command_parser(self, command):
-        parser = argparse.ArgumentParser()
-        prog = "%s %s" % (parser.prog, command._basecmd)
-        super(OptionParser, self).__init__(prog, add_help=False,
-                                           parents=[self.main_parser],
-                                           description=command.summary)
-        super(OptionParser, self).add_argument('command', nargs=1,
-                                               help=argparse.SUPPRESS)
-        self.command_arg_parser = argparse.ArgumentParser(prog, add_help=False)
-        self.command_arg_parser.print_usage = self.print_usage
-        command.set_argparser(self)
-        return self
+        general_grp.add_argument('command', nargs='?', help=argparse.SUPPRESS)
 
     def _add_cmd_usage(self, cmd, group):
         """ store usage info about a single dnf command."""
@@ -377,38 +366,45 @@ class OptionParser(argparse.ArgumentParser):
                     usage += "%-25s %s\n" % (name, summary)
         return usage
 
-    def add_argument(self, *args, **kwargs):
-        # process options and arguments separately
+    def _add_command_options(self, command):
+        self.prog = "%s %s" % (self.prog, command._basecmd)
+        self.description = command.summary
+        self.command_positional_parser = argparse.ArgumentParser(self.prog, add_help=False)
+        self.command_positional_parser.print_usage = self.print_usage
+        self.command_positional_parser._positionals.title = None
+        self.command_group = self.add_argument_group(
+            '{} command-specific options'.format(command._basecmd.capitalize()))
+        self.command_group.add_argument = self.cmd_add_argument
+        command.set_argparser(self.command_group)
+
+    def cmd_add_argument(self, *args, **kwargs):
         if all([(arg[0] in self.prefix_chars) for arg in args]):
-            return super(OptionParser, self).add_argument(*args, **kwargs)
+            return type(self.command_group).add_argument(self.command_group, *args, **kwargs)
         else:
-            return self.command_arg_parser.add_argument(*args, **kwargs)
+            return self.command_positional_parser.add_argument(*args, **kwargs)
 
     def parse_main_args(self, args):
-        parser = argparse.ArgumentParser(add_help=False,
-                                         parents=[self.main_parser])
-        parser.add_argument('command', nargs='?', help=argparse.SUPPRESS)
-        namespace, _unused_args = parser.parse_known_args(args)
+        namespace, _unused_args = self.parse_known_args(args)
         return namespace
 
     def parse_command_args(self, command, args):
-        self._command_parser(command)
-        namespace, extras = super(OptionParser,
-                                  self).parse_known_args(args)
-        command.opts = self.command_arg_parser.parse_args(extras, namespace)
+        self._add_command_options(command)
+        namespace, unused_args = self.parse_known_args(args)
+        namespace = self.command_positional_parser.parse_args(unused_args, namespace)
+        command.opts = namespace
         return command.opts
 
     def print_usage(self, file_=None):
-        # pylint: disable=E0202,W0212
-        self._actions += self.command_arg_parser._actions
+        if self.command_positional_parser:
+            self._actions += self.command_positional_parser._actions
         super(OptionParser, self).print_usage(file_)
 
     def print_help(self, command=None):
         # pylint: disable=W0212
         if command:
-            cp = self._command_parser(command)
-            cp._actions += cp.command_arg_parser._actions
-            super(OptionParser, cp).print_help()
+            self._add_command_options(command)
+            self._actions += self.command_positional_parser._actions
+            self._action_groups.append(self.command_positional_parser._positionals)
         else:
-            self.main_parser.usage = self.get_usage()
-            self.main_parser.print_help()
+            self.usage = self.get_usage()
+        super(OptionParser, self).print_help()

--- a/tests/cli/test_option_parser.py
+++ b/tests/cli/test_option_parser.py
@@ -46,7 +46,7 @@ class OptionParserTest(tests.support.TestCase):
 
     def test_parse(self):
         parser, opts = _parse(self.command, ['update', '--nogpgcheck'])
-        self.assertEqual(opts.command, ['update'])
+        self.assertEqual(opts.command, 'update')
         self.assertFalse(opts.gpgcheck)
         self.assertIsNone(opts.color)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -128,7 +128,7 @@ class CliTest(tests.support.DnfBaseTestCase):
         for param in params:
             self.cli.configure(args=param)
             self.assertTrue(self.base.conf.assumeyes)
-            self.assertEqual(self.cli.command.opts.command, ["install"])
+            self.assertEqual(self.cli.command.opts.command, "install")
             self.assertEqual(self.cli.command.opts.pkg_specs, ["pkg1", "pkg2"])
 
     def test_configure_repos(self, _):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -241,7 +241,7 @@ class RepoPkgsCommandTest(tests.support.DnfBaseTestCase):
                 tests.support.patch_std_streams() as (stdout, stderr), \
                 mock.patch('logging.Logger.critical'):
             tests.support.command_configure(self.cmd, [])
-        self.assertEqual(exit.exception.code, 1)
+        self.assertEqual(exit.exception.code, 2)
 
 
 class RepoPkgsCheckUpdateSubCommandTest(tests.support.DnfBaseTestCase):


### PR DESCRIPTION
Help for dnf commands is now divided into two parts - "General DNF options"
and "Command specific options". This commit also prevents mixing
options from these two distinct groups together which was previous behaviour
for argument from mutually exclusive groups (e.g. --best/--nobest).
Also the command specific options are printed later - under the general ones,
so the user sees them on the screen without need to scroll up.