### PR TITLE
Fix: --setopt and repo with dots

### DIFF
--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -102,7 +102,7 @@ class OptionParser(argparse.ArgumentParser):
                 logger.warning(_("Setopt argument has no value: %s"), values)
                 return
             k, v = vals
-            period = k.find('.')
+            period = k.rfind('.')
             if period != -1:
                 repo = k[:period]
                 k = k[period+1:]


### PR DESCRIPTION
The "--setopt" have had a problem with repositories with dots.

Example:
"--setopt=re.po.option=value " had been parsed as repo "re" and option
"po.option". Correct result is repo "re.po" and option "option".