### PR TITLE
Fix the debugsource package name

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -79,7 +79,7 @@
 It supports RPMs, modules and comps groups & environments.
 
 Name:           dnf
-Version:        4.2.9
+Version:        4.2.10
 Release:        1%{?dist}
 Summary:        %{pkg_summary}
 # For a breakdown of the licensing, see PACKAGE-LICENSING

--- a/dnf/package.py
+++ b/dnf/package.py
@@ -83,6 +83,15 @@ class Package(hawkey.Package):
         return name + self.DEBUGINFO_SUFFIX
 
     @property
+    def debugsource_name(self):
+        # :api
+        """
+        Returns name of the debugsource package for this package.
+        e.g. krb5-libs -> krb5-debugsource
+        """
+        return self.source_name + self.DEBUGSOURCE_SUFFIX
+
+    @property
     def _from_cmdline(self):
         return self.reponame == hawkey.CMDLINE_REPO_NAME
 

--- a/dnf/package.py
+++ b/dnf/package.py
@@ -38,6 +38,9 @@ logger = logging.getLogger("dnf")
 class Package(hawkey.Package):
     """ Represents a package. #:api """
 
+    DEBUGINFO_SUFFIX = "-debuginfo"  # :api
+    DEBUGSOURCE_SUFFIX = "-debugsource"  # :api
+
     def __init__(self, initobject, base):
         super(Package, self).__init__(initobject)
         self.base = base
@@ -64,10 +67,20 @@ class Package(hawkey.Package):
     def debug_name(self):
         # :api
         """
-        returns name of debuginfo package for given package
+        Returns name of the debuginfo package for this package.
+        If this package is a debuginfo package, returns its name.
+        If this package is a debugsource package, returns the debuginfo package
+        for the base package.
         e.g. kernel-PAE -> kernel-PAE-debuginfo
         """
-        return "{}-debuginfo".format(self.name)
+        if self.name.endswith(self.DEBUGINFO_SUFFIX):
+            return self.name
+
+        name = self.name
+        if self.name.endswith(self.DEBUGSOURCE_SUFFIX):
+            name = name[:-len(self.DEBUGSOURCE_SUFFIX)]
+
+        return name + self.DEBUGINFO_SUFFIX
 
     @property
     def _from_cmdline(self):
@@ -109,7 +122,7 @@ class Package(hawkey.Package):
         returns name of debuginfo package for source package of given package
         e.g. krb5-libs -> krb5-debuginfo
         """
-        return "{}-debuginfo".format(self.source_name)
+        return self.source_name + self.DEBUGINFO_SUFFIX
 
     @property
     def source_name(self):

--- a/dnf/package.py
+++ b/dnf/package.py
@@ -64,34 +64,6 @@ class Package(hawkey.Package):
         self._priv_chksum = val
 
     @property
-    def debug_name(self):
-        # :api
-        """
-        Returns name of the debuginfo package for this package.
-        If this package is a debuginfo package, returns its name.
-        If this package is a debugsource package, returns the debuginfo package
-        for the base package.
-        e.g. kernel-PAE -> kernel-PAE-debuginfo
-        """
-        if self.name.endswith(self.DEBUGINFO_SUFFIX):
-            return self.name
-
-        name = self.name
-        if self.name.endswith(self.DEBUGSOURCE_SUFFIX):
-            name = name[:-len(self.DEBUGSOURCE_SUFFIX)]
-
-        return name + self.DEBUGINFO_SUFFIX
-
-    @property
-    def debugsource_name(self):
-        # :api
-        """
-        Returns name of the debugsource package for this package.
-        e.g. krb5-libs -> krb5-debugsource
-        """
-        return self.source_name + self.DEBUGSOURCE_SUFFIX
-
-    @property
     def _from_cmdline(self):
         return self.reponame == hawkey.CMDLINE_REPO_NAME
 
@@ -125,13 +97,11 @@ class Package(hawkey.Package):
         self._priv_size = val
 
     @property
-    def source_debug_name(self):
-        # :api
-        """
-        returns name of debuginfo package for source package of given package
-        e.g. krb5-libs -> krb5-debuginfo
-        """
-        return self.source_name + self.DEBUGINFO_SUFFIX
+    def _pkgid(self):
+        if self.hdr_chksum is None:
+            return None
+        (_, chksum) = self.hdr_chksum
+        return binascii.hexlify(chksum)
 
     @property
     def source_name(self):
@@ -154,11 +124,41 @@ class Package(hawkey.Package):
         return srcname
 
     @property
-    def _pkgid(self):
-        if self.hdr_chksum is None:
-            return None
-        (_, chksum) = self.hdr_chksum
-        return binascii.hexlify(chksum)
+    def debug_name(self):
+        # :api
+        """
+        Returns name of the debuginfo package for this package.
+        If this package is a debuginfo package, returns its name.
+        If this package is a debugsource package, returns the debuginfo package
+        for the base package.
+        e.g. kernel-PAE -> kernel-PAE-debuginfo
+        """
+        if self.name.endswith(self.DEBUGINFO_SUFFIX):
+            return self.name
+
+        name = self.name
+        if self.name.endswith(self.DEBUGSOURCE_SUFFIX):
+            name = name[:-len(self.DEBUGSOURCE_SUFFIX)]
+
+        return name + self.DEBUGINFO_SUFFIX
+
+    @property
+    def debugsource_name(self):
+        # :api
+        """
+        Returns name of the debugsource package for this package.
+        e.g. krb5-libs -> krb5-debugsource
+        """
+        return self.source_name + self.DEBUGSOURCE_SUFFIX
+
+    @property
+    def source_debug_name(self):
+        # :api
+        """
+        returns name of debuginfo package for source package of given package
+        e.g. krb5-libs -> krb5-debuginfo
+        """
+        return self.source_name + self.DEBUGINFO_SUFFIX
 
     @property # yum compatibility attribute
     def idx(self):


### PR DESCRIPTION
Return the proper debugsource package name instead of the debuginfo name
from Package.source_debug_name().

https://bugzilla.redhat.com/show_bug.cgi?id=1586084