### PR TITLE
Use WantedBy=timers.target for all dnf timers (RhBug:1798475)

### DIFF
--- a/etc/systemd/dnf-automatic-download.timer
+++ b/etc/systemd/dnf-automatic-download.timer
@@ -10,4 +10,4 @@ RandomizedDelaySec=60m
 Persistent=true
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=timers.target

--- a/etc/systemd/dnf-automatic-install.timer
+++ b/etc/systemd/dnf-automatic-install.timer
@@ -10,4 +10,4 @@ RandomizedDelaySec=60m
 Persistent=true
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=timers.target

--- a/etc/systemd/dnf-automatic-notifyonly.timer
+++ b/etc/systemd/dnf-automatic-notifyonly.timer
@@ -10,4 +10,4 @@ RandomizedDelaySec=60m
 Persistent=true
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=timers.target

--- a/etc/systemd/dnf-automatic.timer
+++ b/etc/systemd/dnf-automatic.timer
@@ -10,4 +10,4 @@ RandomizedDelaySec=60m
 Persistent=true
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=timers.target

--- a/etc/systemd/dnf-makecache.timer
+++ b/etc/systemd/dnf-makecache.timer
@@ -11,4 +11,4 @@ OnUnitInactiveSec=1h
 Unit=dnf-makecache.service
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=timers.target


### PR DESCRIPTION
According to systemd.special(7) it is recommended that timer units
installed by applications get pulled in from timers.target unit.

https://bugzilla.redhat.com/show_bug.cgi?id=1798475