### PR TITLE
handling of xml:base (RhBug:1727137)

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1131,7 +1131,7 @@ class Base(object):
          output messages about the download operation.
 
         """
-        remote_pkgs, local_repository_pkgs = self._select_remote_pkgs(pkglist)
+        remote_pkgs, local_pkgs = self._select_remote_pkgs(pkglist)
         if remote_pkgs:
             if progress is None:
                 progress = dnf.callback.NullDownloadProgress()
@@ -1144,8 +1144,12 @@ class Base(object):
             self._download_remote_payloads(payloads, drpm, progress, callback_total)
 
         if self.conf.destdir:
-            for pkg in local_repository_pkgs:
-                location = os.path.join(pkg.repo.pkgdir, pkg.location.lstrip("/"))
+            for pkg in local_pkgs:
+                if pkg.baseurl:
+                    location = os.path.join(pkg.baseurl.replace("file://", ""),
+                                            pkg.location.lstrip("/"))
+                else:
+                    location = os.path.join(pkg.repo.pkgdir, pkg.location.lstrip("/"))
                 shutil.copy(location, self.conf.destdir)
 
     def add_remote_rpms(self, path_list, strict=True, progress=None):

--- a/dnf/package.py
+++ b/dnf/package.py
@@ -211,11 +211,11 @@ class Package(hawkey.Package):
         if self._from_cmdline:
             return self.location
         loc = self.location
-        if not self.repo._repo.isLocal():
-            loc = os.path.basename(loc)
-        elif self.baseurl and self.baseurl.startswith('file://'):
+        if self.repo._repo.isLocal() and self.baseurl and self.baseurl.startswith('file://'):
             return os.path.join(self.baseurl, loc.lstrip("/"))[7:]
-        return os.path.join(self.repo.pkgdir, loc.lstrip("/"))
+        if not self._is_local_pkg():
+            loc = os.path.basename(loc)
+        return os.path.join(self.pkgdir, loc.lstrip("/"))
 
     def remote_location(self, schemes=('http', 'ftp', 'file', 'https')):
         # :api
@@ -249,6 +249,13 @@ class Package(hawkey.Package):
             return True
         return self._from_cmdline or \
             (self.repo._repo.isLocal() and (not self.baseurl or self.baseurl.startswith('file://')))
+
+    @property
+    def pkgdir(self):
+        if (self.repo._repo.isLocal() and not self._is_local_pkg()):
+            return self.repo.cache_pkgdir()
+        else:
+            return self.repo.pkgdir
 
     # yum compatibility method
     def returnIdSum(self):

--- a/dnf/repo.py
+++ b/dnf/repo.py
@@ -233,7 +233,7 @@ class PackagePayload(dnf.callback.Payload):
 
     def _librepo_target(self):
         pkg = self.pkg
-        pkgdir = pkg.repo.pkgdir
+        pkgdir = pkg.pkgdir
         dnf.util.ensure_dir(pkgdir)
 
         target_dct = {
@@ -458,6 +458,9 @@ class Repo(dnf.conf.RepoConf):
         # :api
         if self._repo.isLocal():
             return dnf.util.strip_prefix(self.baseurl[0], 'file://')
+        return self.cache_pkgdir()
+
+    def cache_pkgdir(self):
         if self._pkgdir is not None:
             return self._pkgdir
         return os.path.join(self._repo.getCachedir(), _PACKAGES_RELATIVE_DIR)


### PR DESCRIPTION
Because there can be local repository with remote and local packages at the same time (using xml:base) we cannot ask the repo where a pkgdir for its package is, only the package knows if it is remote or local.

We don't want to needlessly copy local packages to cache. At the same time we want to
download remote packages from local repositories to cache. And all of this has to work with --destdir.