### PR TITLE
[doc] Describe relation of dnf.conf with defaults in conf (RhBug:1738…

### DIFF
--- a/doc/cli_vs_yum.rst
+++ b/doc/cli_vs_yum.rst
@@ -117,6 +117,15 @@ Also see related Fedora bugzillas `982947
 
 .. _skip_if_unavailable_default:
 
+===========================================
+ ``skip_if_unavailable`` enabled by default
+===========================================
+
+In some distributions DNF is shipped with ``skip_if_unavailable=True`` in
+:ref:`DNF configuration file <conf_ref-label>` file. The reason for the change is that third-party
+repositories may often be unavailable. Note that without `skip_if_unavailable=True`` YUM immediately
+stops on a repo error, confusing and bothering the user.
+
 ============================================
  ``skip_if_unavailable`` enabled by default
 ============================================

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -89,7 +89,8 @@ or :ref:`mirrorlist <mirrorlist-label>` option definition.
 
     ``True`` instructs the solver to either use a package with the highest available
     version or fail. On ``False``, do not fail if the latest version cannot be
-    installed and go with the lower version. The default is ``True``.
+    installed and go with the lower version. The default is ``True``. The default can be overridden
+    by :ref:`DNF configuration file <conf_ref-label>` that can differ for particular distribution.
 
 ``cachedir``
     :ref:`string <string-label>`
@@ -712,7 +713,9 @@ configuration.
     If enabled, DNF will continue running and disable the repository that couldn't be synchronized
     for any reason. This option doesn't affect skipping of unavailable packages after dependency
     resolution. To check inaccessibility of repository use it in combination with
-    :ref:`refresh command line option <refresh_command-label>`. The default is ``False``.
+    :ref:`refresh command line option <refresh_command-label>`. The default is ``False``. The
+    default can be overridden by :ref:`DNF configuration file <conf_ref-label>` that can differ for
+    particular distribution.
 
 .. _sslcacert-label:
 


### PR DESCRIPTION
…837)

Options skip_if_unavailable and best are shipped with different defaults
for particular distributions. Defaults are adjusted by different content
of dnf.conf. The patch mentions the situation for those two options.

https://bugzilla.redhat.com/show_bug.cgi?id=1738837