### PR TITLE
dnf-automatic: Change all systemd timers to a fixed time of day (RhBu…

### DIFF
--- a/etc/systemd/dnf-automatic-download.timer
+++ b/etc/systemd/dnf-automatic-download.timer
@@ -5,10 +5,9 @@ ConditionPathExists=!/run/ostree-booted
 Wants=network-online.target
 
 [Timer]
-OnBootSec=1h
-OnUnitInactiveSec=1d
-RandomizedDelaySec=5m
-AccuracySec=1s
+OnCalendar=*-*-* 6:00
+RandomizedDelaySec=60m
+Persistent=true
 
 [Install]
 WantedBy=multi-user.target

--- a/etc/systemd/dnf-automatic-install.timer
+++ b/etc/systemd/dnf-automatic-install.timer
@@ -5,10 +5,9 @@ ConditionPathExists=!/run/ostree-booted
 Wants=network-online.target
 
 [Timer]
-OnBootSec=1h
-OnUnitInactiveSec=1d
-RandomizedDelaySec=5m
-AccuracySec=1s
+OnCalendar=*-*-* 6:00
+RandomizedDelaySec=60m
+Persistent=true
 
 [Install]
 WantedBy=multi-user.target

--- a/etc/systemd/dnf-automatic-notifyonly.timer
+++ b/etc/systemd/dnf-automatic-notifyonly.timer
@@ -5,10 +5,9 @@ ConditionPathExists=!/run/ostree-booted
 Wants=network-online.target
 
 [Timer]
-OnBootSec=1h
-OnUnitInactiveSec=1d
-RandomizedDelaySec=5m
-AccuracySec=1s
+OnCalendar=*-*-* 6:00
+RandomizedDelaySec=60m
+Persistent=true
 
 [Install]
 WantedBy=multi-user.target

--- a/etc/systemd/dnf-automatic.timer
+++ b/etc/systemd/dnf-automatic.timer
@@ -5,10 +5,9 @@ ConditionPathExists=!/run/ostree-booted
 Wants=network-online.target
 
 [Timer]
-OnBootSec=1h
-OnUnitInactiveSec=1d
-RandomizedDelaySec=5m
-AccuracySec=1s
+OnCalendar=*-*-* 6:00
+RandomizedDelaySec=60m
+Persistent=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
…g:1754609)

Changes all systemd timers of the automatic systemd services to start at
6AM with a randomized delay of one hour. This changes the timing so that
it happens at a predictable time every day (before the business hours).

Removes the AccuracySec=1s, the default is one minute. We don't
need a one second accuracy and the higher default is meant to conserve
energy (probably negligible here).

Adds the Persistent=true option so that the time of the last run is
stored on disk and the unit is run as soon as possible if the event
expired while the machine was turned off.

https://bugzilla.redhat.com/show_bug.cgi?id=1754609