### PR TITLE
Add api to remove additional metadata

### DIFF
--- a/dnf/repo.py
+++ b/dnf/repo.py
@@ -511,6 +511,22 @@ class Repo(dnf.conf.RepoConf):
         """
         self._repo.addMetadataTypeToDownload(metadata_type)
 
+    def remove_metadata_type_from_download(self, metadata_type):
+        # :api
+        """Stop asking for this additional repository metadata type
+        in download.
+
+        Given metadata_type is no longer downloaded by default
+        when this repository is downloaded.
+
+        Parameters
+        ----------
+        metadata_type: string
+
+        Example: remove_metadata_type_from_download("productid")
+        """
+        self._repo.removeMetadataTypeFromDownload(metadata_type)
+
     def get_metadata_path(self, metadata_type):
         # :api
         """Return path to the file with downloaded repository metadata of given type.


### PR DESCRIPTION
Depends on https://github.com/rpm-software-management/libdnf/pull/769

This lets me add some additional metadata, catch the exception if it is missing, and then remove it from the repo so that it functions as normal.