### PR TITLE
Fix "dnf copr help" command, workaround for RhBug:1743902

### DIFF
--- a/dnf/cli/commands/mark.py
+++ b/dnf/cli/commands/mark.py
@@ -41,8 +41,8 @@ class MarkCommand(commands.Command):
     @staticmethod
     def set_argparser(parser):
         parser.add_argument('mark', nargs=1, choices=['install', 'remove', 'group'],
-                            help=_("install: mark as installed by user, "
-                                   "remove: unmark as installed by user, "
+                            help=_("install: mark as installed by user\n"
+                                   "remove: unmark as installed by user\n"
                                    "group: mark as installed by group"))
         parser.add_argument('package', nargs='+', metavar="PACKAGE",
                             help=_("Package specification"))

--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -33,11 +33,18 @@ import sys
 
 logger = logging.getLogger("dnf")
 
+class MultilineHelpFormatter(argparse.HelpFormatter):
+    def _split_lines(self, text, width):
+        if '\n' in text:
+            return text.splitlines()
+        return super(MultilineHelpFormatter, self)._split_lines(text, width)
+
 class OptionParser(argparse.ArgumentParser):
     """ArgumentParser like class to do things the "yum way"."""
 
     def __init__(self, reset_usage=True):
-        super(OptionParser, self).__init__(add_help=False)
+        super(OptionParser, self).__init__(add_help=False,
+                                           formatter_class=MultilineHelpFormatter)
         self.command_positional_parser = None
         self.command_group = None
         self._add_general_options()


### PR DESCRIPTION
- fix option_parser.print_help() method
- allow multi line helps for command line arguments (can be used by https://bugzilla.redhat.com/show_bug.cgi?id=1743902#c6 to specify help strings for individual values)