### PR TITLE
[spec] Drop %systemd_requires from main package

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -110,7 +110,6 @@ Recommends:     (python2-dbus if NetworkManager)
 %endif
 Recommends:     (%{_bindir}/sqlite3 if bash-completion)
 %endif
-%{?systemd_requires}
 Provides:       dnf-command(alias)
 Provides:       dnf-command(autoremove)
 Provides:       dnf-command(check-update)


### PR DESCRIPTION
DNF can work just fine without systemd, even though there are some
services (dnf-makecache.{service,timer}) which enhance DNF.

From Fedora downstream: https://src.fedoraproject.org/rpms/dnf/pull-request/17