### PR TITLE
Fix behavior of `install-n` command

### DIFF
--- a/dnf/cli/commands/autoremove.py
+++ b/dnf/cli/commands/autoremove.py
@@ -65,8 +65,9 @@ class AutoremoveCommand(commands.Command):
 
     def run(self):
         if any([self.opts.grp_specs, self.opts.pkg_specs, self.opts.filenames]):
-            forms = [self.nevra_forms[command] for command in self.opts.command
-                     if command in list(self.nevra_forms.keys())]
+            forms = []
+            if self.opts.command in self.nevra_forms:
+                forms = [self.nevra_forms[self.opts.command]]
 
             self.base.autoremove(forms,
                                  self.opts.pkg_specs,

--- a/dnf/cli/commands/install.py
+++ b/dnf/cli/commands/install.py
@@ -74,12 +74,12 @@ class InstallCommand(commands.Command):
         nevra_forms = self._get_nevra_forms_from_command()
 
         self.cli._populate_update_security_filter(self.opts, self.base.sack.query())
-        if self.opts.command == ['localinstall'] and (self.opts.grp_specs or self.opts.pkg_specs):
+        if self.opts.command == 'localinstall' and (self.opts.grp_specs or self.opts.pkg_specs):
             self._log_not_valid_rpm_file_paths(self.opts.grp_specs)
             if self.base.conf.strict:
                 raise dnf.exceptions.Error(_('Nothing to do.'))
         skipped_grp_specs = []
-        if self.opts.grp_specs and self.opts.command != ['localinstall']:
+        if self.opts.grp_specs and self.opts.command != 'localinstall':
             if dnf.base.WITH_MODULES:
                 try:
                     module_base = dnf.module.module_base.ModuleBase(self.base)
@@ -108,10 +108,10 @@ class InstallCommand(commands.Command):
             self._inform_not_a_valid_combination(skipped_grp_specs)
             if self.base.conf.strict:
                 raise dnf.exceptions.Error(_('Nothing to do.'))
-        elif skipped_grp_specs and self.opts.command != ['localinstall']:
+        elif skipped_grp_specs and self.opts.command != 'localinstall':
             self._install_groups(skipped_grp_specs)
 
-        if self.opts.command != ['localinstall']:
+        if self.opts.command != 'localinstall':
             errs = self._install_packages(nevra_forms)
 
         if (len(errs) != 0 or len(err_pkgs) != 0 or error_module_specs) and self.base.conf.strict:

--- a/dnf/cli/commands/install.py
+++ b/dnf/cli/commands/install.py
@@ -120,10 +120,10 @@ class InstallCommand(commands.Command):
                                                            packages=err_pkgs)
 
     def _get_nevra_forms_from_command(self):
-        return [self.nevra_forms[command]
-                for command in self.opts.command
-                if command in list(self.nevra_forms.keys())
-                ]
+        if self.opts.command in self.nevra_forms:
+            return [self.nevra_forms[self.opts.command]]
+        else:
+            return []
 
     def _log_not_valid_rpm_file_paths(self, grp_specs):
         group_names = map(lambda g: '@' + g, grp_specs)

--- a/dnf/cli/commands/remove.py
+++ b/dnf/cli/commands/remove.py
@@ -79,8 +79,9 @@ class RemoveCommand(commands.Command):
 
     def run(self):
 
-        forms = [self.nevra_forms[command] for command in self.opts.command
-                 if command in list(self.nevra_forms.keys())]
+        forms = []
+        if self.opts.command in self.nevra_forms:
+            forms = [self.nevra_forms[self.opts.command]]
 
         # local pkgs not supported in erase command
         self.opts.pkg_specs += self.opts.filenames

--- a/dnf/cli/commands/repolist.py
+++ b/dnf/cli/commands/repolist.py
@@ -100,7 +100,7 @@ class RepoListCommand(commands.Command):
         if not self.opts.quiet:
             self.cli.redirect_repo_progress()
         demands = self.cli.demands
-        if any((self.base.conf.verbose, ('repoinfo' in self.opts.command))):
+        if self.base.conf.verbose or self.opts.command == 'repoinfo':
             demands.available_repos = True
             demands.sack_activation = True
 
@@ -139,10 +139,10 @@ class RepoListCommand(commands.Command):
                 enabled = True
                 if arg == 'disabled':
                     continue
-                if any((include_status, verbose, 'repoinfo' in self.opts.command)):
+                if include_status or verbose or self.opts.command == 'repoinfo':
                     ui_enabled = ehibeg + _('enabled') + hiend
                     ui_endis_wid = exact_width(_('enabled'))
-                if verbose or ('repoinfo' in self.opts.command):
+                if verbose or self.opts.command == 'repoinfo':
                     ui_size = _repo_size(self.base.sack, repo)
             else:
                 enabled = False
@@ -151,7 +151,7 @@ class RepoListCommand(commands.Command):
                 ui_enabled = dhibeg + _('disabled') + hiend
                 ui_endis_wid = exact_width(_('disabled'))
 
-            if not any((verbose, ('repoinfo' in self.opts.command))):
+            if not (verbose or self.opts.command == 'repoinfo'):
                 rid = ucd(repo.id)
                 cols.append((rid, repo.name, (ui_enabled, ui_endis_wid)))
             else:
@@ -287,6 +287,6 @@ class RepoListCommand(commands.Command):
                 print("%s %s %s" % (fill_exact_width(rid, id_len),
                                     fill_exact_width(rname, nm_len, nm_len),
                                     ui_enabled))
-        if any((verbose, ('repoinfo' in self.opts.command))):
+        if verbose or self.opts.command == 'repoinfo':
             msg = _('Total packages: {}')
             print(msg.format(_num2ui_num(tot_num)))

--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -448,10 +448,8 @@ class RepoQueryCommand(commands.Command):
             remote_packages = self._add_add_remote_packages()
 
             kwark = {}
-            forms = [self.nevra_forms[command] for command in self.opts.command
-                     if command in list(self.nevra_forms.keys())]
-            if forms:
-                kwark["forms"] = forms
+            if self.opts.command in self.nevra_forms:
+                kwark["forms"] = [self.nevra_forms[self.opts.command]]
             pkgs = []
             query_results = q.filter(empty=True)
 

--- a/dnf/cli/commands/updateinfo.py
+++ b/dnf/cli/commands/updateinfo.py
@@ -112,9 +112,9 @@ class UpdateInfoCommand(commands.Command):
         self.cli.demands.available_repos = True
         self.cli.demands.sack_activation = True
 
-        if self.opts.command[0] in self.direct_commands:
+        if self.opts.command in self.direct_commands:
             # we were called with direct command
-            self.opts.spec_action = self.direct_commands[self.opts.command[0]]
+            self.opts.spec_action = self.direct_commands[self.opts.command]
         else:
             if self.opts._spec_action:
                 self.opts.spec_action = self.opts._spec_action


### PR DESCRIPTION
Commit de9643afbdf5bb (first shipped in dnf 4.2.8) changed `opts.command` from a list to a simple string, but code in `InstallCommand` still handledit as if it was a list.

This broke silently because Python will iterate over a string character by character, so it never produced a syntax error or an exception that would be noticed.

But it broke behavior of the `install-n` form, since it would no longer detect that command to restrict search of packages.

Before this commit, this command would (incorrectly) succeed:

```
$ dnf install-n joe-4.6
```

After this commit:

```
$ dnf install-n joe-4.6
No match for argument: joe-4.6
  * Maybe you meant: joe
Error: Unable to find a match: joe-4.6
```

The latter is consistent with behavior in dnf 4.2.7 and earlier.
