### PR TITLE
Dont check if repo is expired if it doesn't have loaded metadata (RhBug:1745170)

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -231,7 +231,8 @@ class Base(object):
 
     def _store_persistent_data(self):
         if self._repo_persistor and not self.conf.cacheonly:
-            expired = [r.id for r in self.repos.iter_enabled() if r._repo.isExpired()]
+            expired = [r.id for r in self.repos.iter_enabled()
+                       if (r.metadata and r._repo.isExpired())]
             self._repo_persistor.expired_to_add.update(expired)
             self._repo_persistor.save()
 


### PR DESCRIPTION
Checking whether a repo is expired if it doesn't have loaded
cached metadata always returns true (libdnf's getAge on empty
string returns a big number)

If a command didn't load repository caches it ended up always
expiring all its repos by storing their IDs in expired_repos.json

https://bugzilla.redhat.com/show_bug.cgi?id=1745170

test: https://github.com/rpm-software-management/ci-dnf-stack/pull/645