### PR TITLE
Use init_query argument in get_best_query()

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -1,5 +1,5 @@
 # default dependencies
-%global hawkey_version 0.36.0
+%global hawkey_version 0.37.0
 %global libcomps_version 0.1.8
 %global libmodulemd_version 1.4.0
 %global rpm_version 4.14.0
@@ -81,7 +81,7 @@
 It supports RPMs, modules and comps groups & environments.
 
 Name:           dnf
-Version:        4.2.12
+Version:        4.2.13
 Release:        1%{?dist}
 Summary:        %{pkg_summary}
 # For a breakdown of the licensing, see PACKAGE-LICENSING

--- a/dnf/module/module_base.py
+++ b/dnf/module/module_base.py
@@ -539,12 +539,13 @@ class ModuleBase(object):
         output = set()
         modulePackages = self.base._moduleContainer.getModulePackages()
         baseQuery = self.base.sack.query().filterm(empty=True).apply()
+        getBestInitQuery = self.base.sack.query(flags=hawkey.IGNORE_MODULAR_EXCLUDES)
 
         for spec in rpm_specs:
             subj = dnf.subject.Subject(spec)
             baseQuery = baseQuery.union(subj.get_best_query(
                 self.base.sack, with_nevra=True, with_provides=False, with_filenames=False,
-                exclude_flags=hawkey.IGNORE_MODULAR_EXCLUDES))
+                query=getBestInitQuery))
 
         baseQuery.apply()
 


### PR DESCRIPTION
Libdnf hawkey interface supports new argument "init_query"
in get_best_query() and get_best_solution() methods. The patch uses
this argument instead of removed argument "exclude_flags".

Depends on https://github.com/rpm-software-management/libdnf/pull/823