### PR TITLE
Fix misplaced parenthesis

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -442,7 +442,7 @@ class Base(object):
             logger.info(_("The downloaded packages were saved in cache "
                           "until the next successful transaction."))
             logger.info(_("You can remove cached packages by executing "
-                          "'%s'."), "{prog} clean packages").format(prog=dnf.util.MAIN_PROG)
+                          "'%s'."), "{prog} clean packages".format(prog=dnf.util.MAIN_PROG))
 
         # Do not trigger the lazy creation:
         if self._history is not None:


### PR DESCRIPTION
This can cause nice traceback when trying to install package with
fileconflict:

Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/dnf/cli/main.py", line 65, in main
    return _main(base, args, cli_class, option_parser_class)
  File "/usr/lib/python3.7/site-packages/dnf/cli/main.py", line 98, in _main
    return cli_run(cli, base)
  File "/usr/lib/python3.7/site-packages/dnf/cli/main.py", line 122, in cli_run
    ret = resolving(cli, base)
  File "/usr/lib/python3.7/site-packages/dnf/cli/main.py", line 166, in resolving
    base.do_transaction(display=displays)
  File "/usr/lib/python3.7/site-packages/dnf/cli/cli.py", line 243, in do_transaction
    tid = super(BaseCli, self).do_transaction(display)
  File "/usr/lib/python3.7/site-packages/dnf/base.py", line 856, in do_transaction
    raise dnf.exceptions.Error(errstring)
dnf.exceptions.Error: Transaction test error:
  file /usr/bin/nitrate from install of python3-nitrate-1.5-1.fc30.noarch conflicts with file from package python2-nitrate-1.4-2.fc30.noarch
  file /usr/share/man/man1/python-nitrate.1.gz from install of python3-nitrate-1.5-1.fc30.noarch conflicts with file from package python2-nitrate-1.4-2.fc30.noarch

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/dnf", line 58, in <module>
    main.user_main(sys.argv[1:], exit_code=True)
  File "/usr/lib/python3.7/site-packages/dnf/cli/main.py", line 191, in user_main
    errcode = main(args)
  File "/usr/lib/python3.7/site-packages/dnf/cli/main.py", line 65, in main
    return _main(base, args, cli_class, option_parser_class)
  File "/usr/lib/python3.7/site-packages/dnf/base.py", line 123, in __exit__
    self.close()
  File "/usr/lib/python3.7/site-packages/dnf/base.py", line 466, in close
    self._finalize_base()
  File "/usr/lib/python3.7/site-packages/dnf/base.py", line 445, in _finalize_base
    "'%s'."), "{prog} clean packages").format(prog=dnf.util.MAIN_PROG)
AttributeError: 'NoneType' object has no attribute 'format'