### PR TITLE
Group install takes obsoletes into account (RhBug:1761137)

### DIFF
--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -614,6 +614,7 @@ Groups are virtual collections of packages. DNF keeps track of groups that the u
     specified. All `mandatory` and `Default` packages will be installed whenever possible.
     Conditional packages are installed if they meet their requirement.
     If the group is already (partially) installed, the command installs the missing packages from the group.
+    Depending on the value of :ref:`obsoletes configuration option <obsoletes_conf_option-label>` group installation takes obsoletes into account.
 
 .. _grouplist_command-label:
 


### PR DESCRIPTION
The problem occurs when a group definition contained both obsoleter and
obsoleted packages.

For example group xfce-desktop contains mandatory packages xfce4-session
and xfce4-session-engines:

<group>
    <id>xfce-desktop</id>
    <packagereq type="mandatory">xfce4-session</packagereq>
    <packagereq type="mandatory">xfce4-session-engines</packagereq>
</group>

But during the release cycle the xfce4-session-engines got obsoleted by
the xfce4-session package:

$ dnf repoquery --obsoletes xfce4-session
xfce4-session-engines <= 4.13.1

Originally "group install" command did not take obsoletes into account
and solver resolved the transaction by leaving old versions of
xfce4-session and xfce4-session-engines (which do not obsolete one
another) on the system and prints warning about conflicting requests:

Problem: package xfce4-session-4.14.0-1.fc30.x86_64 obsoletes xfce4-session-engines <= 4.13.1 provided by xfce4-session-engines-4.13.1-23.fc30.x86_64
  - cannot install the best candidate for the job
  - conflicting requests

With this change only newer version of the xfce4-session got installed.

https://bugzilla.redhat.com/show_bug.cgi?id=1761137