### PR TITLE
Update `dnf alias` documentation

### DIFF
--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -458,9 +458,9 @@ Alias Examples
 ``dnf alias add rm=remove``
     Adds a new command alias called ``rm`` which works the same as the ``remove`` command.
 
-``dnf alias add update="\update --skip-broken --disableexcludes=all --obsoletes"``
-    Adds a new command alias called ``update`` which works the same as the ``update`` command,
-    with additional options. Note that the original ``update`` command is prefixed with a ``\``
+``dnf alias add upgrade="\upgrade --skip-broken --disableexcludes=all --obsoletes"``
+    Adds a new command alias called ``upgrade`` which works the same as the ``upgrade`` command,
+    with additional options. Note that the original ``upgrade`` command is prefixed with a ``\``
     to prevent an infinite loop in alias processing.
 
 .. _alias_processing_examples-label:


### PR DESCRIPTION
One of the examples shows an alias for the deprecated `update` command; update it
to show an example for `upgrade` instead.

Signed-off-by: Michel Salim <michel@fb.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rpm-software-management/dnf/1588)
<!-- Reviewable:end -->
