### PR TITLE
Add Requires information into module info commands

### DIFF
--- a/dnf/module/module_base.py
+++ b/dnf/module/module_base.py
@@ -523,10 +523,11 @@ class ModuleBase(object):
         column_value.setNewlineWrapFunction()
 
         for line_name, value in lines.items():
-            if value:
-                line = table.newLine()
-                line.getColumnCell(column_name).setData(line_name)
-                line.getColumnCell(column_value).setData(str(value))
+            if value is None:
+                value = ""
+            line = table.newLine()
+            line.getColumnCell(column_name).setData(line_name)
+            line.getColumnCell(column_value).setData(str(value))
 
         return table
 

--- a/dnf/module/module_base.py
+++ b/dnf/module/module_base.py
@@ -497,6 +497,12 @@ class ModuleBase(object):
                 lines["Repo"] = modulePackage.getRepoID()
                 lines["Summary"] = modulePackage.getSummary()
                 lines["Description"] = modulePackage.getDescription()
+                req_set = set()
+                for req in modulePackage.getModuleDependencies():
+                    for require_dict in req.getRequires():
+                        for mod_require, stream in require_dict.items():
+                            req_set.add("{}:[{}]".format(mod_require, ",".join(stream)))
+                lines["Requires"] = "\n".join(sorted(req_set))
                 lines["Artifacts"] = "\n".join(sorted(modulePackage.getArtifacts()))
                 output.add(self._create_simple_table(lines).toString())
         str_table = "\n\n".join(sorted(output))


### PR DESCRIPTION
Requires is very useful for debugging when any dependency issue in
modules. The information is also available in verbose output, but it is
difficult to filter it out.

Requires tests - https://github.com/rpm-software-management/ci-dnf-stack/pull/701