### PR TITLE
Remove movement of _ds_callback to local variable (RhBug:1736879)

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -813,9 +813,6 @@ class Base(object):
         lock = dnf.lock.build_rpmdb_lock(self.conf.persistdir,
                                          self.conf.exit_on_lock)
         with lock:
-            # save our ds_callback out
-            dscb = self._ds_callback
-            self._ds_callback = None
             self.transaction._populate_rpm_ts(self._ts)
 
             msgs = self._run_rpm_check()
@@ -851,8 +848,6 @@ class Base(object):
 
             # unset the sigquit handler
             timer = dnf.logging.Timer('transaction')
-            # put back our depcheck callback
-            self._ds_callback = dscb
             # setup our rpm ts callback
             cb = dnf.yum.rpmtrans.RPMTransaction(self, displays=display)
             if self.conf.debuglevel < 2:


### PR DESCRIPTION
According to the code and history, the movement is not needed anymore,
because it is not called during do_transaction from anywhere.

The movement in combination with shell command could result in traceback,
when do_transaction step failed and second resolve is called.

https://bugzilla.redhat.com/show_bug.cgi?id=1736879