### PR TITLE
[spec] Fix-up yum conflict

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -154,11 +154,13 @@ Common data and configuration files for DNF
 %package -n %{yum_subpackage_name}
 Requires:       %{name} = %{version}-%{release}
 Summary:        %{pkg_summary}
+%if 0%{?fedora}
 %if 0%{?fedora} >= 31
 Provides:       %{name}-yum = %{version}-%{release}
 Obsoletes:      %{name}-yum < %{version}-%{release}
 %else
 Conflicts:      yum < 3.4.3-505
+%endif
 %endif
 
 %description -n %{yum_subpackage_name}


### PR DESCRIPTION
In commit 519593cb, I dropped the conflict on "yum" for fedora >= 31 (so
that I could rename the "dnf-yum" subpackage to "yum" in follow-up
commits).

However, I accidentally removed the outer %if macro as well.  As a
result, we now conflict with the stock yum-3 on RHEL-7.  Not nice.

This commit puts back the outer %if to fix that.