### PR TITLE
[repoquery] Do not use updateFailSafeData at all

### DIFF
--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -404,7 +404,6 @@ class RepoQueryCommand(commands.Command):
             print(_('Available query-tags: use --queryformat ".. %{tag} .."'))
             print(QUERY_TAGS)
             return
-        self.base._moduleContainer.updateFailSafeData()
 
         self.cli._populate_update_security_filter(self.opts, self.base.sack.query())
 


### PR DESCRIPTION
Repoquery command works read only, it doesn't run any
transaction / module operation. That said saving the fail safe
data is unnecessary.