### PR TITLE
History list and info fixes

### DIFF
--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -1003,9 +1003,10 @@ class HistoryCommand(Command):
     def run(self):
         vcmd = self.opts.transactions_action
 
-        if vcmd == 'list':
+        ret = None
+        if vcmd == 'list' and (self.transaction_ids or not self.opts.transactions):
             ret = self.output.historyListCmd(self.transaction_ids)
-        elif vcmd == 'info':
+        elif vcmd == 'info' and (self.transaction_ids or not self.opts.transactions):
             ret = self.output.historyInfoCmd(self.transaction_ids, self.opts.transactions,
                                              self.merged_transaction_ids)
         elif vcmd == 'undo':

--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -1654,7 +1654,7 @@ Transaction Summary
         if tids is None:
             return
 
-        old_tids = self.history.old(tids)
+        transactions = self.history.old(tids)
         if self.conf.history_list_view == 'users':
             uids = [1, 2]
         elif self.conf.history_list_view == 'commands':
@@ -1664,11 +1664,11 @@ Transaction Summary
             uids = set()
             done = 0
             blanks = 0
-            for old in old_tids:
+            for transaction in transactions:
                 done += 1
-                if old.cmdline is None:
+                if transaction.cmdline is None:
                     blanks += 1
-                uids.add(old.loginuid)
+                uids.add(transaction.loginuid)
 
         fmt = "%s | %s | %s | %s | %s"
         if len(uids) == 1:
@@ -1684,30 +1684,30 @@ Transaction Summary
         print("-" * 79)
         fmt = "%6u | %s | %-16.16s | %s | %4u"
 
-        for old in old_tids:
+        for transaction in transactions:
             if len(uids) == 1:
-                name = old.cmdline or ''
+                name = transaction.cmdline or ''
             else:
-                name = self._pwd_ui_username(old.loginuid, 24)
+                name = self._pwd_ui_username(transaction.loginuid, 24)
             name = ucd(name)
             tm = time.strftime("%Y-%m-%d %H:%M",
-                               time.localtime(old.beg_timestamp))
-            num, uiacts = self._history_uiactions(old.data())
+                               time.localtime(transaction.beg_timestamp))
+            num, uiacts = self._history_uiactions(transaction.data())
             name = fill_exact_width(name, 24, 24)
             uiacts = fill_exact_width(uiacts, 14, 14)
             rmark = lmark = ' '
-            if old.return_code is None:
+            if transaction.return_code is None:
                 rmark = lmark = '*'
-            elif old.return_code:
+            elif transaction.return_code:
                 rmark = lmark = '#'
                 # We don't check .errors, because return_code will be non-0
-            elif old.is_output:
+            elif transaction.is_output:
                 rmark = lmark = 'E'
-            if old.altered_lt_rpmdb:
+            if transaction.altered_lt_rpmdb:
                 rmark = '<'
-            if old.altered_gt_rpmdb:
+            if transaction.altered_gt_rpmdb:
                 lmark = '>'
-            print(fmt % (old.tid, name, tm, uiacts, num), "%s%s" % (lmark, rmark))
+            print(fmt % (transaction.tid, name, tm, uiacts, num), "%s%s" % (lmark, rmark))
 
     def historyInfoCmd(self, extcmds, pats=[], mtids=set()):
         """Output information about a transaction in history
@@ -1716,20 +1716,20 @@ Transaction Summary
         :raises dnf.exceptions.Error in case no transactions were found
         """
         tids = set(extcmds)
-        old = self.history.last()
-        if old is None:
+        last = self.history.last()
+        if last is None:
             logger.critical(_('No transactions'))
             raise dnf.exceptions.Error(_('Failed history info'))
 
-        lasttid = old.tid
-        lastdbv = old.end_rpmdb_version
+        lasttid = last.tid
+        lastdbv = last.end_rpmdb_version
 
         transactions = []
         if not tids and len(extcmds) < 2:
-            old = self.history.last(complete_transactions_only=False)
-            if old is not None:
-                tids.add(old.tid)
-                transactions.append(old)
+            last = self.history.last(complete_transactions_only=False)
+            if last is not None:
+                tids.add(last.tid)
+                transactions.append(last)
         else:
             transactions = self.history.old(tids)
 

--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -1650,61 +1650,64 @@ Transaction Summary
         :param extcmds: list of extra command line arguments
         """
         tids = self._history_list_transactions(extcmds)
-        if tids is not None:
-            old_tids = self.history.old(tids)
-            if self.conf.history_list_view == 'users':
-                uids = [1, 2]
-            elif self.conf.history_list_view == 'commands':
-                uids = [1]
-            else:
-                assert self.conf.history_list_view == 'single-user-commands'
-                uids = set()
-                done = 0
-                blanks = 0
-                for old in old_tids:
-                    done += 1
-                    if old.cmdline is None:
-                        blanks += 1
-                    uids.add(old.loginuid)
 
-            fmt = "%s | %s | %s | %s | %s"
-            if len(uids) == 1:
-                name = _("Command line")
-            else:
-                # TRANSLATORS: user names who executed transaction in history command output
-                name = _("User name")
-            print(fmt % (fill_exact_width(_("ID"), 6, 6),
-                        fill_exact_width(name, 24, 24),
-                        fill_exact_width(_("Date and time"), 16, 16),
-                        fill_exact_width(_("Action(s)"), 14, 14),
-                        fill_exact_width(_("Altered"), 7, 7)))
-            print("-" * 79)
-            fmt = "%6u | %s | %-16.16s | %s | %4u"
+        if tids is None:
+            return
 
+        old_tids = self.history.old(tids)
+        if self.conf.history_list_view == 'users':
+            uids = [1, 2]
+        elif self.conf.history_list_view == 'commands':
+            uids = [1]
+        else:
+            assert self.conf.history_list_view == 'single-user-commands'
+            uids = set()
+            done = 0
+            blanks = 0
             for old in old_tids:
-                if len(uids) == 1:
-                    name = old.cmdline or ''
-                else:
-                    name = self._pwd_ui_username(old.loginuid, 24)
-                name = ucd(name)
-                tm = time.strftime("%Y-%m-%d %H:%M",
-                                   time.localtime(old.beg_timestamp))
-                num, uiacts = self._history_uiactions(old.data())
-                name = fill_exact_width(name, 24, 24)
-                uiacts = fill_exact_width(uiacts, 14, 14)
-                rmark = lmark = ' '
-                if old.return_code is None:
-                    rmark = lmark = '*'
-                elif old.return_code:
-                    rmark = lmark = '#'
-                    # We don't check .errors, because return_code will be non-0
-                elif old.is_output:
-                    rmark = lmark = 'E'
-                if old.altered_lt_rpmdb:
-                    rmark = '<'
-                if old.altered_gt_rpmdb:
-                    lmark = '>'
-                print(fmt % (old.tid, name, tm, uiacts, num), "%s%s" % (lmark, rmark))
+                done += 1
+                if old.cmdline is None:
+                    blanks += 1
+                uids.add(old.loginuid)
+
+        fmt = "%s | %s | %s | %s | %s"
+        if len(uids) == 1:
+            name = _("Command line")
+        else:
+            # TRANSLATORS: user names who executed transaction in history command output
+            name = _("User name")
+        print(fmt % (fill_exact_width(_("ID"), 6, 6),
+                    fill_exact_width(name, 24, 24),
+                    fill_exact_width(_("Date and time"), 16, 16),
+                    fill_exact_width(_("Action(s)"), 14, 14),
+                    fill_exact_width(_("Altered"), 7, 7)))
+        print("-" * 79)
+        fmt = "%6u | %s | %-16.16s | %s | %4u"
+
+        for old in old_tids:
+            if len(uids) == 1:
+                name = old.cmdline or ''
+            else:
+                name = self._pwd_ui_username(old.loginuid, 24)
+            name = ucd(name)
+            tm = time.strftime("%Y-%m-%d %H:%M",
+                               time.localtime(old.beg_timestamp))
+            num, uiacts = self._history_uiactions(old.data())
+            name = fill_exact_width(name, 24, 24)
+            uiacts = fill_exact_width(uiacts, 14, 14)
+            rmark = lmark = ' '
+            if old.return_code is None:
+                rmark = lmark = '*'
+            elif old.return_code:
+                rmark = lmark = '#'
+                # We don't check .errors, because return_code will be non-0
+            elif old.is_output:
+                rmark = lmark = 'E'
+            if old.altered_lt_rpmdb:
+                rmark = '<'
+            if old.altered_gt_rpmdb:
+                lmark = '>'
+            print(fmt % (old.tid, name, tm, uiacts, num), "%s%s" % (lmark, rmark))
 
     def historyInfoCmd(self, extcmds, pats=[], mtids=set()):
         """Output information about a transaction in history

--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -1648,12 +1648,6 @@ Transaction Summary
         transactions.
 
         :param extcmds: list of extra command line arguments
-        :return: (exit_code, [errors])
-
-        exit_code is::
-
-            0 = we're done, exit
-            1 = we've errored, exit with error string
         """
         tids = self._history_list_transactions(extcmds)
         if tids is not None:
@@ -1716,18 +1710,13 @@ Transaction Summary
         """Output information about a transaction in history
 
         :param extcmds: list of extra command line arguments
-        :return: (exit_code, [errors])
-
-        exit_code is::
-
-            0 = we're done, exit
-            1 = we've errored, exit with error string
+        :raises dnf.exceptions.Error in case no transactions were found
         """
         tids = set(extcmds)
         old = self.history.last()
         if old is None:
             logger.critical(_('No transactions'))
-            return 1, [_('Failed history info')]
+            raise dnf.exceptions.Error(_('Failed history info'))
 
         lasttid = old.tid
         lastdbv = old.end_rpmdb_version
@@ -1743,7 +1732,7 @@ Transaction Summary
 
         if not tids:
             logger.critical(_('No transaction ID, or package, given'))
-            return 1, [_('Failed history info')]
+            raise dnf.exceptions.Error(_('Failed history info'))
 
         bmtid, emtid = -1, -1
         mobj = None

--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -1593,10 +1593,10 @@ Transaction Summary
             # TRANSLATORS: user names who executed transaction in history command output
             name = _("User name")
         print(fmt % (fill_exact_width(_("ID"), 6, 6),
-                    fill_exact_width(name, 24, 24),
-                    fill_exact_width(_("Date and time"), 16, 16),
-                    fill_exact_width(_("Action(s)"), 14, 14),
-                    fill_exact_width(_("Altered"), 7, 7)))
+                     fill_exact_width(name, 24, 24),
+                     fill_exact_width(_("Date and time"), 16, 16),
+                     fill_exact_width(_("Action(s)"), 14, 14),
+                     fill_exact_width(_("Altered"), 7, 7)))
         print("-" * 79)
         fmt = "%6u | %s | %-16.16s | %s | %4u"
 


### PR DESCRIPTION
Improvements for the `history list` and `history info` command functions, ultimately fixing when a nonexistent package name was used as an argument causing to list all transactions or print info for the last one.