### PR TITLE
[doc] update reference to plugin documentation (RhBug:1706386)

### DIFF
--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -1803,7 +1803,7 @@ See Also
 ========
 
 * :manpage:`dnf.conf(5)`, :ref:`DNF Configuration Reference <conf_ref-label>`
-* :manpage:`dnf.plugin.*(8)`, assorted DNF plugins that might be installed on the system.
+* :manpage:`dnf-PLUGIN(8)` for documentation on DNF plugins.
 * :manpage:`dnf.modularity(7)`, :ref:`Modularity overview <modularity-label>`.
 * `DNF`_ project homepage (https://github.com/rpm-software-management/dnf/)
 * How to report a bug (https://github.com/rpm-software-management/dnf/wiki/Bug-Reporting)


### PR DESCRIPTION
After moving DNF plugins from dnf.plugin.* to dnf-*, update the
reference in the main DNF manpage.

Not sure about using caps like `dnf-PLUGIN` to stand for an arbitrary plugin in the reference...

I'm also wondering if I should tie the versions of `dnf` and `dnf-plugins-core` / `dnf-plugins-extras` to ensure this reference is valid (and the user doesn't end up e.g. with `dnf` that will tell them plugin docs are at dnf-* while the plugin package is older and still has docs at dnf.plugin.*)?

Requires:
https://github.com/rpm-software-management/dnf-plugins-core/pull/369
https://github.com/rpm-software-management/dnf-plugins-extras/pull/169