### PR TITLE
[doc] Explain the backslash notation also near the example (RhBug:168…

### DIFF
--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -454,10 +454,12 @@ Alias Examples
     Lists all defined aliases.
 
 ``dnf alias add rm=remove``
-    Adds new alias command called "rm" which does the same thing as the command "remove".
+    Adds a new command alias called ``rm`` which works the same as the ``remove`` command.
 
 ``dnf alias add update="\update --skip-broken --disableexcludes=all --obsoletes"``
-    Adds new alias command called "update" which does the same thing as the command "update", but with options ``--skip-broken --disableexcludes=all --obsoletes``.
+    Adds a new command alias called ``update`` which works the same as the ``update`` command,
+    with additional options. Note that the original ``update`` command is prefixed with a ``\``
+    to prevent an infinite loop in alias processing.
 
 .. _alias_processing_examples-label:
 


### PR DESCRIPTION
…0482)

https://bugzilla.redhat.com/show_bug.cgi?id=1680482
The backslash notation is mentioned before, but this adds an explanation
directly to the example where it is used.

Note: this functionality is currently broken and will be fixed by https://github.com/rpm-software-management/dnf/pull/1553