### PR TITLE
docs:clarify the behavior of `enabled`

### DIFF
--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -458,7 +458,7 @@ configuration file by your distribution to override the DNF defaults.
 ``enabled``
     :ref:`boolean <boolean-label>`
 
-    Include this repository as a package source. The default is True.
+    Include this repository as a package source. The default is True. A repository that does not have the `enabled=0` entry is enabled by default.
 
 .. _repo_gpgkey-label:
 


### PR DESCRIPTION
In the man page, it is not mentioned that the repository must not have enabled=1 to work. Vica versa, the enabled string is used to disable a repository.