### PR TITLE
cli: reconcile how permissions are effectively checked vs. suggestion

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -808,7 +808,8 @@ class Cli(object):
 
         if demands.root_user:
             if not dnf.util.am_i_root():
-                raise dnf.exceptions.Error(_('This command has to be run under the root user.'))
+                raise dnf.exceptions.Error(_('This command has to be run under ' \
+                        'fully privileged user (e.g. root).'))
 
         if demands.changelogs:
             for repo in repos.iter_enabled():


### PR DESCRIPTION
Nowhere to be found that UID-0 user has to go under "root" login name,
making the message confusing for cases it is not the case.

The original message would only be credible, if that was indeed how the
check was constructed, but for obvious reasons, it is not like that.