### PR TITLE
[updateinfo] Do not show older install-only pkgs updates (RhBug:1649383,1728004)

### DIFF
--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -1524,6 +1524,11 @@ Updateinfo Command
     cases when an advisory refers to a newer version but there is no enabled
     repository which contains any newer version.
 
+    Note, that ``--available`` tooks only the latest installed versions of
+    packages into account. In case of the kernel packages (when multiple
+    version could be installed simultaneously) also packages of the currently
+    running version of kernel are added.
+
     If given and if neither ID, type (``bugfix``, ``enhancement``,
     ``security``/``sec``) nor a package name of an advisory matches
     ``<spec>``, the advisory is not taken into account. The matching is


### PR DESCRIPTION
'updateinfo --available' command used to show advisories for all
installed versions of packages. In the case of install-only packages
(where multiple versions of the package could be installed) this led to
printing also already installed advisories. New behavior is to print only
advisories for the latest installed version of the package (plus in case
of kernel advisories for the currently running kernel). E.g.:

available advisories:
kernel-5.2.13

installed kernels:
kernel-5.2.13
kernel-5.2.14

running kernel:
kernel-5.2.14

Previous behavior:
```
$ dnf updateinfo --list
<advisories for kernel-5.2.13 are listed>
```

New behavior:
```
$ dnf updateinfo --list
<no kernel advisories are printed>
```

https://bugzilla.redhat.com/show_bug.cgi?id=1649383
https://bugzilla.redhat.com/show_bug.cgi?id=1728004