### PR TITLE
[repoquery] Do not set protected packages for --unsafisfied (RhBug:17…

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -1,5 +1,5 @@
 # default dependencies
-%global hawkey_version 0.45.1
+%global hawkey_version 0.46.1
 %global libcomps_version 0.1.8
 %global libmodulemd_version 1.4.0
 %global rpm_version 4.14.0

--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -486,6 +486,7 @@ class RepoQueryCommand(commands.Command):
             rpmdb = dnf.sack.rpmdb_sack(self.base)
             rpmdb._configure(self.base.conf.installonlypkgs, self.base.conf.installonly_limit)
             goal = dnf.goal.Goal(rpmdb)
+            goal.protect_running_kernel = False
             solved = goal.run(verify=True)
             if not solved:
                 print(dnf.util._format_resolve_problems(goal.problem_rules()))


### PR DESCRIPTION
…50745)

When kernel had an unsatisfied dependency, it resulted in confusing
message "Problem: The operation would result in removing the following
protected packages: kernel-core" and no other problems were reported.