### PR TITLE
repoquery: fix rich deps matching by using provide expansion from libdnf

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -1,5 +1,5 @@
 # default dependencies
-%global hawkey_version 0.41.0
+%global hawkey_version 0.44.0
 %global libcomps_version 0.1.8
 %global libmodulemd_version 1.4.0
 %global rpm_version 4.14.0

--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -674,7 +674,7 @@ class RepoQueryCommand(commands.Command):
                             ar[querypkg.name + "." + querypkg.arch] = querypkg
                     pkgquery = self.base.sack.query().filterm(pkg=list(ar.values()))
                 else:
-                    pkgquery = self.by_all_deps(pkg.name, None, aquery) if opts.alldeps \
+                    pkgquery = self.by_all_deps((pkg.name, ), None, aquery) if opts.alldeps \
                         else aquery.filter(requires__glob=pkg.name)
                 self.tree_seed(pkgquery, aquery, opts, level + 1, usedpkgs)
 

--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -303,6 +303,12 @@ class RepoQueryCommand(commands.Command):
                       "(optionally with '--alldeps', but not with '--exactdeps'), or with "
                       "'--requires <REQ> --resolve'"))
 
+        if self.opts.alldeps or self.opts.exactdeps:
+            if not (self.opts.whatrequires or self.opts.whatdepends):
+                raise dnf.cli.CliError(
+                    _("argument {} requires --whatrequires or --whatdepends option".format(
+                        '--alldeps' if self.opts.alldeps else '--exactdeps')))
+
         if self.opts.srpm:
             self.base.repos.enable_source_repos()
 
@@ -496,10 +502,6 @@ class RepoQueryCommand(commands.Command):
             else:
                 q.filterm(file__glob=self.opts.whatprovides)
         if self.opts.alldeps or self.opts.exactdeps:
-            if not (self.opts.whatrequires or self.opts.whatdepends):
-                raise dnf.exceptions.Error(
-                    _("argument {} requires --whatrequires or --whatdepends option".format(
-                        '--alldeps' if self.opts.alldeps else '--exactdeps')))
             if self.opts.alldeps:
                 q = self.by_all_deps(self.opts.whatrequires, self.opts.whatdepends, q)
             else:

--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -499,7 +499,8 @@ class RepoQueryCommand(commands.Command):
         if self.opts.file:
             q.filterm(file__glob=self.opts.file)
         if self.opts.whatconflicts:
-            q.filterm(conflicts=self.opts.whatconflicts)
+            rels = q.filter(conflicts__glob=self.opts.whatconflicts)
+            q = rels.union(q.filter(conflicts=self._resolve_nevras(self.opts.whatconflicts, q)))
         if self.opts.whatobsoletes:
             q.filterm(obsoletes=self.opts.whatobsoletes)
         if self.opts.whatprovides:
@@ -526,13 +527,18 @@ class RepoQueryCommand(commands.Command):
                 q = self.by_all_deps(self.opts.whatdepends, q, True)
 
         if self.opts.whatrecommends:
-            q.filterm(recommends__glob=self.opts.whatrecommends)
+            rels = q.filter(recommends__glob=self.opts.whatrecommends)
+            q = rels.union(q.filter(recommends=self._resolve_nevras(self.opts.whatrecommends, q)))
         if self.opts.whatenhances:
-            q.filterm(enhances__glob=self.opts.whatenhances)
+            rels = q.filter(enhances__glob=self.opts.whatenhances)
+            q = rels.union(q.filter(enhances=self._resolve_nevras(self.opts.whatenhances, q)))
         if self.opts.whatsupplements:
-            q.filterm(supplements__glob=self.opts.whatsupplements)
+            rels = q.filter(supplements__glob=self.opts.whatsupplements)
+            q = rels.union(q.filter(supplements=self._resolve_nevras(self.opts.whatsupplements, q)))
         if self.opts.whatsuggests:
-            q.filterm(suggests__glob=self.opts.whatsuggests)
+            rels = q.filter(suggests__glob=self.opts.whatsuggests)
+            q = rels.union(q.filter(suggests=self._resolve_nevras(self.opts.whatsuggests, q)))
+
         if self.opts.latest_limit:
             q = q.latest(self.opts.latest_limit)
         # reduce a query to security upgrades if they are specified

--- a/doc/api_queries.rst
+++ b/doc/api_queries.rst
@@ -101,16 +101,19 @@
     release           string         match against packages' releases
     reponame          string         match against packages repositories' names
     version           string         match against packages' versions
-    obsoletes         Query          match packages that obsolete any package from query
     pkg               Query          match against packages in query
     pkg*              list           match against hawkey.Packages in list
     provides          string         match against packages' provides
     provides*         Hawkey.Reldep  match against packages' provides
-    requires          string         match against packages' requirements
-    requires*         Hawkey.Reldep  match against packages' requirements
+    <DEP>             string         match against packages' <DEP>
+    <DEP>*            Hawkey.Reldep  match a reldep against packages' <DEP>
+    <DEP>*            Query          match the result of a query against packages' <DEP>
+    <DEP>*            list(Package)  match the list of hawkey.Packages against packages' <DEP>
     sourcerpm         string         match against packages' source rpm
     upgrades          boolean        see :meth:`upgrades`. Defaults to ``False``.
     ===============   ============== ======================================================
+
+    ``<DEP>`` can be any of: requires, conflicts, obsoletes, enhances, recomments, suggests, supplements
 
     \* The key can also accept a list of values with specified type.
 
@@ -132,6 +135,8 @@
     For example, the following creates a query that matches all packages containing the string "club" in its name::
 
       q = base.sack.query().filter(name__substr="club")
+
+    Note that using packages or queries for dependency filtering performs a more advanced resolution than using a string or a reldep. When a package list or a query is used, rich dependencies are resolved in a more precise way than what is possible when a string or a reldep is used.
 
   .. method:: filterm(\*\*kwargs)
 


### PR DESCRIPTION
This is meant to fix a bug where rich dependencies would match a package even if the require specified a different version range than doesn't match the version of the provide.

Uses new libdnf (PR linked below) that can expand package provides while filtering so that it doesn't haveto be implemented in dnf in a non-straightforward way that was causing it to match rich dependencies incorrectly. Further description is with the commits, along with some shortcomings this currently has.

https://github.com/rpm-software-management/libdnf/pull/762

Tests for this are here:
https://github.com/rpm-software-management/ci-dnf-stack/pull/577

https://bugzilla.redhat.com/show_bug.cgi?id=1534123
https://bugzilla.redhat.com/show_bug.cgi?id=1698034