### PR TITLE
[doc] document NEVRA parsing in the man page

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -2139,8 +2139,7 @@ class Base(object):
         to one version lower than the package installed.
         """
         subj = dnf.subject.Subject(pkg_spec)
-        q = subj.get_best_query(self.sack, with_nevra=True, with_provides=False,
-                                with_filenames=False)
+        q = subj.get_best_query(self.sack)
         if not q:
             msg = _('No match for argument: %s') % pkg_spec
             raise dnf.exceptions.PackageNotFoundError(msg, pkg_spec)

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -813,9 +813,6 @@ e.g. to only those that update an installed package. The :ref:`exclude
 result, but if the \-\ :ref:`-disableexcludes <disableexcludes-label>` command line
 option is used, it ensures that all installed packages will be listed.
 
-All the forms take the ``[<package-file-spec>...]`` parameter to further limit the
-result to only packages that match it.
-
 ``dnf [options] list [--all] [<package-file-spec>...]``
     Lists all packages, present in the RPMDB, in a repository or both.
 

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -574,7 +574,7 @@ Distribution-Synchronization command
 Downgrade Command
 -----------------
 
-``dnf [options] downgrade <package-installed-spec>...``
+``dnf [options] downgrade <package-spec>...``
     Downgrades the specified packages to the highest installable package of all known lower versions
     if possible. When version is given and is lower than version of installed package then it
     downgrades to target version.
@@ -1553,7 +1553,7 @@ Upgrade Command
     Updates each package to the latest version that is both available and
     resolvable.
 
-``dnf [options] upgrade <package-installed-spec>...``
+``dnf [options] upgrade <package-spec>...``
     Updates each specified package to the latest available version. Updates
     dependencies as necessary.
 
@@ -1579,7 +1579,7 @@ Upgrade-Minimal Command
     Updates each package to the latest available version that provides a bugfix, enhancement
     or a fix for a security issue (security).
 
-``dnf [options] upgrade-minimal <package-installed-spec>...``
+``dnf [options] upgrade-minimal <package-spec>...``
     Updates each specified package to the latest available version that provides
     a bugfix, enhancement or a fix for security issue (security). Updates
     dependencies as necessary.
@@ -1636,9 +1636,6 @@ matching is never attempted there.
 
 ``<package-name-spec>`` is similar to ``<package-file-spec>`` except file provide
 matching is never attempted there.
-
-``<package-installed-spec>`` is similar to ``<package-spec>`` except it
-considers only installed packages.
 
 .. _specifying_packages_versions-label:
 

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -1603,36 +1603,69 @@ Upgrade-To Command
 Specifying Packages
 ===================
 
-Many commands take a ``<package-spec>`` parameter that selects a package for the
-operation. DNF looks for interpretations of the parameter from the most commonly
-used meanings to the least, that is it tries to see if the given spec fits one
-of the following patterns (in decreasing order of priority):
+Many commands take a ``<package-spec>`` parameter that selects a package for
+the operation. The ``<package-spec>`` argument is matched against package
+NEVRAs, provides and file provides.
 
+``<package-file-spec>`` is similar to ``<package-spec>``, except provides
+matching is not performed. Therefore, ``<package-file-spec>`` is matched only
+against NEVRAs and file provides.
+
+``<package-name-spec>`` is matched against NEVRAs only.
+
+-----
+Globs
+-----
+
+Package specification supports the same glob pattern matching that shell does,
+in all three above mentioned packages it matches against (NEVRAs, provides and
+file provides).
+
+The following patterns are supported:
+
+``*``
+    Matches any number of characters.
+``?``
+    Matches any single character.
+``[]``
+    Matches any one of the enclosed characters. A pair of characters separated
+    by a hyphen denotes a range expression; any character that falls between
+    those two characters, inclusive, is matched. If the first character
+    following the ``[`` is a ``!`` or a ``^`` then any character not enclosed
+    is matched.
+``{}``
+    Matches any of the comma separated list of enclosed strings.
+
+--------------
+NEVRA Matching
+--------------
+
+When matching against NEVRAs, partial matching is supported. DNF tries to match
+the spec against the following list of NEVRA forms (in decreasing order of
+priority):
+
+* ``name-[epoch:]version-release.arch``
 * ``name.arch``
 * ``name``
-* ``name-[epoch:]version-release.arch``
 * ``name-[epoch:]version-release``
 * ``name-[epoch:]version``
 
-Note that ``name`` can in general contain dashes (e.g. ``package-subpackage``).
+Note that ``name`` can in general contain dashes (e.g. ``package-with-dashes``).
 
-Failing to match the input argument to an existing package name based on the
-patterns above, DNF tries to see if the argument matches an existing provide.
+The first form that matches any packages is used and the remaining forms are
+not tried. If none of the forms match any packages, an attempt is made to match
+the ``<package-spec>`` against full package NEVRAs. This is only relevant
+if globs are present in the ``<package-spec>``.
 
-By default, if multiple versions of the selected package exist in the repository, the
-most recent version suitable for the given operation is used. If the selected
-package exists for multiple architectures, the packages which best match the
-system's architecture will be preferred. The name specification is
-case-sensitive, globbing characters "``?``, ``*`` and ``[`` are allowed and
-trigger shell-like glob matching. If a globbing character is present in ``name``,
-DNF expands given ``name`` first and consequently selects all packages matching
-the expanded ``<package-spec>``.
+``<package-spec>`` matches NEVRAs the same way ``<package-name-spec>`` does,
+but in case matching NEVRAs fails, it attempts to match against provides and
+file provides of packages as well.
 
-``<package-file-spec>`` is similar to ``<package-spec>`` except the provides
-matching is never attempted there.
-
-``<package-name-spec>`` is similar to ``<package-file-spec>`` except file provide
-matching is never attempted there.
+You can specify globs as part of any of the five NEVRA components. You can also
+specify a glob pattern to match over multiple NEVRA components (in other words,
+to match across the NEVRA separators). In that case, however, you need to write
+the spec to match against full package NEVRAs, as it is not possible to split
+such spec into NEVRA forms.
 
 .. _specifying_packages_versions-label:
 

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -672,7 +672,7 @@ transactions and act according to this information (assuming the
     The default history action is listing information about given transactions
     in a table. Each ``<spec>`` can be either a ``<transaction-spec>``, which
     specifies a transaction directly, or a ``<transaction-spec>..<transaction-spec>``,
-    which specifies a range of transactions, or a ``<package-file-spec>``,
+    which specifies a range of transactions, or a ``<package-name-spec>``,
     which specifies a transaction by a package which it manipulated. When no
     transaction is specified, list all known transactions.
 
@@ -1632,6 +1632,9 @@ DNF expands given ``name`` first and consequently selects all packages matching
 the expanded ``<package-spec>``.
 
 ``<package-file-spec>`` is similar to ``<package-spec>`` except the provides
+matching is never attempted there.
+
+``<package-name-spec>`` is similar to ``<package-file-spec>`` except file provide
 matching is never attempted there.
 
 ``<package-installed-spec>`` is similar to ``<package-spec>`` except it

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -208,10 +208,10 @@ Options
 
 .. _exclude_option-label:
 
-``-x <package-spec>, --exclude=<package-spec>``
-    Exclude packages specified by ``<package-spec>`` from the operation.
+``-x <package-file-spec>, --exclude=<package-file-spec>``
+    Exclude packages specified by ``<package-file-spec>`` from the operation.
 
-``--excludepkgs=<package-spec>``
+``--excludepkgs=<package-file-spec>``
     Deprecated option. It was replaced by the \-\ :ref:`-exclude <exclude_option-label>` option.
 
 ``--forcearch=<arch>``
@@ -382,7 +382,7 @@ List options are comma-separated. Command-line options override respective setti
 Commands
 ========
 
-For an explanation of ``<package-spec>`` and ``<package-name-spec>`` see
+For an explanation of ``<package-spec>`` and ``<package-file-spec>`` see
 :ref:`\specifying_packages-label`.
 
 For an explanation of ``<package-nevr-spec>`` see
@@ -504,9 +504,9 @@ Check Command
 Check-Update Command
 --------------------
 
-``dnf [options] check-update [--changelogs] [<package-spec>...]``
+``dnf [options] check-update [--changelogs] [<package-file-spec>...]``
 
-    Non-interactively checks if updates of the specified packages are available. If no ``<package-spec>`` is given, checks whether any updates at all are available for your system. DNF exit code will be 100 when there are updates available and a list of the updates will be printed, 0 if not and 1 if an error occurs. If ``--changelogs`` option is specified, also changelog delta of packages about to be updated is printed.
+    Non-interactively checks if updates of the specified packages are available. If no ``<package-file-spec>`` is given, checks whether any updates at all are available for your system. DNF exit code will be 100 when there are updates available and a list of the updates will be printed, 0 if not and 1 if an error occurs. If ``--changelogs`` option is specified, also changelog delta of packages about to be updated is printed.
 
     Please note that having a specific newer version available for an installed package (and reported by ``check-update``) does not imply that subsequent ``dnf upgrade`` will install it. The difference is that ``dnf upgrade`` has restrictions (like package dependencies being satisfied) to take into account.
 
@@ -672,7 +672,7 @@ transactions and act according to this information (assuming the
     The default history action is listing information about given transactions
     in a table. Each ``<spec>`` can be either a ``<transaction-spec>``, which
     specifies a transaction directly, or a ``<transaction-spec>..<transaction-spec>``,
-    which specifies a range of transactions, or a ``<package-name-spec>``,
+    which specifies a range of transactions, or a ``<package-file-spec>``,
     which specifies a transaction by a package which it manipulated. When no
     transaction is specified, list all known transactions.
 
@@ -684,21 +684,21 @@ transactions and act according to this information (assuming the
 
 .. _history_redo_command-label:
 
-``dnf history redo <transaction-spec>|<package-name-spec>``
+``dnf history redo <transaction-spec>|<package-file-spec>``
     Repeat the specified transaction. Uses the last transaction (with the highest ID)
-    if more than one transaction for given <package-name-spec> is found. If it is not possible
+    if more than one transaction for given <package-file-spec> is found. If it is not possible
     to redo some operations due to the current state of RPMDB, it will not redo the transaction.
 
-``dnf history rollback <transaction-spec>|<package-name-spec>``
+``dnf history rollback <transaction-spec>|<package-file-spec>``
     Undo all transactions performed after the specified transaction. Uses the last transaction
-    (with the highest ID) if more than one transaction for given <package-name-spec> is found.
+    (with the highest ID) if more than one transaction for given <package-file-spec> is found.
     If it is not possible to undo some transactions due to the current state of RPMDB, it will not undo
     any transaction.
 
-``dnf history undo <transaction-spec>|<package-name-spec>``
+``dnf history undo <transaction-spec>|<package-file-spec>``
     Perform the opposite operation to all operations performed in the specified transaction.
     Uses the last transaction (with the highest ID) if more than one transaction for given
-    <package-name-spec> is found. If it is not possible to undo some operations due to
+    <package-file-spec> is found. If it is not possible to undo some operations due to
     the current state of RPMDB, it will not undo the transaction.
 
 ``dnf history userinstalled``
@@ -720,7 +720,7 @@ and :ref:`\configuration_files_replacement_policy-label`.
 Info Command
 ------------
 
-``dnf [options] info [<package-name-spec>...]``
+``dnf [options] info [<package-file-spec>...]``
     Lists description and summary information about installed and available packages.
 
 This command by default does not force a sync of expired metadata. See also :ref:`\metadata_synchronization-label`.
@@ -813,30 +813,30 @@ e.g. to only those that update an installed package. The :ref:`exclude
 result, but if the \-\ :ref:`-disableexcludes <disableexcludes-label>` command line
 option is used, it ensures that all installed packages will be listed.
 
-All the forms take the ``[<package-spec>...]`` parameter to further limit the
-result to only packages that matching it.
+All the forms take the ``[<package-file-spec>...]`` parameter to further limit the
+result to only packages that match it.
 
-``dnf [options] list [--all] [<package-name-spec>...]``
+``dnf [options] list [--all] [<package-file-spec>...]``
     Lists all packages, present in the RPMDB, in a repository or both.
 
-``dnf [options] list --installed [<package-name-spec>...]``
+``dnf [options] list --installed [<package-file-spec>...]``
     Lists installed packages.
 
-``dnf [options] list --available [<package-name-spec>...]``
+``dnf [options] list --available [<package-file-spec>...]``
     Lists available packages.
 
-``dnf [options] list --extras [<package-name-spec>...]``
+``dnf [options] list --extras [<package-file-spec>...]``
     Lists extras, that is packages installed on the system that are not
     available in any known repository.
 
-``dnf [options] list --obsoletes [<package-name-spec>...]``
+``dnf [options] list --obsoletes [<package-file-spec>...]``
     List packages installed on the system that are obsoleted by packages in
     any known repository.
 
-``dnf [options] list --recent [<package-name-spec>...]``
+``dnf [options] list --recent [<package-file-spec>...]``
     List packages recently added into the repositories.
 
-``dnf [options] list --upgrades [<package-name-spec>...]``
+``dnf [options] list --upgrades [<package-file-spec>...]``
     List upgrades available for the installed packages.
 
 ``dnf [options] list --autoremove``
@@ -1075,7 +1075,7 @@ This command by default does not force a sync of expired metadata. See also :ref
 Repoquery Command
 -----------------
 
-``dnf [options] repoquery [<select-options>] [<query-options>] [<package-spec>]``
+``dnf [options] repoquery [<select-options>] [<query-options>] [<package-file-spec>]``
     Searches available DNF repositories for selected packages and displays the requested information about them. It
     is an equivalent of ``rpm -q`` for remote repositories.
 
@@ -1088,11 +1088,11 @@ Repoquery Command
 Select Options
 --------------
 
-Together with ``<package-spec>``, control what packages are displayed in the output. If ``<package-spec>`` is given, limits the resulting set of
-packages to those matching the specification. All packages are considered if no ``<package-spec>`` is specified.
+Together with ``<package-file-spec>``, control what packages are displayed in the output. If ``<package-file-spec>`` is given, limits the resulting set of
+packages to those matching the specification. All packages are considered if no ``<package-file-spec>`` is specified.
 
-``<package-spec>``
-    Package specification in the NEVRA format (name[-[epoch:]version[-release]][.arch]). See :ref:`Specifying Packages
+``<package-file-spec>``
+    Package specification in the NEVRA format (name[-[epoch:]version[-release]][.arch]), a package provide or a file provide. See :ref:`Specifying Packages
     <specifying_packages-label>`.
 
 ``-a``, ``--all``
@@ -1361,77 +1361,77 @@ Repo-Pkgs Command
 Repository-Packages Command
 ---------------------------
 
-The repository-packages command allows the user to run commands on top of all packages in the repository named ``<repoid>``. However, any dependency resolution takes into account packages from all enabled repositories. The ``<package-name-spec>`` and ``<package-spec>`` specifications further limit the candidates to only those packages matching at least one of them.
+The repository-packages command allows the user to run commands on top of all packages in the repository named ``<repoid>``. However, any dependency resolution takes into account packages from all enabled repositories. The ``<package-file-spec>`` and ``<package-spec>`` specifications further limit the candidates to only those packages matching at least one of them.
 
 The ``info`` subcommand lists description and summary information about packages depending on the packages' relation to the repository. The ``list`` subcommand just prints lists of those packages.
 
-``dnf [options] repository-packages <repoid> check-update [<package-name-spec>...]``
+``dnf [options] repository-packages <repoid> check-update [<package-file-spec>...]``
     Non-interactively checks if updates of the specified packages in the repository are available. DNF exit code will be 100 when there are updates available and a list of the updates will be printed.
 
-``dnf [options] repository-packages <repoid> info [--all] [<package-name-spec>...]``
+``dnf [options] repository-packages <repoid> info [--all] [<package-file-spec>...]``
     List all related packages.
 
-``dnf [options] repository-packages <repoid> info --installed [<package-name-spec>...]``
+``dnf [options] repository-packages <repoid> info --installed [<package-file-spec>...]``
     List packages installed from the repository.
 
-``dnf [options] repository-packages <repoid> info --available [<package-name-spec>...]``
+``dnf [options] repository-packages <repoid> info --available [<package-file-spec>...]``
     List packages available in the repository but not currently installed on the system.
 
-``dnf [options] repository-packages <repoid> info --extras [<package-name-specs>...]``
+``dnf [options] repository-packages <repoid> info --extras [<package-file-specs>...]``
     List packages installed from the repository that are not available in any repository.
 
-``dnf [options] repository-packages <repoid> info --obsoletes [<package-name-spec>...]``
+``dnf [options] repository-packages <repoid> info --obsoletes [<package-file-spec>...]``
     List packages in the repository that obsolete packages installed on the system.
 
-``dnf [options] repository-packages <repoid> info --recent [<package-name-spec>...]``
+``dnf [options] repository-packages <repoid> info --recent [<package-file-spec>...]``
     List packages recently added into the repository.
 
-``dnf [options] repository-packages <repoid> info --upgrades [<package-name-spec>...]``
+``dnf [options] repository-packages <repoid> info --upgrades [<package-file-spec>...]``
     List packages in the repository that upgrade packages installed on the system.
 
 ``dnf [options] repository-packages <repoid> install [<package-spec>...]``
     Install all packages in the repository.
 
-``dnf [options] repository-packages <repoid> list [--all] [<package-name-spec>...]``
+``dnf [options] repository-packages <repoid> list [--all] [<package-file-spec>...]``
     List all related packages.
 
-``dnf [options] repository-packages <repoid> list --installed [<package-name-spec>...]``
+``dnf [options] repository-packages <repoid> list --installed [<package-file-spec>...]``
     List packages installed from the repository.
 
-``dnf [options] repository-packages <repoid> list --available [<package-name-spec>...]``
+``dnf [options] repository-packages <repoid> list --available [<package-file-spec>...]``
     List packages available in the repository but not currently installed on the system.
 
-``dnf [options] repository-packages <repoid> list --extras [<package-name-spec>...]``
+``dnf [options] repository-packages <repoid> list --extras [<package-file-spec>...]``
     List packages installed from the repository that are not available in any repository.
 
-``dnf [options] repository-packages <repoid> list --obsoletes [<package-name-spec>...]``
+``dnf [options] repository-packages <repoid> list --obsoletes [<package-file-spec>...]``
     List packages in the repository that obsolete packages installed on the system.
 
-``dnf [options] repository-packages <repoid> list --recent [<package-name-spec>...]``
+``dnf [options] repository-packages <repoid> list --recent [<package-file-spec>...]``
     List packages recently added into the repository.
 
-``dnf [options] repository-packages <repoid> list --upgrades [<package-name-spec>...]``
+``dnf [options] repository-packages <repoid> list --upgrades [<package-file-spec>...]``
     List packages in the repository that upgrade packages installed on the system.
 
-``dnf [options] repository-packages <repoid> move-to [<package-name-spec>...]``
+``dnf [options] repository-packages <repoid> move-to [<package-spec>...]``
     Reinstall all those packages that are available in the repository.
 
-``dnf [options] repository-packages <repoid> reinstall [<package-name-spec>...]``
+``dnf [options] repository-packages <repoid> reinstall [<package-spec>...]``
     Run the ``reinstall-old`` subcommand. If it fails, run the ``move-to`` subcommand.
 
-``dnf [options] repository-packages <repoid> reinstall-old [<package-name-spec>...]``
+``dnf [options] repository-packages <repoid> reinstall-old [<package-spec>...]``
     Reinstall all those packages that were installed from the repository and simultaneously are available in the repository.
 
-``dnf [options] repository-packages <repoid> remove [<package-name-spec>...]``
+``dnf [options] repository-packages <repoid> remove [<package-spec>...]``
     Remove all packages installed from the repository along with any packages depending on the packages being removed. If ``clean_requirements_on_remove`` is enabled (the default) also removes any dependencies that are no longer needed.
 
-``dnf [options] repository-packages <repoid> remove-or-distro-sync [<package-name-spec>...]``
+``dnf [options] repository-packages <repoid> remove-or-distro-sync [<package-spec>...]``
     Select all packages installed from the repository. Upgrade, downgrade or keep those of them that are available in another repository to match the latest version available there and remove the others along with any packages depending on the packages being removed. If ``clean_requirements_on_remove`` is enabled (the default) also removes any dependencies that are no longer needed.
 
-``dnf [options] repository-packages <repoid> remove-or-reinstall [<package-name-spec>...]``
+``dnf [options] repository-packages <repoid> remove-or-reinstall [<package-spec>...]``
     Select all packages installed from the repository. Reinstall those of them that are available in another repository and remove the others along with any packages depending on the packages being removed. If ``clean_requirements_on_remove`` is enabled (the default) also removes any dependencies that are no longer needed.
 
-``dnf [options] repository-packages <repoid> upgrade [<package-name-spec>...]``
+``dnf [options] repository-packages <repoid> upgrade [<package-spec>...]``
     Update all packages to the highest resolvable version available in the repository.
 
 ``dnf [options] repository-packages <repoid> upgrade-to <package-nevr-specs>...``
@@ -1631,7 +1631,7 @@ trigger shell-like glob matching. If a globbing character is present in ``name``
 DNF expands given ``name`` first and consequently selects all packages matching
 the expanded ``<package-spec>``.
 
-``<package-name-spec>`` is similar to ``<package-spec>`` except the provides
+``<package-file-spec>`` is similar to ``<package-spec>`` except the provides
 matching is never attempted there.
 
 ``<package-installed-spec>`` is similar to ``<package-spec>`` except it

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -504,9 +504,9 @@ Check Command
 Check-Update Command
 --------------------
 
-``dnf [options] check-update [--changelogs] [<package-specs>...]``
+``dnf [options] check-update [--changelogs] [<package-spec>...]``
 
-    Non-interactively checks if updates of the specified packages are available. If no ``<package-specs>`` are given, checks whether any updates at all are available for your system. DNF exit code will be 100 when there are updates available and a list of the updates will be printed, 0 if not and 1 if an error occurs. If ``--changelogs`` option is specified, also changelog delta of packages about to be updated is printed.
+    Non-interactively checks if updates of the specified packages are available. If no ``<package-spec>`` is given, checks whether any updates at all are available for your system. DNF exit code will be 100 when there are updates available and a list of the updates will be printed, 0 if not and 1 if an error occurs. If ``--changelogs`` option is specified, also changelog delta of packages about to be updated is printed.
 
     Please note that having a specific newer version available for an installed package (and reported by ``check-update``) does not imply that subsequent ``dnf upgrade`` will install it. The difference is that ``dnf upgrade`` has restrictions (like package dependencies being satisfied) to take into account.
 
@@ -574,7 +574,7 @@ Distribution-Synchronization command
 Downgrade Command
 -----------------
 
-``dnf [options] downgrade <package-installed-specs>...``
+``dnf [options] downgrade <package-installed-spec>...``
     Downgrades the specified packages to the highest installable package of all known lower versions
     if possible. When version is given and is lower than version of installed package then it
     downgrades to target version.
@@ -813,30 +813,30 @@ e.g. to only those that update an installed package. The :ref:`exclude
 result, but if the \-\ :ref:`-disableexcludes <disableexcludes-label>` command line
 option is used, it ensures that all installed packages will be listed.
 
-All the forms take the ``[<package-specs>...]`` parameter to further limit the
+All the forms take the ``[<package-spec>...]`` parameter to further limit the
 result to only packages that matching it.
 
-``dnf [options] list [--all] [<package-name-specs>...]``
+``dnf [options] list [--all] [<package-name-spec>...]``
     Lists all packages, present in the RPMDB, in a repository or both.
 
-``dnf [options] list --installed [<package-name-specs>...]``
+``dnf [options] list --installed [<package-name-spec>...]``
     Lists installed packages.
 
-``dnf [options] list --available [<package-name-specs>...]``
+``dnf [options] list --available [<package-name-spec>...]``
     Lists available packages.
 
-``dnf [options] list --extras [<package-name-specs>...]``
+``dnf [options] list --extras [<package-name-spec>...]``
     Lists extras, that is packages installed on the system that are not
     available in any known repository.
 
-``dnf [options] list --obsoletes [<package-name-specs>...]``
+``dnf [options] list --obsoletes [<package-name-spec>...]``
     List packages installed on the system that are obsoleted by packages in
     any known repository.
 
-``dnf [options] list --recent [<package-name-specs>...]``
+``dnf [options] list --recent [<package-name-spec>...]``
     List packages recently added into the repositories.
 
-``dnf [options] list --upgrades [<package-name-specs>...]``
+``dnf [options] list --upgrades [<package-name-spec>...]``
     List upgrades available for the installed packages.
 
 ``dnf [options] list --autoremove``
@@ -877,13 +877,13 @@ Makecache Command
 Mark Command
 -------------
 
-``dnf mark install <package-specs>...``
+``dnf mark install <package-spec>...``
     Marks the specified packages as installed by user. This can be useful if any package was installed as a dependency and is desired to stay on the system when :ref:`\autoremove_command-label` or :ref:`\remove_command-label` along with `clean_requirements_on_remove` configuration option set to ``True`` is executed.
 
-``dnf mark remove <package-specs>...``
+``dnf mark remove <package-spec>...``
     Unmarks the specified packages as installed by user. Whenever you as a user don't need a specific package you can mark it for removal. The package stays installed on the system but will be removed when :ref:`\autoremove_command-label` or :ref:`\remove_command-label` along with `clean_requirements_on_remove` configuration option set to ``True`` is executed. You should use this operation instead of :ref:`\remove_command-label` if you're not sure whether the package is a requirement of other user installed packages on the system.
 
-``dnf mark group <package-specs>...``
+``dnf mark group <package-spec>...``
     Marks the specified packages as installed by group. This can be useful if any package was
     installed as a dependency or a user and is desired to be protected and handled as a group
     member like during group remove.
@@ -1010,7 +1010,7 @@ Provides Command
 Reinstall Command
 -----------------
 
-``dnf [options] reinstall <package-specs>...``
+``dnf [options] reinstall <package-spec>...``
     Installs the specified packages, fails if some of the packages are either
     not installed or not available (i.e. there is no repository where to
     download the same RPM).
@@ -1021,7 +1021,7 @@ Reinstall Command
 Remove Command
 --------------
 
-``dnf [options] remove <package-specs>...``
+``dnf [options] remove <package-spec>...``
     Removes the specified packages from the system along with any packages depending on the packages being removed. Each ``<spec>`` can be either a ``<package-spec>``, which specifies a package directly, or a ``@<group-spec>``, which specifies an (environment) group which contains it. If ``clean_requirements_on_remove`` is enabled (the default), also removes any dependencies that are no longer needed.
 
 ``dnf [options] remove --duplicates``
@@ -1401,7 +1401,7 @@ The ``info`` subcommand lists description and summary information about packages
 ``dnf [options] repository-packages <repoid> list --available [<package-name-spec>...]``
     List packages available in the repository but not currently installed on the system.
 
-``dnf [options] repository-packages <repoid> list --extras [<package-name-specs>...]``
+``dnf [options] repository-packages <repoid> list --extras [<package-name-spec>...]``
     List packages installed from the repository that are not available in any repository.
 
 ``dnf [options] repository-packages <repoid> list --obsoletes [<package-name-spec>...]``
@@ -1553,7 +1553,7 @@ Upgrade Command
     Updates each package to the latest version that is both available and
     resolvable.
 
-``dnf [options] upgrade <package-installed-specs>...``
+``dnf [options] upgrade <package-installed-spec>...``
     Updates each specified package to the latest available version. Updates
     dependencies as necessary.
 
@@ -1579,7 +1579,7 @@ Upgrade-Minimal Command
     Updates each package to the latest available version that provides a bugfix, enhancement
     or a fix for a security issue (security).
 
-``dnf [options] upgrade-minimal <package-installed-specs>...``
+``dnf [options] upgrade-minimal <package-installed-spec>...``
     Updates each specified package to the latest available version that provides
     a bugfix, enhancement or a fix for security issue (security). Updates
     dependencies as necessary.
@@ -1634,7 +1634,7 @@ the expanded ``<package-spec>``.
 ``<package-name-spec>`` is similar to ``<package-spec>`` except the provides
 matching is never attempted there.
 
-``<package-installed-specs>`` is similar to ``<package-specs>`` except it
+``<package-installed-spec>`` is similar to ``<package-spec>`` except it
 considers only installed packages.
 
 .. _specifying_packages_versions-label:

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -546,7 +546,7 @@ different distribution release versions.
 Deplist command
 ---------------
 
-``dnf [options] deplist [<select-options>] [<query-options>] [<pkg-spec>]``
+``dnf [options] deplist [<select-options>] [<query-options>] [<package-spec>]``
     Alias for :ref:`dnf repoquery --deplist <deplist_option-label>`.
 
 .. _distro_sync_command-label:
@@ -1075,7 +1075,7 @@ This command by default does not force a sync of expired metadata. See also :ref
 Repoquery Command
 -----------------
 
-``dnf [options] repoquery [<select-options>] [<query-options>] [<pkg-spec>]``
+``dnf [options] repoquery [<select-options>] [<query-options>] [<package-spec>]``
     Searches available DNF repositories for selected packages and displays the requested information about them. It
     is an equivalent of ``rpm -q`` for remote repositories.
 
@@ -1088,10 +1088,10 @@ Repoquery Command
 Select Options
 --------------
 
-Together with ``<pkg-spec>``, control what packages are displayed in the output. If ``<pkg-spec>`` is given, limits the resulting set of
-packages to those matching the specification. All packages are considered if no ``<pkg-spec>`` is specified.
+Together with ``<package-spec>``, control what packages are displayed in the output. If ``<package-spec>`` is given, limits the resulting set of
+packages to those matching the specification. All packages are considered if no ``<package-spec>`` is specified.
 
-``<pkg-spec>``
+``<package-spec>``
     Package specification in the NEVRA format (name[-[epoch:]version[-release]][.arch]). See :ref:`Specifying Packages
     <specifying_packages-label>`.
 


### PR DESCRIPTION
A handful of general fixes regarding the <package-spec> markers throughout the man page and a rewrite of the description of NEVRA parsing in the package specs. Unless I totally misunderstood something, the current documentation is actually quite wrong...