### PR TITLE
Change test according to new behavior of libdnf

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -81,7 +81,7 @@
 It supports RPMs, modules and comps groups & environments.
 
 Name:           dnf
-Version:        4.2.10
+Version:        4.2.11
 Release:        1%{?dist}
 Summary:        %{pkg_summary}
 # For a breakdown of the licensing, see PACKAGE-LICENSING

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -423,15 +423,10 @@ class RepoPkgsInfoSubCommandTest(tests.support.DnfBaseTestCase):
     def test_info_extras(self):
         """Test whether only extras installed from the repository are listed."""
         tsis = []
-        for pkg in self.base.sack.query().installed().filter(name='tour'):
+        for pkg in self.base.sack.query().installed().filter(name='test'):
             pkg._force_swdb_repoid = "main"
             self.history.rpm.add_install(pkg)
-#            tsi = dnf.transaction.TransactionItem(
-#                dnf.transaction.INSTALL,
-#                installed=pkg,
-#                reason=libdnf.transaction.TransactionItemReason_USER
-#            )
-#            tsis.append(tsi)
+
         self._swdb_commit(tsis)
 
         cmd = dnf.cli.commands.RepoPkgsCommand(self.cli)
@@ -441,8 +436,8 @@ class RepoPkgsInfoSubCommandTest(tests.support.DnfBaseTestCase):
         self.assertEqual(
             stdout.getvalue(),
             u'Extra Packages\n'
-            u'Name         : tour\n'
-            u'Version      : 5\n'
+            u'Name         : test\n'
+            u'Version      : 1\n'
             u'Release      : 0\n'
             u'Architecture : noarch\n'
             u'Size         : 0.0  \n'

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -58,7 +58,7 @@ class QueriesTest(tests.support.TestCase):
 
     def test_extras(self):
         pkgs = self.sack.query().extras()
-        self.assertEqual(len(pkgs), tests.support.TOTAL_RPMDB_COUNT - 2)
+        self.assertEqual(len(pkgs), tests.support.TOTAL_RPMDB_COUNT - 4)
 
     def test_installed_exact(self):
         pkgs = self.sack.query().installed()._nevra("tour-4.9-0.noarch")


### PR DESCRIPTION
The formal implementation marks as an extras installed packages that are
not in set of available packages (using full NEVRA for comparison).