### PR TITLE
completion: fix path to platform-python (RhBug:1679008)

### DIFF
--- a/etc/bash_completion.d/dnf
+++ b/etc/bash_completion.d/dnf
@@ -110,8 +110,8 @@ _dnf_set_python_exec()
     if [[ "$( readlink /usr/bin/dnf )" == "dnf-2" ]]; then
         __dnf_python_exec="/usr/bin/python2"
     else
-        if [ -x /usr/libexec/system-python ]; then
-            __dnf_python_exec="/usr/libexec/system-python"
+        if [ -x /usr/libexec/platform-python ]; then
+            __dnf_python_exec="/usr/libexec/platform-python"
         else
             __dnf_python_exec="/usr/bin/python3"
         fi


### PR DESCRIPTION
Running dnf in containers or other minimal systems does not usr nor
require python3.  Yet without /usr/bin/python3, completion does not
work.  This is due to a bad path in the code which checks for the path
to python in _dnf_set_python_exec().

The system-python name was changed to platform-python at some point.
Using dnf completion on a system without python3 should work using the
same python that dnf itself uses, /usr/libexec/platform-python.

Arguably, this path should be set via @PYTHON_EXECUTABLE@ as it is for
bin/dnf for consistency and correctness.