### PR TITLE
[repoquery] Do --latest-limit filter sooner (RhBug:1561795)

### DIFF
--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -424,6 +424,8 @@ class RepoQueryCommand(commands.Command):
 
         if self.opts.recent:
             q = q._recent(self.base.conf.recent)
+        if self.opts.latest_limit:
+            q = q.latest(self.opts.latest_limit)
         if self.opts.available:
             if self.opts.list and self.opts.list != "installed":
                 print(self.cli.optparser.print_usage())
@@ -497,8 +499,6 @@ class RepoQueryCommand(commands.Command):
             q.filterm(supplements__glob=self.opts.whatsupplements)
         if self.opts.whatsuggests:
             q.filterm(suggests__glob=self.opts.whatsuggests)
-        if self.opts.latest_limit:
-            q = q.latest(self.opts.latest_limit)
         # reduce a query to security upgrades if they are specified
         q = self.base._merge_update_filters(q, warning=False)
         if self.opts.srpm:


### PR DESCRIPTION
Move --latest-limit filter execution closer to --avaliable, --installed,
--recent etc.
This gives dnf repoquery ability to operate only on the newest available
versions of packages when for example searching packages that require
some capability.

Before the patch "dnf repoquery --latest-limit=1 --whatrequires
CAPABILITY" command first limited the packageset to those providing the
capability and then print only the newest versions of found packages.
Now first the packageset is limited to the latest versions and than the
capability is looked for.

https://bugzilla.redhat.com/show_bug.cgi?id=1561795