### PR TITLE
Check if arguments can be encoded in 'utf-8'

### DIFF
--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -404,7 +404,16 @@ class OptionParser(argparse.ArgumentParser):
         else:
             return self.command_positional_parser.add_argument(*args, **kwargs)
 
+    def _check_encoding(self, args):
+        for arg in args:
+            try:
+                arg.encode('utf-8')
+            except UnicodeEncodeError as e:
+                raise dnf.exceptions.ConfigError(
+                    _("Cannot encode argument '%s': %s") % (arg, str(e)))
+
     def parse_main_args(self, args):
+        self._check_encoding(args)
         namespace, _unused_args = self.parse_known_args(args)
         return namespace
 


### PR DESCRIPTION
This doesn't prohibit using different locale, but raises an error
when different encoding is used in arguments than set by locale.

Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/795