### PR TITLE
Restore functionality of remove --oldinstallonly

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1975,17 +1975,19 @@ class Base(object):
             return 0
 
     def _upgrade_internal(self, query, obsoletes, reponame, pkg_spec=None):
-        installed = self.sack.query().installed()
-        q = query.intersection(self.sack.query().filterm(name=[pkg.name for pkg in installed]))
+        installed_all = self.sack.query().installed()
+        q = query.intersection(self.sack.query().filterm(name=[pkg.name for pkg in installed_all]))
+        installed_query = q.installed()
         if obsoletes:
             obsoletes = self.sack.query().available().filterm(
-                obsoletes=q.installed().union(q.upgrades()))
+                obsoletes=installed_query.union(q.upgrades()))
             # add obsoletes into transaction
             q = q.union(obsoletes)
         if reponame is not None:
             q.filterm(reponame=reponame)
         q = self._merge_update_filters(q, pkg_spec=pkg_spec)
         if q:
+            q = q.available().union(installed_query.latest())
             sltr = dnf.selector.Selector(self.sack)
             sltr.set(pkg=q)
             self._goal.upgrade(select=sltr)

--- a/dnf/cli/commands/remove.py
+++ b/dnf/cli/commands/remove.py
@@ -110,8 +110,14 @@ class RemoveCommand(commands.Command):
 
         if self.opts.oldinstallonly:
             q = self.base.sack.query()
-            instonly = self.base._get_installonly_query(q.installed()).latest(
-                - self.base.conf.installonly_limit)
+            instonly = self.base._get_installonly_query(q.installed()).latest(-1)
+            # also remove running kernel from the set
+            kernel = self.base.sack.get_running_kernel()
+            if kernel is not None:
+                running_installonly = instonly.filter(
+                    epoch=kernel.epoch, version=kernel.version, release=kernel.release)
+                if running_installonly:
+                    instonly = instonly.difference(running_installonly)
             if instonly:
                 for pkg in instonly:
                     self.base.package_remove(pkg)

--- a/doc/cli_vs_yum.rst
+++ b/doc/cli_vs_yum.rst
@@ -387,15 +387,15 @@ Original YUM tool          New DNF command                                  Pack
 
 Detailed table for ``package-cleanup`` replacement:
 
-==================================       =====================================
-``package-cleanup --dupes``              ``dnf repoquery --duplicates``
-``package-cleanup --leaves``             ``dnf repoquery --unneeded``
-``package-cleanup --orphans``            ``dnf repoquery --extras``
-``package-cleanup --oldkernels``         ``dnf repoquery --installonly``
-``package-cleanup --problems``           ``dnf repoquery --unsatisfied``
-``package-cleanup --cleandupes``         ``dnf remove --duplicates``
-``package-cleanup --oldkernels``         ``dnf remove --oldinstallonly``
-==================================       =====================================
+==========================================       ===============================================================
+``package-cleanup --dupes``                      ``dnf repoquery --duplicates``
+``package-cleanup --leaves``                     ``dnf repoquery --unneeded``
+``package-cleanup --orphans``                    ``dnf repoquery --extras``
+``package-cleanup --problems``                   ``dnf repoquery --unsatisfied``
+``package-cleanup --cleandupes``                 ``dnf remove --duplicates``
+``package-cleanup --oldkernels``                 ``dnf remove --oldinstallonly``
+``package-cleanup --oldkernels --keep=2``        ``dnf remove $(dnf repoquery --installonly --latest-limit=-2)``
+==========================================       ===============================================================
 
 =============================
 yum-updateonboot and yum-cron

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -1061,7 +1061,7 @@ Remove Command
     dnf-shell sub-commands could help.
 
 ``dnf [options] remove --oldinstallonly``
-    Removes old installonly packages, keeping only ``installonly_limit`` latest versions.
+    Removes old installonly packages, keeping only latest versions and version of running kernel.
 
     There are also a few specific remove commands ``remove-n``, ``remove-na`` and ``remove-nevra``
     that allow the specification of an exact argument in the NEVRA format.


### PR DESCRIPTION
Additionally it also starts to protect running kernel.

https://bugzilla.redhat.com/show_bug.cgi?id=1774666