### PR TITLE
Improve dnf performance

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ###############
- Dandified YUM
+ Improve Dandified YUM
 ###############
 
 .. image:: https://raw.githubusercontent.com/rpm-software-management/dnf/gh-pages/logos/DNF_logo.png


### PR DESCRIPTION
dnf installs very slow and only install's 4 or 8 packages concurrently on SSD, however there is not much disk or CPU activity, internet was not a problem since its a local repo. Package resolution should be faster on a High End PC, I bet yum may also be slow even on a supercomputer, this indicates that yum is too inefficient.

Yum should install faster, maximize maybe utlize 25% of CPU and SSD bandwidth. Package resolution should be faster on a High End PC.

1. Yum could as well add a dependency look ahead, where it decompresses 10-100 rpms (depending on the system resources) for que for installation on high end system.
2. Yum could as well install 20 or more packages concurrently and implement advance package dependency resolution for such capability.