### PR TITLE
DNF can use config from the remote location (RhBug:1721091)

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -1003,6 +1003,9 @@ class Cli(object):
         timer = dnf.logging.Timer('config')
         conf = self.base.conf
 
+        # replace remote config path with downloaded file
+        conf._check_remote_file('config_file_path')
+
         # search config file inside the installroot first
         conf._search_inside_installroot('config_file_path')
 


### PR DESCRIPTION
When the remote location is passed via -c option, the remote
configuration file is downloaded into temporary location and this
temporary file is then used as a configuration file.

https://bugzilla.redhat.com/show_bug.cgi?id=1721091

Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/682