### PR TITLE
Enable versionlock for check-update command (RhBug:1750620)

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -5,7 +5,7 @@
 %global rpm_version 4.14.0
 
 # conflicts
-%global conflicts_dnf_plugins_core_version 4.0.6
+%global conflicts_dnf_plugins_core_version 4.0.12
 %global conflicts_dnf_plugins_extras_version 4.0.4
 %global conflicts_dnfdaemon_version 0.3.19
 
@@ -81,7 +81,7 @@
 It supports RPMs, modules and comps groups & environments.
 
 Name:           dnf
-Version:        4.2.15
+Version:        4.2.16
 Release:        1%{?dist}
 Summary:        %{pkg_summary}
 # For a breakdown of the licensing, see PACKAGE-LICENSING

--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -273,6 +273,7 @@ class CheckUpdateCommand(Command):
         demands = self.cli.demands
         demands.sack_activation = True
         demands.available_repos = True
+        demands.plugin_filtering_enabled = True
         if self.opts.changelogs:
             demands.changelogs = True
         _checkEnabledRepo(self.base)

--- a/dnf/cli/demand.py
+++ b/dnf/cli/demand.py
@@ -58,3 +58,8 @@ class DemandSheet(object):
     changelogs = _BoolDefault(False)
 
     transaction_display = None
+
+    # This demand controlls applicability of the plugins that could filter
+    # repositories packages (e.g. versionlock).
+    # If it stays None, the demands.resolving is used as a fallback.
+    plugin_filtering_enabled = _BoolDefault(None)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1750620

Requires: https://github.com/rpm-software-management/dnf-plugins-core/pull/370

Test: https://github.com/rpm-software-management/ci-dnf-stack/pull/687

For testing you can use the copr repo: https://copr.fedorainfracloud.org/coprs/mblaha/versionlockdemand/