### PR TITLE
Add 'history new' subcommand (RhBug:1761680)

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -1,5 +1,5 @@
 # default dependencies
-%global hawkey_version 0.39.1
+%global hawkey_version 0.39.2
 %global libcomps_version 0.1.8
 %global libmodulemd_version 1.4.0
 %global rpm_version 4.14.0

--- a/dnf/db/history.py
+++ b/dnf/db/history.py
@@ -318,6 +318,18 @@ class SwdbInterface(object):
     def reset_db(self):
         return self.swdb.resetDatabase()
 
+    def backup_db(self, path=None):
+        if path is None:
+            db_dir = os.path.dirname(self.dbpath)
+            db_name, db_suffix = os.path.basename(self.dbpath).split('.')
+            backup_name = '{}-{}.{}'.format(
+                db_name,
+                time.strftime('%Y-%m-%d-%H-%M-%S', time.gmtime()),
+                db_suffix)
+            path = os.path.join(db_dir, backup_name)
+        self.swdb.backupDatabase(path)
+        return path
+
     # TODO: rename to get_last_transaction?
     def last(self, complete_transactions_only=True):
         # TODO: complete_transactions_only

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -721,6 +721,10 @@ transactions and act according to this information (assuming the
     results can be accomplished with ``dnf repoquery --userinstalled``, and the repoquery
     command is more powerful in formatting of the output.
 
+``dnf history new``
+    Clears the transaction history database.
+    Be careful because after issuing this command all DNF package history is lost (including information about installed groups and about packages marked as installed by user - see :ref:`mark command <mark_command-label>`).
+
 This command by default does not force a sync of expired metadata, except for
 the redo, rollback, and undo subcommands.
 See also :ref:`\metadata_synchronization-label`


### PR DESCRIPTION
This command creates backup of current history database, then
deletes the database and creates fresh and empty new one.

https://bugzilla.redhat.com/show_bug.cgi?id=1761680


Requires: https://github.com/rpm-software-management/libdnf/pull/854
Test: https://github.com/rpm-software-management/ci-dnf-stack/pull/705