### PR TITLE
Do not run _configure_from_options twice

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -965,8 +965,6 @@ class Cli(object):
 
         self.base.configure_plugins()
 
-        self.base.conf._configure_from_options(opts)
-
         self.command.configure()
 
         if self.base.conf.destdir:

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -951,10 +951,6 @@ class Cli(object):
             self.base._allow_erasing = True
         if opts.freshest_metadata:
             self.demands.freshest_metadata = opts.freshest_metadata
-        if opts.debugsolver:
-            self.base.conf.debug_solver = True
-        if opts.obsoletes:
-            self.base.conf.obsoletes = True
         self.command.pre_configure()
         self.base.pre_configure_plugins()
 

--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -277,7 +277,7 @@ class MainConf(BaseConfig):
         config_args = ['plugins', 'version', 'config_file_path',
                        'debuglevel', 'errorlevel', 'installroot',
                        'best', 'assumeyes', 'assumeno', 'clean_requirements_on_remove', 'gpgcheck',
-                       'showdupesfromrepos', 'plugins', 'ip_resolve',
+                       'showdupesfromrepos', 'ip_resolve',
                        'rpmverbosity', 'disable_excludes', 'color',
                        'downloadonly', 'exclude', 'excludepkgs', 'skip_broken',
                        'tsflags', 'arch', 'basearch', 'ignorearch', 'cacheonly', 'comment']

--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -335,6 +335,12 @@ class MainConf(BaseConfig):
                             msg = _("Main config did not have a %s attr. before setopt")
                             logger.warning(msg, name)
 
+        if getattr(opts 'debugsolver'):
+            self._set_value("debug_solver", True, dnf.conf.PRIO_COMMANDLINE)
+
+        if getattr(opts 'obsoletes'):
+            self._set_value("obsoletes", True, dnf.conf.PRIO_COMMANDLINE)
+
     def exclude_pkgs(self, pkgs):
         # :api
         name = "excludepkgs"


### PR DESCRIPTION
All config args processed by _configure_from_options are defined in
main options parser. Commands do not add any arguments that would
require second round of processing.
Running it twice caused that values of append options in base.conf
are doubled:
$ dnf --setopt=excludepkgs=a --setopt=excludepkgs=b
=> self.base.conf.excludepkgs = ['a', 'b', 'a', 'b']