### PR TITLE
Prevent printing empty Error Summary (RhBug: 1690414)

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -858,8 +858,12 @@ class Base(object):
                 for descr in tserrors:
                     errstring += '  %s\n' % ucd(descr)
 
-                raise dnf.exceptions.Error(errstring + '\n' +
-                                        self._trans_error_summary(errstring))
+                summary = self._trans_error_summary(errstring)
+                if summary:
+                    errstring += '\n' + summary
+
+                raise dnf.exceptions.Error(errstring)
+
 
             logger.info(_('Transaction test succeeded.'))
             timer()
@@ -910,6 +914,9 @@ class Base(object):
                     'At least %dMB more space needed on the %s filesystem.',
                     'At least %dMB more space needed on the %s filesystem.',
                     disk[k]) % (disk[k], k) + '\n'
+
+        if not summary:
+            return None
 
         summary = _('Error Summary') + '\n-------------\n' + summary
 


### PR DESCRIPTION
When test transaction fails we generate Error Summary but it contains
information only if the error happened because of lacking disk space
otherwise we get the headline "Error Summary" without any text this
commit prevents this.