### PR TITLE
Provide only callable hints with --help

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -81,7 +81,7 @@
 It supports RPMs, modules and comps groups & environments.
 
 Name:           dnf
-Version:        4.2.13
+Version:        4.2.14
 Release:        1%{?dist}
 Summary:        %{pkg_summary}
 # For a breakdown of the licensing, see PACKAGE-LICENSING

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -442,7 +442,7 @@ class Base(object):
             logger.info(_("The downloaded packages were saved in cache "
                           "until the next successful transaction."))
             logger.info(_("You can remove cached packages by executing "
-                          "'%s'."), "dnf clean packages")
+                          "'%s'."), "{prog} clean packages").format(prog=dnf.util.MAIN_PROG)
 
         # Do not trigger the lazy creation:
         if self._history is not None:
@@ -938,7 +938,8 @@ class Base(object):
                 lastdbv = lastdbv.end_rpmdb_version
 
             if lastdbv is None or rpmdbv != lastdbv:
-                logger.debug(_("RPMDB altered outside of DNF."))
+                logger.debug(_("RPMDB altered outside of {prog}.").format(
+                    prog=dnf.util.MAIN_PROG_UPPER))
 
             cmdline = None
             if hasattr(self, 'args') and self.args:

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -170,8 +170,9 @@ class BaseCli(dnf.Base):
                 report_module_switch(switchedModules)
                 msg = _("It is not possible to switch enabled streams of a module.\n"
                         "It is recommended to remove all installed content from the module, and "
-                        "reset the module using 'dnf module reset <module_name>' command. After "
-                        "you reset the module, you can install the other stream.")
+                        "reset the module using '{prog} module reset <module_name>' command. After "
+                        "you reset the module, you can install the other stream.").format(
+                    prog=dnf.util.MAIN_PROG)
                 raise dnf.exceptions.Error(msg)
 
         trans = self.transaction
@@ -205,10 +206,11 @@ class BaseCli(dnf.Base):
                 (self._history and (self._history.group or self._history.env)):
             # confirm with user
             if self.conf.downloadonly:
-                logger.info(_("DNF will only download packages for the transaction."))
+                logger.info(_("{prog} will only download packages for the transaction.").format(
+                    prog=dnf.util.MAIN_PROG_UPPER))
             elif 'test' in self.conf.tsflags:
-                logger.info(_("DNF will only download packages, install gpg keys, and check the "
-                              "transaction."))
+                logger.info(_("{prog} will only download packages, install gpg keys, and check the "
+                              "transaction.").format(prog=dnf.util.MAIN_PROG_UPPER))
             if self._promptWanted():
                 if self.conf.assumeno or not self.output.userconfirm():
                     raise CliError(_("Operation aborted."))
@@ -793,7 +795,8 @@ class Cli(object):
         self.base.repos.all()._set_key_import(key_import)
 
     def _log_essentials(self):
-        logger.debug('DNF version: %s', dnf.const.VERSION)
+        logger.debug('{prog} version: %s'.format(prog=dnf.util.MAIN_PROG_UPPER),
+                     dnf.const.VERSION)
         logger.log(dnf.logging.DDEBUG,
                         'Command: %s', self.cmdstring)
         logger.log(dnf.logging.DDEBUG,
@@ -840,11 +843,13 @@ class Cli(object):
             logger.critical(_('No such command: %s. Please use %s --help'),
                             basecmd, sys.argv[0])
             if self.base.conf.plugins:
-                logger.critical(_("It could be a DNF plugin command, "
-                            "try: \"dnf install 'dnf-command(%s)'\""), basecmd)
+                logger.critical(_("It could be a {PROG} plugin command, "
+                                  "try: \"{prog} install 'dnf-command(%s)'\"").format(
+                    prog=dnf.util.MAIN_PROG, PROG=dnf.util.MAIN_PROG_UPPER), basecmd)
             else:
-                logger.critical(_("It could be a DNF plugin command, "
-                            "but loading of plugins is currently disabled."))
+                logger.critical(_("It could be a {prog} plugin command, "
+                                  "but loading of plugins is currently disabled.").format(
+                    prog=dnf.util.MAIN_PROG_UPPER))
             raise CliError
         self.command = command_cls(self)
 

--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -58,7 +58,7 @@ You can do that by running the command:
 
 
 Alternatively you can specify the url to the key you would like to use
-for a repository in the 'gpgkey' option in a repository section and DNF
+for a repository in the 'gpgkey' option in a repository section and {prog}}
 will install it for you.
 
 For more information contact your distribution or package provider.""")
@@ -76,7 +76,7 @@ def _checkGPGKey(base, cli):
     if not base._gpg_key_check():
         for repo in base.repos.iter_enabled():
             if (repo.gpgcheck or repo.repo_gpgcheck) and not repo.gpgkey:
-                logger.critical("\n%s\n", gpg_msg)
+                logger.critical("\n%s\n", gpg_msg.format(prog=dnf.util.MAIN_PROG_UPPER))
                 logger.critical(_("Problem repository: %s"), repo)
                 raise dnf.cli.CliError
 
@@ -806,7 +806,8 @@ class HelpCommand(Command):
     @staticmethod
     def set_argparser(parser):
         parser.add_argument('cmd', nargs='?', metavar=_('COMMAND'),
-                            help="DNF command to get help for")
+                            help=_("{prog} command to get help for").format(
+                                prog=dnf.util.MAIN_PROG_UPPER))
 
     def run(self):
         if (not self.opts.cmd

--- a/dnf/cli/commands/module.py
+++ b/dnf/cli/commands/module.py
@@ -23,6 +23,7 @@ from dnf.cli import commands, CliError
 from dnf.i18n import _
 from dnf.module.exceptions import NoModuleException
 from dnf.util import logger
+import dnf.util
 
 import sys
 import os
@@ -286,5 +287,6 @@ class ModuleCommand(commands.Command):
         if self.opts.subcmd[0] not in not_required_argument:
             if not self.opts.module_spec:
                 raise CliError(
-                    "dnf {} {}: too few arguments".format(self.opts.command,
-                                                          self.opts.subcmd[0]))
+                    _("{} {} {}: too few arguments").format(dnf.util.MAIN_PROG,
+                                                            self.opts.command,
+                                                            self.opts.subcmd[0]))

--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -248,7 +248,8 @@ class RepoQueryCommand(commands.Command):
             'installed': _('Display only installed packages.'),
             'extras': _('Display only packages that are not present in any of available repositories.'),
             'upgrades': _('Display only packages that provide an upgrade for some already installed package.'),
-            'unneeded': _('Display only packages that can be removed by "dnf autoremove" command.'),
+            'unneeded': _('Display only packages that can be removed by "{prog} autoremove" '
+                          'command.').format(prog=dnf.util.MAIN_PROG),
             'userinstalled': _('Display only packages that were installed by user.')
         }
         list_group = parser.add_mutually_exclusive_group()
@@ -515,10 +516,11 @@ class RepoQueryCommand(commands.Command):
                     'conflicts', 'enhances', 'obsoletes', 'provides', 'recommends',
                     'requires', 'suggests', 'supplements'):
                 raise dnf.exceptions.Error(
-                    _("No valid switch specified\nusage: dnf repoquery [--conflicts|"
-                        "--enhances|--obsoletes|--provides|--recommends|--requires|"
-                        "--suggest|--supplements|--whatrequires] [key] [--tree]\n\n"
-                        "description:\n  For the given packages print a tree of the packages."))
+                    _("No valid switch specified\nusage: {prog} repoquery [--conflicts|"
+                      "--enhances|--obsoletes|--provides|--recommends|--requires|"
+                      "--suggest|--supplements|--whatrequires] [key] [--tree]\n\n"
+                      "description:\n  For the given packages print a tree of the"
+                      "packages.").format(prog=dnf.util.MAIN_PROG))
             self.tree_seed(q, orquery, self.opts)
             return
 

--- a/dnf/cli/commands/shell.py
+++ b/dnf/cli/commands/shell.py
@@ -21,7 +21,7 @@
 from dnf.cli import commands
 from dnf.i18n import _, ucd
 
-
+import dnf.util
 import cmd
 import copy
 import dnf
@@ -44,7 +44,7 @@ class ShellDemandSheet(object):
 class ShellCommand(commands.Command, cmd.Cmd):
 
     aliases = ('shell', 'sh')
-    summary = _('run an interactive DNF shell')
+    summary = _('run an interactive {prog} shell').format(prog=dnf.util.MAIN_PROG_UPPER)
 
     MAPPING = {'repo': 'repo',
                'repository': 'repo',
@@ -66,7 +66,8 @@ class ShellCommand(commands.Command, cmd.Cmd):
     @staticmethod
     def set_argparser(parser):
         parser.add_argument('script', nargs='?', metavar=_('SCRIPT'),
-                            help=_('Script to run in DNF shell'))
+                            help=_('Script to run in {prog} shell').format(
+                                prog=dnf.util.MAIN_PROG_UPPER))
 
     def configure(self):
         # append to ShellDemandSheet missing demands from

--- a/dnf/cli/commands/swap.py
+++ b/dnf/cli/commands/swap.py
@@ -20,6 +20,8 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from dnf.i18n import _
 from dnf.cli import commands
+
+import dnf.util
 import logging
 
 logger = logging.getLogger("dnf")
@@ -30,7 +32,8 @@ class SwapCommand(commands.Command):
     """
 
     aliases = ('swap',)
-    summary = _('run an interactive dnf mod for remove and install one spec')
+    summary = _('run an interactive {prog} mod for remove and install one spec').format(
+        prog=dnf.util.MAIN_PROG_UPPER)
 
     @staticmethod
     def set_argparser(parser):

--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -364,7 +364,8 @@ class OptionParser(argparse.ArgumentParser):
         """ get the usage information to show the user. """
         desc = {'main': _('List of Main Commands:'),
                 'plugin': _('List of Plugin Commands:')}
-        usage = '%s [options] COMMAND\n' % self._main_prog
+        main_prog = self._main_prog if self._main_prog in ["dnf", "yum"] else "dnf"
+        usage = '%s [options] COMMAND\n' % main_prog
         for grp in ['main', 'plugin']:
             if not grp in self._cmd_groups:
                 # dont add plugin usage, if we dont have plugins
@@ -377,7 +378,8 @@ class OptionParser(argparse.ArgumentParser):
         return usage
 
     def _add_command_options(self, command):
-        self.prog = "%s %s" % (self._main_prog, command._basecmd)
+        main_prog = self._main_prog if self._main_prog in ["dnf", "yum"] else "dnf"
+        self.prog = "%s %s" % (main_prog, command._basecmd)
         self.description = command.summary
         self.command_positional_parser = argparse.ArgumentParser(self.prog, add_help=False)
         self.command_positional_parser.print_usage = self.print_usage

--- a/dnf/lock.py
+++ b/dnf/lock.py
@@ -98,7 +98,7 @@ class ProcessLock(object):
                 old_pid = int(old_pid)
             except ValueError:
                 msg = _('Malformed lock file found: %s.\n'
-                        'Ensure no other dnf process is running and '
+                        'Ensure no other dnf/yum process is running and '
                         'remove the lock file manually or run '
                         'systemd-tmpfiles --remove dnf.conf.') % (self.target)
                 raise LockError(msg)

--- a/dnf/util.py
+++ b/dnf/util.py
@@ -25,6 +25,7 @@ from __future__ import unicode_literals
 from .pycomp import PY3, basestring
 from dnf.i18n import _, ucd
 from functools import reduce
+import argparse
 import dnf
 import dnf.callback
 import dnf.const
@@ -42,6 +43,9 @@ import time
 import libdnf.repo
 
 logger = logging.getLogger('dnf')
+
+MAIN_PROG = argparse.ArgumentParser().prog if argparse.ArgumentParser().prog == "yum" else "dnf"
+MAIN_PROG_UPPER = MAIN_PROG.upper()
 
 """DNF Utilities."""
 

--- a/tests/cli/test_option_parser.py
+++ b/tests/cli/test_option_parser.py
@@ -124,7 +124,7 @@ class OptionParserAddCmdTest(tests.support.TestCase):
     def test_get_usage(self):
         parser = argparse.ArgumentParser()
         output = [
-            u'%s [options] COMMAND' % parser.prog,
+            u'%s [options] COMMAND' % (parser.prog if parser.prog in ["dnf", "yum"] else "dnf"),
             u'',
             u'List of Main Commands:',
             u'',


### PR DESCRIPTION
The patch should resolves:
yum-builddep --help
usage: yum-builddep builddep [-c [config file]] [-q] [-v] [--version]

Requires CI - https://github.com/rpm-software-management/ci-dnf-stack/pull/668