### PR TITLE
logging: always log the repo loading error, but not to stderr (RhBug:…

### DIFF
--- a/dnf/logging.py
+++ b/dnf/logging.py
@@ -169,6 +169,9 @@ class Logging(object):
         # put the marker in the file now:
         _paint_mark(logger_dnf)
 
+        logger_dnf_no_stderr = logging.getLogger("dnf_no_stderr")
+        logger_dnf_no_stderr.addHandler(handler)
+
         # setup Python warnings
         logging.captureWarnings(True)
         logger_warnings = logging.getLogger("py.warnings")

--- a/dnf/repo.py
+++ b/dnf/repo.py
@@ -66,6 +66,7 @@ CACHE_FILES = {
 }
 
 logger = logging.getLogger("dnf")
+logger_no_stderr = logging.getLogger("dnf_no_stderr")
 
 
 def repo_id_invalid(repo_id):
@@ -554,6 +555,10 @@ class Repo(dnf.conf.RepoConf):
         try:
             ret = self._repo.load()
         except RuntimeError as e:
+            if self.skip_if_unavailable:
+                logger_no_stderr.warning(e)
+            else:
+                logger_no_stderr.error(e)
             raise dnf.exceptions.RepoError(str(e))
         self.metadata = Metadata(self._repo)
         return ret


### PR DESCRIPTION
…1741442)

When loading a repository fails, an exception is thrown, which is logged
(as well as printed to stderr) in dnf/cli/main.py when run from the
command line. When run from API, the exception is thrown but not logged.

We should log these important errors even if we raise an exception on
the API. The problem is the "dnf" logger automatically prints everything
loggged as WARNING or higher to stderr, which means on command line the
error would be printed to stderr twice.

This commit adds another logger, "dnf_no_stderr", which only logs to the
file and not to stderr. This logger is then used to log the repo loading
error.

https://bugzilla.redhat.com/show_bug.cgi?id=1741442

---
I'm adding a WIP label just because I don't find this a very nice solution (otherwise I don't think it's getting better), even though creating a logger that only logs to the file ended up being quite painless... @pkratoch, have a look :slightly_smiling_face: 