### PR TITLE
List arguments: only first empty value is used (RhBug:1788154)

### DIFF
--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -82,9 +82,15 @@ class OptionParser(argparse.ArgumentParser):
         SPLITTER = r'\s*[,\s]\s*'
 
         def __call__(self, parser, namespace, values, opt_str):
+            first = True
             for val in re.split(self.SPLITTER, values):
-                super(OptionParser._SplitCallback,
-                      self).__call__(parser, namespace, val, opt_str)
+                if first or val:
+                    # Empty values are sometimes used to clear existing content of the option.
+                    # Only the first value in the parsed string can be empty. Other empty values
+                    # are ignored.
+                    super(OptionParser._SplitCallback,
+                          self).__call__(parser, namespace, val, opt_str)
+                first = False
 
     class _SplitExtendDictCallback(argparse.Action):
         """ Split string at "," or whitespace to (key, value).


### PR DESCRIPTION
Empty values are used to clear existing content of the options of type
"append".

Examples:
`"--exclude"` is option of type "append". So, argument `"--exclude=iftop"` adds package "iftop" into the list
of excluded packages. But argument `"--exclude=,iftop"` replaces existing content of the excluded packages by "iftop". The first item is empty -> that means clear all existing items from the list.

Every empty value could clear the list before the patch.
So, the argument `"--exclude=iftop,,atop"` removed all existing items and only "atop" was added into the list (parsed left to right). And `"--exclude=iftop,atop,"` just cleared the list. This logic is redundant. Because `"--exclude=iftop,atop,"` is the same as `"--exclude="`.

So only first empty value is used and other empty values are ignored with the patch.

Note:
The `<value>` in `"--setopt=<option>=<value>"` and config files are parsed by libdnf.
The similar patch https://github.com/rpm-software-management/libdnf/pull/879 is needed to libdnf to be consistent. 