### PR TITLE
dnf-automatic: Mention the date/time that updates were applied

### DIFF
--- a/dnf/automatic/emitter.py
+++ b/dnf/automatic/emitter.py
@@ -27,8 +27,10 @@ import dnf.pycomp
 import smtplib
 import email.utils
 import subprocess
+import time
 
 APPLIED = _("The following updates have been applied on '%s':")
+APPLIED_TIMESTAMP = _("Updates completed at %s")
 AVAILABLE = _("The following updates are available on '%s':")
 DOWNLOADED = _("The following updates were downloaded on '%s':")
 
@@ -48,6 +50,7 @@ class Emitter(object):
         if self._applied:
             msg.append(APPLIED % self._system_name)
             msg.append(self._available_msg)
+            msg.append(APPLIED_TIMESTAMP % time.strftime("%c"))
         elif self._downloaded:
             msg.append(DOWNLOADED % self._system_name)
             msg.append(self._available_msg)


### PR DESCRIPTION
This commit adds text like the following to the message that is generated when dnf-automatic has
applied updates:
Updates completed at Sat Apr  4 11:09:17 2020

This is nice information to have up-front, especially for the motd emitter.