### PR TITLE
repoquery: Add a switch to disable modular excludes (RhBug:1568740)

### DIFF
--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -1129,6 +1129,9 @@ packages to those matching the specification. All packages are considered if no 
 ``--available``
     Limit the resulting set to available packages only (set by default).
 
+``--disable-modular-filtering``
+    Disables filtering of modular packages, so that packages of inactive module streams are included in the result.
+
 ``--extras``
     Limit the resulting set to packages that are not present in any of the available repositories.
 

--- a/doc/modularity.rst
+++ b/doc/modularity.rst
@@ -44,6 +44,15 @@ modular package
     Stream is a collection of packages, a virtual repository. It is identified with
     ``Name`` and ``Stream`` from modulemd separated with colon, for example "postgresql:9.6".
 
+    Module streams can be ``active`` or ``inactive``. ``active`` means the RPM
+    packages from this stream are included in the set of available packages.
+    Packages from ``inactive`` streams are filtered out.  Streams are
+    ``active`` either if marked as ``default`` or if they are explicitly
+    ``enabled`` by a user action. Streams that satisfy dependencies of
+    ``default`` or ``enabled`` streams are also considered ``active``.  Only
+    one stream of a particular module can be ``active`` at a given point in
+    time.
+
 
 ===================
  Package filtering


### PR DESCRIPTION
Add the --ignore-modular-excludes switch that will turn off modular
excludes, so that the command lists all package from all modules that
match the query.

https://bugzilla.redhat.com/show_bug.cgi?id=1568740

Tests are here: https://github.com/rpm-software-management/ci-dnf-stack/pull/673