### PR TITLE
Restore functionality of dnf remove --duplicates (regression)

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -620,8 +620,17 @@ class Base(object):
         for pkg in goal.list_reinstalls():
             self._ds_callback.pkg_added(pkg, 'r')
             obs = goal.obsoleted_by_package(pkg)
-            reinstalled = obs[0]
-            ts.add_reinstall(pkg, reinstalled, obs[1:])
+            nevra_pkg = str(pkg)
+            # reinstall could obsolete multiple packages with the same NEVRA or different NEVRA
+            # Set the package with the same NEVRA as reinstalled
+            obsoletes = []
+            for obs_pkg in obs:
+                if str(obs_pkg) == nevra_pkg:
+                    obsoletes.insert(0, obs_pkg)
+                else:
+                    obsoletes.append(obs_pkg)
+            reinstalled = obsoletes[0]
+            ts.add_reinstall(pkg, reinstalled, obsoletes[1:])
         for pkg in goal.list_installs():
             self._ds_callback.pkg_added(pkg, 'i')
             obs = goal.obsoleted_by_package(pkg)

--- a/dnf/db/group.py
+++ b/dnf/db/group.py
@@ -321,7 +321,8 @@ class RPMTransaction(object):
                 modular_problems += self._test_fail_safe(hdr, tsi.pkg)
                 ts.addReinstall(hdr, tsi)
             elif tsi.action == libdnf.transaction.TransactionItemAction_REINSTALLED:
-                pass
+                # Required when multiple packages with the same NEVRA marked as installed
+                ts.addErase(tsi.pkg.idx)
             elif tsi.action == libdnf.transaction.TransactionItemAction_REMOVE:
                 ts.addErase(tsi.pkg.idx)
             elif tsi.action == libdnf.transaction.TransactionItemAction_UPGRADE:

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -1025,7 +1025,10 @@ Remove Command
     Removes the specified packages from the system along with any packages depending on the packages being removed. Each ``<spec>`` can be either a ``<package-spec>``, which specifies a package directly, or a ``@<group-spec>``, which specifies an (environment) group which contains it. If ``clean_requirements_on_remove`` is enabled (the default), also removes any dependencies that are no longer needed.
 
 ``dnf [options] remove --duplicates``
-    Removes older version of duplicated packages.
+    Removes older versions of duplicate packages. To ensure the integrity of the system it
+    reinstalls the newest package. In some cases the command cannot resolve conflicts. In such cases
+    the :ref:`dnf shell <shell_command-label>` command with ``remove --duplicates`` and ``upgrade``
+    dnf-shell sub-commands could help.
 
 ``dnf [options] remove --oldinstallonly``
     Removes old installonly packages, keeping only ``installonly_limit`` latest versions.


### PR DESCRIPTION
I tested it with broken upgrade and reinstall transactions.

I would love to create a test for the functionality, but creation of broken system in testing environment is something that I am unable to delivery.