### PR TITLE
Make DNF compatible with FIPS mode (RhBug:1762032)

### DIFF
--- a/dnf/lock.py
+++ b/dnf/lock.py
@@ -40,7 +40,7 @@ def _fit_lock_dir(dir_):
         # for regular users the best we currently do is not to clash with
         # another DNF process of the same user. Since dir_ is quite definitely
         # not writable for us, yet significant, use its hash:
-        hexdir = hashlib.md5(dir_.encode('utf-8')).hexdigest()
+        hexdir = hashlib.sha1(dir_.encode('utf-8')).hexdigest()
         dir_ = os.path.join(misc.getCacheDir(), 'locks', hexdir)
     return dir_
 


### PR DESCRIPTION
DNF used MD5 hash to create lock directory path. MD5 is not approved in FIPS mode.
The patch uses SHA1 instead of MD5.