### PR TITLE
Fix priority of default value of repo name attribute to PRIO_DEFAULT

### DIFF
--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -430,7 +430,7 @@ class RepoConf(BaseConfig):
             parent._config if parent else libdnf.conf.ConfigMain()), section, parser)
         self._masterConfig = parent._config if parent else libdnf.conf.ConfigMain()
         if section:
-            self.name = section
+            self._config.name().set(PRIO_DEFAULT, section)
 
     def _configure_from_options(self, opts):
         """Configure repos from the opts. """


### PR DESCRIPTION
Implicit priority PRIO_RUNTIME was used before. PRIO_RUNTIME is unusable
for default value. It cannot be overwritten by a repoconfig.