### PR TITLE
[.packit.yaml] use fedora-all and remove specfile_path & upstream_project_name

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,13 +1,9 @@
 ---
-upstream_project_name: dnf
-specfile_path: dnf.spec
 jobs:
 - job: copr_build
   trigger: pull_request
   metadata:
     targets:
-    - fedora-rawhide-x86_64
-    - fedora-30-x86_64
-    - fedora-29-x86_64
+    - fedora-all
     - mageia-cauldron-x86_64
     - opensuse-tumbleweed-x86_64


### PR DESCRIPTION
`fedora-all` is alias for all stable/development releases
`specfile_path` & `upstream_project_name` are not needed

https://packit.dev/docs/configuration