### PR TITLE
Report missing profiles or default as broken module (RhBug:1790967)

### DIFF
--- a/dnf/module/module_base.py
+++ b/dnf/module/module_base.py
@@ -121,14 +121,14 @@ class ModuleBase(object):
                             else:
                                 msg = _("No default profiles for module {}:{}").format(name, stream)
                             logger.error(msg)
-                            no_match_specs.append(spec)
+                            error_specs.append(spec)
                         for profile in set(profiles_strings):
                             module_profiles = latest_module.getProfiles(profile)
                             if not module_profiles:
                                 logger.error(
                                     _("Default profile {} not available in module {}:{}").format(
                                         profile, name, stream))
-                                no_match_specs.append(spec)
+                                error_specs.append(spec)
 
                             profiles.extend(module_profiles)
                     for profile in profiles:

--- a/dnf/module/module_base.py
+++ b/dnf/module/module_base.py
@@ -119,7 +119,7 @@ class ModuleBase(object):
                                         ": {}").format(
                                     name, stream, profile_names)
                             else:
-                                msg = _("No default profiles for module {}:{}").format(name, stream)
+                                msg = _("No profiles for module {}:{}").format(name, stream)
                             logger.error(msg)
                             error_specs.append(spec)
                         for profile in set(profiles_strings):


### PR DESCRIPTION
Missing default profile will be reported as:
No default profiles for module pki-core:10.6
Error: Problems in request:
broken groups or modules: pki-core

https://bugzilla.redhat.com/show_bug.cgi?id=1790967