### PR TITLE
[transaction] Set an error for first tsi in unknown state

### DIFF
--- a/dnf/yum/rpmtrans.py
+++ b/dnf/yum/rpmtrans.py
@@ -386,6 +386,10 @@ class RPMTransaction(object):
         msg = "Error unpacking rpm package %s" % tsi.pkg
         for display in self.displays:
             display.error(msg)
+        for tsi1 in transaction_list:
+            if tsi1.state == libdnf.transaction.TransactionItemState_UNKNOWN:
+                tsi1.state = libdnf.transaction.TransactionItemState_ERROR
+                return
         tsi.state = libdnf.transaction.TransactionItemState_ERROR
 
     def _scriptError(self, amount, total, key):


### PR DESCRIPTION
It should prevent "TransactionItem state is not set" in case of multiple
same NEVRASs and single with an error.