### PR TITLE
Bump dnf version

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -81,7 +81,7 @@
 It supports RPMs, modules and comps groups & environments.
 
 Name:           dnf
-Version:        4.2.16
+Version:        4.2.17
 Release:        1%{?dist}
 Summary:        %{pkg_summary}
 # For a breakdown of the licensing, see PACKAGE-LICENSING


### PR DESCRIPTION
The version bump from the PR
https://github.com/rpm-software-management/dnf/pull/1530 was not
applied.