### PR TITLE
Add error message when no active modules matched (RhBug:1696204)

### DIFF
--- a/dnf/module/module_base.py
+++ b/dnf/module/module_base.py
@@ -81,6 +81,8 @@ class ModuleBase(object):
                     install_module_list = [x for x in module_list
                                            if self.base._moduleContainer.isModuleActive(x.getId())]
                     if not install_module_list:
+                        logger.error(_("All matches for argument '{0}' in module '{1}:{2}' are not "
+                                       "active").format(spec, name, stream))
                         error_specs.append(spec)
                         continue
                     profiles = []


### PR DESCRIPTION
The error is logged when argument matched but no active module is in
the set. We don't know why all matches are not active because not only
unsatisfied dependencies could be the reason.

https://bugzilla.redhat.com/show_bug.cgi?id=1696204
Test - https://github.com/rpm-software-management/ci-dnf-stack/pull/690