### PR TITLE
Fix: [spec] hawkey_version 0.45.0 (DNF depends on libdnf.error module)

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -1,5 +1,5 @@
 # default dependencies
-%global hawkey_version 0.44.0
+%global hawkey_version 0.45.0
 %global libcomps_version 0.1.8
 %global libmodulemd_version 1.4.0
 %global rpm_version 4.14.0


### PR DESCRIPTION
The patch "Handle custom exceptions from libdnf" depends on libdnf.error
module that was added into libdnf version 0.45.0 (https://github.com/rpm-software-management/libdnf/pull/866).