### PR TITLE
Remove includepkgs option (RhBug:1813460)

### DIFF
--- a/doc/cli_vs_yum.rst
+++ b/doc/cli_vs_yum.rst
@@ -87,12 +87,6 @@ following will work::
 
     dnf -x '*flask*' list installed 'python-f*'
 
-==========================================================
- YUM's conf directive ``includepkgs`` is just ``include``
-==========================================================
-
-``include`` directive name of [main] and Repo configuration is a more logical and better named counterpart of ``exclude`` in DNF.
-
 =======================================
 The ``include`` option has been removed
 =======================================


### PR DESCRIPTION
includepkg otpion is the same in yum and dnf
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1813460