### PR TITLE
[RFC] Exit `dnf shell` with non-zero return code when there are errors

### DIFF
--- a/dnf/cli/commands/shell.py
+++ b/dnf/cli/commands/shell.py
@@ -65,6 +65,8 @@ class ShellCommand(commands.Command, cmd.Cmd):
 
     @staticmethod
     def set_argparser(parser):
+        parser.add_argument('--errexit', action='store_true', default=None,
+                            help=_('Exit immediately if a command produces an error.'))
         parser.add_argument('script', nargs='?', metavar=_('SCRIPT'),
                             help=_('Script to run in {prog} shell').format(
                                 prog=dnf.util.MAIN_PROG_UPPER))
@@ -127,6 +129,8 @@ class ShellCommand(commands.Command, cmd.Cmd):
                     cmd.run()
                 except dnf.exceptions.Error as e:
                     logger.error(_("Error:") + " " + ucd(e))
+                    if self.opts.errexit:
+                        sys.exit(1)
                     return
             else:
                 self._help()
@@ -277,6 +281,8 @@ exit (or quit)           exit the shell""")
                 self.base.do_transaction()
             except dnf.exceptions.Error as e:
                 logger.error(_("Error:") + " " + ucd(e))
+                if self.opts.errexit:
+                    sys.exit(1)
             else:
                 logger.info(_("Complete!"))
             self._clean()


### PR DESCRIPTION
This is a feature request to be able to detect errors (such as unknown/invalid package names or impossible transaction) when running through `dnf shell`.

The proposed commit introduces an `--errexit` argument to enable this behavior:

```
$ sudo bin/dnf-3 shell --errexit
Last metadata expiration check: 1:00:17 ago on Mon 30 Dec 2019 09:17:15 AM PST.
> install sl asdfg
No match for argument: asdfg
Error: Unable to find a match: asdfg
$ echo $?
1
```

This is equivalent to the behavior of command `sudo dnf install sl asdfg`, it will exit right away without executing any commands.

We like `dnf shell` since in some cases we want to execute multiple DNF actions and we would like to group them into a single transaction, but unfortunately we lose a lot of the error checking in that case...

Is something like this desirable and acceptable? Should this become the default behavior of `dnf shell`? How about this `--errexit` argument (name is inspired on similar behavior on bourne shell.) Should I also add `config errexit true` as a possibility from the shell itself? (I'm also thinking of graceful fallback to versions of DNF without this commit present.)

I also thought of a slightly different approach involving counting errors. That would allow us to, for instance, execute a partial transaction and still exit 2 when there were any errors in previous steps, or perhaps exit 1 when the transaction itself couldn't be executed at all. But in the end, I figured something as simple as this might already be enough for my use case...

Comments? Thanks!
