### PR TITLE
Fix Repo and RepoConf init

### DIFF
--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -426,9 +426,11 @@ class RepoConf(BaseConfig):
     """Option definitions for repository INI file sections."""
 
     def __init__(self, parent, section=None, parser=None):
-        super(RepoConf, self).__init__(libdnf.conf.ConfigRepo(
-            parent._config if parent else libdnf.conf.ConfigMain()), section, parser)
-        self._masterConfig = parent._config if parent else libdnf.conf.ConfigMain()
+        masterConfig = parent._config if parent else libdnf.conf.ConfigMain()
+        super(RepoConf, self).__init__(libdnf.conf.ConfigRepo(masterConfig), section, parser)
+        # Do not remove! Attribute is a reference holder.
+        # Prevents premature removal of the masterConfig. The libdnf ConfigRepo points to it.
+        self._masterConfigRefHolder = masterConfig
         if section:
             self._config.name().set(PRIO_DEFAULT, section)
 

--- a/dnf/repo.py
+++ b/dnf/repo.py
@@ -422,7 +422,7 @@ class Repo(dnf.conf.RepoConf):
         super(Repo, self).__init__(section=name, parent=parent_conf)
 
         self._config.this.disown()  # _repo will be the owner of _config
-        self._repo = libdnf.repo.Repo(name, self._config)
+        self._repo = libdnf.repo.Repo(name if name else "", self._config)
 
         self._md_pload = MDPayload(dnf.callback.NullDownloadProgress())
         self._callbacks = RepoCallbacks(self)

--- a/doc/api_repos.rst
+++ b/doc/api_repos.rst
@@ -116,7 +116,7 @@ Repository Configuration
   .. method:: __init__(name=None, parent_conf=None)
 
     Init repository with ID `name` and the `parent_conf` which an instance of :class:`dnf.conf.Conf`
-    holding main dnf configuration.
+    holding main dnf configuration. Repository ID must be a string that can contain ASCII letters, digits, and `-_.:` characters.
 
   .. method:: add_metadata_type_to_download(metadata_type)
 


### PR DESCRIPTION
The id argument of libdnf.repo.Repo() constructor can't be None.
Fix reference holding to libdnf::ConfigMain object in RepoConf.