### PR TITLE
Fix crash with "dnf -d 6 repolist" (RhBug:1812682)

### DIFF
--- a/dnf/cli/commands/repolist.py
+++ b/dnf/cli/commands/repolist.py
@@ -125,7 +125,7 @@ class RepoListCommand(commands.Command):
             logger.warning(_('No repositories available'))
             return
         include_status = arg == 'all' or (arg == 'enabled-default' and extcmds)
-
+        repoinfo_output = []
         for repo in repos:
             if len(extcmds) and not _repo_match(repo, extcmds):
                 continue
@@ -235,9 +235,10 @@ class RepoListCommand(commands.Command):
                 if repo.repofile:
                     out += [self.output.fmtKeyValFill(_("Repo-filename      : "),
                                                       repo.repofile)]
+                repoinfo_output.append("\n".join(map(ucd, out)))
 
-                print("\n" + "\n".join(map(ucd, out)))
-
+        if repoinfo_output:
+            print("\n\n".join(repoinfo_output))
         if not verbose and cols:
             #  Work out the first (id) and last (enabled/disabled/count),
             # then chop the middle (name)...

--- a/dnf/cli/commands/repolist.py
+++ b/dnf/cli/commands/repolist.py
@@ -93,14 +93,14 @@ class RepoListCommand(commands.Command):
                             help=_("Repository specification"))
 
     def pre_configure(self):
-        if not self.opts.verbose and not self.opts.quiet:
+        if not self.opts.quiet:
             self.cli.redirect_logger(stdout=logging.WARNING, stderr=logging.INFO)
 
     def configure(self):
-        if not self.opts.verbose and not self.opts.quiet:
+        if not self.opts.quiet:
             self.cli.redirect_repo_progress()
         demands = self.cli.demands
-        if any((self.opts.verbose, ('repoinfo' in self.opts.command))):
+        if any((self.base.conf.verbose, ('repoinfo' in self.opts.command))):
             demands.available_repos = True
             demands.sack_activation = True
 

--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -272,11 +272,11 @@ class RepoQueryCommand(commands.Command):
                             help=_('the key to search for'))
 
     def pre_configure(self):
-        if not self.opts.verbose and not self.opts.quiet:
+        if not self.opts.quiet:
             self.cli.redirect_logger(stdout=logging.WARNING, stderr=logging.INFO)
 
     def configure(self):
-        if not self.opts.verbose and not self.opts.quiet:
+        if not self.opts.quiet:
             self.cli.redirect_repo_progress()
         demands = self.cli.demands
 

--- a/dnf/cli/commands/search.py
+++ b/dnf/cli/commands/search.py
@@ -143,11 +143,11 @@ class SearchCommand(commands.Command):
         return counter
 
     def pre_configure(self):
-        if not self.opts.verbose and not self.opts.quiet:
+        if not self.opts.quiet:
             self.cli.redirect_logger(stdout=logging.WARNING, stderr=logging.INFO)
 
     def configure(self):
-        if not self.opts.verbose and not self.opts.quiet:
+        if not self.opts.quiet:
             self.cli.redirect_repo_progress()
         demands = self.cli.demands
         demands.available_repos = True


### PR DESCRIPTION
Recently base.conf.verbose and opts.verbose changed meaning therefore
they cannot be used by the same name.

https://bugzilla.redhat.com/show_bug.cgi?id=1812682

CI-TESTS: https://github.com/rpm-software-management/ci-dnf-stack/pull/806