### PR TITLE
Set error when "-c" option requires nonexistent file (RhBug:1512457)

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -985,6 +985,12 @@ class Cli(object):
         # search config file inside the installroot first
         conf._search_inside_installroot('config_file_path')
 
+        # check whether a config file is requested from command line and the file exists
+        filename = conf._get_value('config_file_path')
+        if (conf._get_priority('config_file_path') == dnf.conf.PRIO_COMMANDLINE) and \
+                not os.path.isfile(filename):
+            raise dnf.exceptions.ConfigError(_('Config file "{}" does not exist').format(filename))
+
         # read config
         conf.read(priority=dnf.conf.PRIO_MAINCONFIG)
 


### PR DESCRIPTION
Fix of the following problem: When you feed "-c" option in `dnf -c /etc/does-not-exist.conf`
with nonexistent file, dnf still returns 0. This is difference compared to yum.

Test in ci-dnf-stack: [PR #546](https://github.com/rpm-software-management/ci-dnf-stack/pull/546)

https://bugzilla.redhat.com/show_bug.cgi?id=1512457

Signed-off-by: Jan Beran <jberan@redhat.com>