### PR TITLE
Honor priority with check-update (RhBug:1769466)

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -1,5 +1,5 @@
 # default dependencies
-%global hawkey_version 0.39.1
+%global hawkey_version 0.41.0
 %global libcomps_version 0.1.8
 %global libmodulemd_version 1.4.0
 %global rpm_version 4.14.0

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1365,7 +1365,7 @@ class Base(object):
 
         # produce the updates list of tuples
         elif pkgnarrow == 'upgrades':
-            updates = query_for_repo(q).upgrades()
+            updates = query_for_repo(q).filterm(upgrades_by_priority=True)
             # reduce a query to security upgrades if they are specified
             updates = self._merge_update_filters(updates)
             # reduce a query to latest packages
@@ -1417,7 +1417,7 @@ class Base(object):
         elif pkgnarrow == 'obsoletes':
             inst = q.installed()
             obsoletes = query_for_repo(
-                self.sack.query()).filter(obsoletes=inst)
+                self.sack.query()).filter(obsoletes_by_priority=inst)
             # reduce a query to security upgrades if they are specified
             obsoletes = self._merge_update_filters(obsoletes, warning=False)
             obsoletesTuples = []

--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -279,7 +279,7 @@ class CheckUpdateCommand(Command):
         _checkEnabledRepo(self.base)
 
     def run(self):
-        query = self.base.sack.query().upgrades()
+        query = self.base.sack.query().filterm(upgrades_by_priority=True)
         if self.base.conf.obsoletes:
             obsoleted = query.union(self.base.sack.query().installed())
             obsoletes = self.base.sack.query().filter(obsoletes=obsoleted)


### PR DESCRIPTION
Check update is going to use the new query filter that honors repo
priority.

https://bugzilla.redhat.com/show_bug.cgi?id=1769466

Requires: https://github.com/rpm-software-management/libdnf/pull/864

Test: https://github.com/rpm-software-management/ci-dnf-stack/pull/733