### PR TITLE
Bump dnf-yum obsoletes to workaround lower version of dnf in F31 (RhB…

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -158,7 +158,7 @@ Summary:        %{pkg_summary}
 %if 0%{?fedora}
 %if 0%{?fedora} >= 31
 Provides:       %{name}-yum = %{version}-%{release}
-Obsoletes:      %{name}-yum < %{version}-%{release}
+Obsoletes:      %{name}-yum < 5
 %else
 Conflicts:      yum < 3.4.3-505
 %endif


### PR DESCRIPTION
…ug:1760937)

In Fedora 31, dnf has lower version than in Fedora 30, therefore,
the obsolete has no effect and it breaks system-upgrade when dnf-yum
is installed. This workaround prevents that.

https://bugzilla.redhat.com/show_bug.cgi?id=1760937