### PR TITLE
Show modular problem with module enable

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -161,7 +161,7 @@ class Base(object):
         try:
             solver_errors = self.sack.filter_modules(
                 self._moduleContainer, hot_fix_repos, self.conf.installroot,
-                self.conf.module_platform_id, False, self.conf.debug_solver)
+                self.conf.module_platform_id, update_only=False, debugsolver=self.conf.debug_solver)
         except hawkey.Exception as e:
             raise dnf.exceptions.Error(ucd(e))
         if solver_errors:

--- a/dnf/module/module_base.py
+++ b/dnf/module/module_base.py
@@ -332,8 +332,8 @@ class ModuleBase(object):
         try:
             solver_errors = self.base.sack.filter_modules(
                 self.base._moduleContainer, hot_fix_repos, self.base.conf.installroot,
-                self.base.conf.module_platform_id,
-                self.base.conf.debug_solver)
+                self.base.conf.module_platform_id, update_only=True,
+                debugsolver=self.base.conf.debug_solver)
         except hawkey.Exception as e:
             raise dnf.exceptions.Error(ucd(e))
         for spec, (nsvcap, moduleDict) in module_dicts.items():


### PR DESCRIPTION
There were incorrectly used argument debugsolver and update_only. In
function _resolve_specs_enable_update_sack debugsolver information was
put in position of update_only argument. In some cases it result that it
was possible to enable module that should produce a modular error.

Requires: https://github.com/rpm-software-management/ci-dnf-stack/pull/608