### PR TITLE
History tbl to max size when redirect to file (RhBug:1786335,1786316)

### DIFF
--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -1632,7 +1632,14 @@ Transaction Summary
         fmt = "%s | %s | %s | %s | %s"
         if len(uids) == 1:
             name = _("Command line")
-            name_width = self.term.columns - 55 if self.term.columns > 79 else 24
+            real_cols = self.term.real_columns
+            if real_cols is None:
+                name_width = (
+                        24 if not transactions
+                        else max([len(t.cmdline) for t in transactions])
+                        )
+            else:
+                name_width = real_cols - 55 if real_cols > 79 else 24
         else:
             # TRANSLATORS: user names who executed transaction in history command output
             name = _("User name")


### PR DESCRIPTION
History table should expand to full size to be able to catch the whole transaction table e.g. when redirected to file

Enhances commit fc31c508fb24730ae4f44f9cf9da9f8ffb9359f9 for PR #1559

Related bugs:
RHEL8:  https://bugzilla.redhat.com/show_bug.cgi?id=1786335
Fedora: https://bugzilla.redhat.com/show_bug.cgi?id=1786316

Partial fix to: https://bugzilla.redhat.com/show_bug.cgi?id=1653607