### PR TITLE
Keep installed packages in upgrade job (RhBug:1728252,1644241)

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -1,5 +1,5 @@
 # default dependencies
-%global hawkey_version 0.35.4
+%global hawkey_version 0.35.5
 %global libcomps_version 0.1.8
 %global libmodulemd_version 1.4.0
 %global rpm_version 4.14.0
@@ -81,7 +81,7 @@
 It supports RPMs, modules and comps groups & environments.
 
 Name:           dnf
-Version:        4.2.10
+Version:        4.2.11
 Release:        1%{?dist}
 Summary:        %{pkg_summary}
 # For a breakdown of the licensing, see PACKAGE-LICENSING

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1968,9 +1968,6 @@ class Base(object):
                 obsoletes=q.installed().union(q.upgrades()))
             # add obsoletes into transaction
             q = q.union(obsoletes)
-        # provide only available packages to solver otherwise selection of available
-        # possibilities will be ignored
-        q = q.available()
         if reponame is not None:
             q.filterm(reponame=reponame)
         q = self._merge_update_filters(q, pkg_spec=pkg_spec)

--- a/dnf/module/module_base.py
+++ b/dnf/module/module_base.py
@@ -214,7 +214,7 @@ class ModuleBase(object):
 
             if not upgrade_package_set:
                 logger.error(_("Unable to match profile in argument {}").format(spec))
-            query = self.base.sack.query().available().filterm(name=upgrade_package_set)
+            query = self.base.sack.query().filterm(name=upgrade_package_set)
             if query:
                 sltr = dnf.selector.Selector(self.base.sack)
                 sltr.set(pkg=query)


### PR DESCRIPTION
In combination with marking of job as TARGETED it prevents from
reinstalling of modified packages with same NEVRA.

https://bugzilla.redhat.com/show_bug.cgi?id=1728252
https://bugzilla.redhat.com/show_bug.cgi?id=1644241

Requires: https://github.com/rpm-software-management/libdnf/pull/786