### PR TITLE
Print nicer DnssecErrors (RhBug:1813244)

### DIFF
--- a/dnf/dnssec.py
+++ b/dnf/dnssec.py
@@ -58,7 +58,7 @@ def email2location(email_address, tag="_openpgpkey"):
     """
     split = email_address.split("@")
     if len(split) != 2:
-        msg = "Email address should contain exactly one '@' sign."
+        msg = "Email address must contain exactly one '@' sign."
         logger.error(msg)
         raise DnssecError(msg)
 

--- a/dnf/dnssec.py
+++ b/dnf/dnssec.py
@@ -59,7 +59,6 @@ def email2location(email_address, tag="_openpgpkey"):
     split = email_address.split("@")
     if len(split) != 2:
         msg = "Email address must contain exactly one '@' sign."
-        logger.error(msg)
         raise DnssecError(msg)
 
     local = split[0]
@@ -287,8 +286,8 @@ class RpmImportedKeys:
                 result = DNSSECKeyVerification.verify(key)
             except DnssecError as e:
                 # Errors in this exception should not be fatal, print it and just continue
-                logger.exception("Exception raised in DNSSEC extension: email={}, exception={}"
-                                 .format(key.email, repr(e)))
+                logger.warning("DNSSEC extension error (email={}): {}"
+                             .format(key.email, e.value))
                 continue
             # TODO: remove revoked keys automatically and possibly ask user to confirm
             if result == Validity.VALID:


### PR DESCRIPTION
Print errors more readable by users. Instead of current exception-like
error:

$ dnf list dnf
DNSSEC extension: Testing already imported keys for their validity.
Email address should contain exactly one '@' sign.
Exception raised in DNSSEC extension: email=@dnsoarc#drool@copr.fedorahosted.org, exception=<DnssecError, value='Email address should contain exactly one '@' sign.'>
Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/dnf/dnssec.py", line 287, in check_imported_keys_validity
    result = DNSSECKeyVerification.verify(key)
  File "/usr/lib/python3.7/site-packages/dnf/dnssec.py", line 227, in verify
    result = DNSSECKeyVerification._cache_miss(input_key)
  File "/usr/lib/python3.7/site-packages/dnf/dnssec.py", line 186, in _cache_miss
    status, result = ctx.resolve(email2location(input_key.email),
  File "/usr/lib/python3.7/site-packages/dnf/dnssec.py", line 63, in email2location
    raise DnssecError(msg)
dnf.dnssec.DnssecError: Email address should contain exactly one '@' sign.
Email address should contain exactly one '@' sign.

Print shorter and clearer error message:

$ dnf list dnf
DNSSEC extension: Testing already imported keys for their validity.
DNSSEC extension error (email=@dnsoarc#drool@copr.fedorahosted.org): Email address must contain exactly one '@' sign.

https://bugzilla.redhat.com/show_bug.cgi?id=1813244