### PR TITLE
Simplify example systemctl commands for dnf-automatic

### DIFF
--- a/doc/automatic.rst
+++ b/doc/automatic.rst
@@ -49,7 +49,7 @@ Regardless of the configuration file settings, the first will only notify of ava
 
 You can select one that most closely fits your needs, customize ``/etc/dnf/automatic.conf`` for any specific behaviors, and enable the timer unit.
 
-For example: ``systemctl enable dnf-automatic-notifyonly.timer && systemctl start dnf-automatic-notifyonly.timer``
+For example: ``systemctl enable --now dnf-automatic-notifyonly.timer``
 
 ===========================
  Configuration File Format
@@ -171,4 +171,3 @@ The email emitter configuration.
 ------------------
 
 Can be used to override settings from DNF's main configuration file. See :doc:`conf_ref`.
-

--- a/doc/cli_vs_yum.rst
+++ b/doc/cli_vs_yum.rst
@@ -406,11 +406,11 @@ However, the similar result can be achieved by ``dnf automatic`` command (see :d
 
 You can either use the shortcut::
 
-  $ systemctl enable dnf-automatic-install.timer && systemctl start dnf-automatic-install.timer
+  $ systemctl enable --now dnf-automatic-install.timer
 
 Or set ``apply_updates`` option of ``/etc/dnf/automatic.conf`` to True and use generic timer unit::
 
-  $ systemctl enable dnf-automatic.timer && systemctl start dnf-automatic.timer
+  $ systemctl enable --now dnf-automatic.timer
 
 The timer in both cases is activated 1 hour after the system was booted up and then repetitively once every 24 hours. There is also a random delay on these timers set to 5 minutes. These values can be tweaked via ``dnf-automatic*.timer`` config files located in the ``/usr/lib/systemd/system/`` directory.
 


### PR DESCRIPTION
The `--now` CLI argument avoids the need to run `systemctl start` as a
separate command.