### PR TITLE
Completion helper should not fail (RhBug:1714376)

### DIFF
--- a/dnf/cli/completion_helper.py.in
+++ b/dnf/cli/completion_helper.py.in
@@ -193,7 +193,7 @@ def main(args):
     cli.configure(args)
     try:
         cli.run()
-    except dnf.exceptions.Error:
+    except (OSError, dnf.exceptions.Error):
         sys.exit(0)
 
 if __name__ == "__main__":


### PR DESCRIPTION
In case the *.solv files for repositories do not exists in the root
cache, completion_helper.py raises this error:

Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/dnf/cli/completion_helper.py", line 201, in <module>
    main(sys.argv[1:])
  File "/usr/lib/python3.7/site-packages/dnf/cli/completion_helper.py", line 195, in main
    cli.run()
  File "/usr/lib/python3.7/site-packages/dnf/cli/cli.py", line 1112, in run
    self._process_demands()
  File "/usr/lib/python3.7/site-packages/dnf/cli/cli.py", line 816, in _process_demands
    load_available_repos=self.demands.available_repos)
  File "/usr/lib/python3.7/site-packages/dnf/base.py", line 406, in fill_sack
    self._add_repo_to_sack(r)
  File "/usr/lib/python3.7/site-packages/dnf/base.py", line 143, in _add_repo_to_sack
    self._sack.load_repo(repo._repo, build_cache=True, **mdload_flags)
OSError: cannot create temporary file: /var/cache/dnf/docker-ce-stable.solv.hj86Gw

https://bugzilla.redhat.com/show_bug.cgi?id=1714376