### PR TITLE
[doc] Describe a behavior when plugin is removed (RhBug:1700741)

### DIFF
--- a/doc/api_plugins.rst
+++ b/doc/api_plugins.rst
@@ -62,6 +62,7 @@ When DNF CLI runs it loads the plugins found in the paths during the CLI's initi
   .. method:: transaction
 
     Plugin can override this. This hook is called immediately after a successful transaction.
+    Plugins that were removed or obsoleted by the transaction will not run the transaction hook.
 
 You may want to see the comparison with `yum plugin hook API`_.
 


### PR DESCRIPTION
When plugin is removed or obsoleted all hooks of removed plugins after
transaction are skipped. The behavior was added because some
of dependencies of the plugin could be also removed and unavailable in
memory. We apply the same behavior also for obsoleted plugins, because
we suggest that obsoleting plugin could have a different code base.

The behavior is not applicable for downgrades or upgrades.

https://bugzilla.redhat.com/show_bug.cgi?id=1700741