### PR TITLE
Allow configuring basearch alongside arch

### DIFF
--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -151,7 +151,7 @@ class BaseConfig(object):
                         logger.debug(_('Unknown configuration value: %s=%s in %s; %s'),
                                      ucd(name), ucd(value), ucd(filename), str(e))
                 else:
-                    if name == 'arch' and hasattr(self, name):
+                    if name in ('arch', 'basearch') and hasattr(self, name):
                         setattr(self, name, value)
                     else:
                         logger.debug(


### PR DESCRIPTION
Previously, `basearch` would always be defined to the automatic value in the `arch` setter.  This allows them to be defined independently.

I was investigating the feasibility of using Fedora >=31 for building 32-bit containers since the full i686 repositories were dropped.  This change allows setting `basearch=x86_64` and `arch=i686` to install 32-bit packages from the 64-bit repositories.  I don't know if it's worth pursuing further because the state of Fedora's dependencies is a disaster, but this seems like a requirement to get that working.  Feel free to close this if it's not wanted.