### PR TITLE
Fix synchronization of version in spec and VERSION.cmake

### DIFF
--- a/VERSION.cmake
+++ b/VERSION.cmake
@@ -1,7 +1,9 @@
 set (DEFAULT_DNF_VERSION "4.2.17")
 
-if(DEFINED DNF_VERSION AND NOT ${DEFAULT_DNF_VERSION} STREQUAL ${DNF_VERSION})
-  message(FATAL_ERROR "Variable DEFAULT_DNF_VERSION=" ${DEFAULT_DNF_VERSION} " in VERSION.cmake differs from Version=" ${DNF_VERSION} " in spec")
+if(DEFINED DNF_VERSION)
+  if(NOT ${DEFAULT_DNF_VERSION} STREQUAL ${DNF_VERSION})
+    message(FATAL_ERROR "Variable DEFAULT_DNF_VERSION=" ${DEFAULT_DNF_VERSION} " in VERSION.cmake differs from Version=" ${DNF_VERSION} " in spec")
+  endif()
 else()
   set (DNF_VERSION ${DEFAULT_DNF_VERSION})
 endif()


### PR DESCRIPTION
It fixes fail when cmake command is used.

cmake ..
CMake Error at VERSION.cmake:3 (if):
  if given arguments:

    "DEFINED" "DNF_VERSION" "AND" "NOT" "4.2.17" "STREQUAL"

  Unknown arguments specified
Call Stack (most recent call first):
  CMakeLists.txt:4 (INCLUDE)