### PR TITLE
Mention the root user in the superuser privileges message

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -810,7 +810,8 @@ class Cli(object):
         if demands.root_user:
             if not dnf.util.am_i_root():
                 raise dnf.exceptions.Error(
-                    _('This command has to be run with superuser privileges.'))
+                    _('This command has to be run with superuser privileges '
+                        '(under the root user on most systems).'))
 
         if demands.changelogs:
             for repo in repos.iter_enabled():


### PR DESCRIPTION
Add a note that on most systems the user with superuser privileges is
root, so that inexperienced users get a more useful hint on what to do
without having to search for what superuser privileges mean.