### PR TITLE
Increase minimal compatible version of rpm to 4.14.2-35 (RhBug:1787637)

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -2,7 +2,7 @@
 %global hawkey_version 0.41.0
 %global libcomps_version 0.1.8
 %global libmodulemd_version 1.4.0
-%global rpm_version 4.14.0
+%global rpm_version 4.14.2-35
 
 # conflicts
 %global conflicts_dnf_plugins_core_version 4.0.12


### PR DESCRIPTION
Since versions >= dnf-4.2.17-3 don't work well with older versions of
python3-rpm (due to python 3 rpm returning string data as
surrogate-escaped utf-8 strings) increase its required version.

https://bugzilla.redhat.com/show_bug.cgi?id=1787637