### PR TITLE
New rpmdb_sack() API method

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1038,7 +1038,7 @@ class Base(object):
         timer = dnf.logging.Timer('verify transaction')
         count = 0
 
-        rpmdb_sack = dnf.sack._rpmdb_sack(self)
+        rpmdb_sack = dnf.sack.rpmdb_sack(self)
 
         # mark group packages that are installed on the system as installed in the db
         q = rpmdb_sack.query().installed()

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -121,7 +121,7 @@ def print_versions(pkgs, base, output):
     def sm_ui_time(x):
         return time.strftime("%c", time.gmtime(x))
 
-    rpmdb_sack = dnf.sack._rpmdb_sack(base)
+    rpmdb_sack = dnf.sack.rpmdb_sack(base)
     done = False
     for pkg in rpmdb_sack.query().installed().filterm(name=pkgs):
         if done:

--- a/dnf/cli/commands/check.py
+++ b/dnf/cli/commands/check.py
@@ -84,7 +84,7 @@ class CheckCommand(commands.Command):
                         if str(require).startswith('('):
                             # rich deps can be only tested by solver
                             if sack is None:
-                                sack = dnf.sack._rpmdb_sack(self.base)
+                                sack = dnf.sack.rpmdb_sack(self.base)
                             selector = dnf.selector.Selector(sack)
                             selector.set(provides=str(require))
                             goal = dnf.goal.Goal(sack)

--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -440,7 +440,7 @@ class RepoQueryCommand(commands.Command):
         elif self.opts.pkgfilter == "installonly":
             q = self.base._get_installonly_query(q)
         elif self.opts.pkgfilter == "unsatisfied":
-            rpmdb = dnf.sack._rpmdb_sack(self.base)
+            rpmdb = dnf.sack.rpmdb_sack(self.base)
             rpmdb._configure(self.base.conf.installonlypkgs, self.base.conf.installonly_limit)
             goal = dnf.goal.Goal(rpmdb)
             solved = goal.run(verify=True)

--- a/dnf/sack.py
+++ b/dnf/sack.py
@@ -65,3 +65,12 @@ def _rpmdb_sack(base):
     except IOError:
         pass
     return sack
+
+
+def rpmdb_sack(base):
+    # :api
+    """
+    Returns a new instance of sack containing only installed packages (@System repo)
+    Useful to get list of the installed RPMs after transaction.
+    """
+    return _rpmdb_sack(base)

--- a/doc/api_sack.rst
+++ b/doc/api_sack.rst
@@ -19,10 +19,16 @@
  Sack
 ======
 
-.. class:: dnf.sack.Sack
+.. module:: dnf.sack
+
+.. class:: Sack
 
   The package sack. Contains metadata information about all known packages, installed and available.
 
   .. method:: query()
 
     Return a :class:`Query<dnf.query.Query>` for querying packages contained in this sack.
+
+.. function:: rpmdb_sack(base)
+
+    Returns a new instance of sack containing only installed packages (@System repo). Useful to get list of the installed RPMs after transaction.


### PR DESCRIPTION
Returns a new instance of sack containing only installed packages (@System repo)
Useful to get list of the installed RPMs after transaction.
This method replaces private _rpmdb_sack() for public use.