### PR TITLE
Fix crashes in callbacks (RhBug:1809600)

### DIFF
--- a/dnf/yum/rpmtrans.py
+++ b/dnf/yum/rpmtrans.py
@@ -46,6 +46,16 @@ TS_FAILED = 100
 TS_INSTALL_STATES = [TS_INSTALL, TS_UPDATE, TS_OBSOLETING]
 TS_REMOVE_STATES = [TS_ERASE, TS_OBSOLETED, TS_UPDATED]
 
+RPM_ACTIONS_SET = {libdnf.transaction.TransactionItemAction_INSTALL,
+                   libdnf.transaction.TransactionItemAction_DOWNGRADE,
+                   libdnf.transaction.TransactionItemAction_DOWNGRADED,
+                   libdnf.transaction.TransactionItemAction_OBSOLETE,
+                   libdnf.transaction.TransactionItemAction_OBSOLETED,
+                   libdnf.transaction.TransactionItemAction_UPGRADE,
+                   libdnf.transaction.TransactionItemAction_UPGRADED,
+                   libdnf.transaction.TransactionItemAction_REMOVE,
+                   libdnf.transaction.TransactionItemAction_REINSTALLED}
+
 logger = logging.getLogger('dnf')
 
 
@@ -240,8 +250,8 @@ class RPMTransaction(object):
                 return self._tsi_cache
         items = []
         for tsi in self.base.transaction:
-            if tsi.action == libdnf.transaction.TransactionItemAction_REINSTALL:
-                # skip REINSTALL in order to return REINSTALLED
+            if tsi.action not in RPM_ACTIONS_SET:
+                # skip REINSTALL in order to return REINSTALLED, or REASON_CHANGE to avoid crash
                 continue
             if str(tsi) == te_nevra:
                 items.append(tsi)


### PR DESCRIPTION
Prevents crashes when reason change is the transaction

Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/dnf/yum/rpmtrans.py", line 267, in callback
    self._elemProgress(key, amount)
  File "/usr/lib/python3.6/site-packages/dnf/yum/rpmtrans.py", line 316, in _elemProgress
    display.filelog(transaction_list[0].pkg, transaction_list[0].action)
  File "/usr/lib/python3.6/site-packages/dnf/db/history.py", line 133, in pkg
    return self._swdb.rpm._swdb_ti_pkg[self._item]
KeyError: <libdnf.transaction.TransactionItem; proxy of <Swig Object of type 'libdnf::TransactionItemPtr *' at 0x7f057852c8d0> >

https://bugzilla.redhat.com/show_bug.cgi?id=1809600

Test: https://github.com/rpm-software-management/ci-dnf-stack/pull/801