### PR TITLE
Updateinfo direct command and verbose list (RhBug:1801092)

### DIFF
--- a/dnf/cli/commands/updateinfo.py
+++ b/dnf/cli/commands/updateinfo.py
@@ -326,24 +326,29 @@ class UpdateInfoCommand(commands.Command):
                         continue
                     elif ref.type == hawkey.REFERENCE_CVE and not self.opts.with_cve:
                         continue
-                    nevra_inst_dict.setdefault((nevra, installed), dict())[ref.id] = (
-                        advisory.type, advisory.severity)
+                    nevra_inst_dict.setdefault((nevra, installed, advisory.updated), dict())[ref.id] = (
+                            advisory.type, advisory.severity)
             else:
-                nevra_inst_dict.setdefault((nevra, installed), dict())[advisory.id] = (
-                    advisory.type, advisory.severity)
+                nevra_inst_dict.setdefault((nevra, installed, advisory.updated), dict())[advisory.id] = (
+                        advisory.type, advisory.severity)
 
         advlist = []
         # convert types to labels, find max len of advisory IDs and types
-        idw = tlw = 0
-        for (nevra, inst), id2type in sorted(nevra_inst_dict.items(), key=lambda x: x[0]):
+        idw = tlw = nw = 0
+        for (nevra, inst, aupdated), id2type in sorted(nevra_inst_dict.items(), key=lambda x: x[0]):
+            nw = max(nw, len(nevra))
             for aid, atypesev in id2type.items():
                 idw = max(idw, len(aid))
                 label = type2label(*atypesev)
                 tlw = max(tlw, len(label))
-                advlist.append((inst2mark(inst), aid, label, nevra))
+                advlist.append((inst2mark(inst), aid, label, nevra, aupdated))
 
-        for (inst, aid, label, nevra) in advlist:
-            print('%s%-*s %-*s %s' % (inst, idw, aid, tlw, label, nevra))
+        for (inst, aid, label, nevra, aupdated) in advlist:
+            if self.base.conf.verbose:
+                print('%s%-*s %-*s %-*s %s' % (inst, idw, aid, tlw, label, nw, nevra, aupdated))
+            else:
+                print('%s%-*s %-*s %s' % (inst, idw, aid, tlw, label, nevra))
+
 
     def display_info(self, apkg_adv_insts):
         """Display the details about available advisories."""

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -1565,8 +1565,9 @@ Updateinfo Command
 
     Depending on the output type, DNF displays just counts of advisory types
     (omitted or ``--summary``), list of advisories (``--list``) or detailed
-    information (``--info``). When the ``-v`` option is used with ``--info``, the
-    information is even more detailed.
+    information (``--info``). The ``-v`` option extends the output. When
+    used with ``--info`` the information is even more detailed. When used
+    with ``--list`` additional column with date of last advisory update is added.
 
     ``<availability>`` specifies whether advisories about newer versions of
     installed packages (omitted or ``--available``), advisories about equal and


### PR DESCRIPTION
This changes the output of `updateinfo list` command in verbose mode, while someone might depend on that I think its fine because the original behavior is still present in non verbose mode.

(The first commit also fixes a bug with direct commands)

Tests:
https://github.com/rpm-software-management/ci-dnf-stack/pull/809

https://bugzilla.redhat.com/show_bug.cgi?id=1801092