### PR TITLE
[dnf-automatic] Wait for internet connection (RhBug:1816308)

### DIFF
--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -172,6 +172,7 @@ class CommandsConfig(Config):
         self.add_option('upgrade_type', libdnf.conf.OptionEnumString('default',
                         libdnf.conf.VectorString(['default', 'security'])))
         self.add_option('random_sleep', libdnf.conf.OptionNumberInt32(300))
+        self.add_option('network_online_timeout', libdnf.conf.OptionNumberInt32(60))
 
     def imply(self):
         if self.apply_updates:
@@ -304,8 +305,8 @@ def main(args):
             base.pre_configure_plugins()
             base.read_all_repos()
 
-            if not wait_for_network(base.repos, 600):
-                logger.warning(_('Network connection not detected.'))
+            if not wait_for_network(base.repos, conf.commands.network_online_timeout):
+                logger.warning(_('System is off-line.'))
 
             base.configure_plugins()
             base.fill_sack()

--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -21,6 +21,13 @@
 from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
+
+import argparse
+import logging
+import random
+import socket
+import time
+
 from dnf.i18n import _, ucd
 import dnf
 import dnf.automatic.emitter
@@ -28,17 +35,12 @@ import dnf.cli
 import dnf.cli.cli
 import dnf.cli.output
 import dnf.conf
-import libdnf.conf
 import dnf.const
 import dnf.exceptions
 import dnf.util
 import dnf.logging
-import hawkey
-import logging
-import socket
-import argparse
-import random
-import time
+import dnf.pycomp
+import libdnf.conf
 
 logger = logging.getLogger('dnf')
 

--- a/doc/automatic.rst
+++ b/doc/automatic.rst
@@ -73,10 +73,15 @@ Setting the mode of operation of the program.
 
     Whether packages comprising the available updates should be downloaded by ``dnf-automatic.timer``. Note that the other timer units override this setting.
 
+``network_online_timeout``
+    time in seconds, default: 60
+
+    Maximal time dnf-automatic will wait until the system is online. 0 means that network availability detection will be skipped.
+
 ``random_sleep``
     time in seconds, default: 0
 
-    Maximal random delay before downloading.  Note that, by default, the ``systemd`` timers also apply a random delay of up to 5 minutes.
+    Maximal random delay before downloading.  Note that, by default, the ``systemd`` timers also apply a random delay of up to 1 hour.
 
 .. _upgrade_type_automatic-label:
 

--- a/doc/automatic.rst
+++ b/doc/automatic.rst
@@ -73,17 +73,17 @@ Setting the mode of operation of the program.
 
     Whether packages comprising the available updates should be downloaded by ``dnf-automatic.timer``. Note that the other timer units override this setting.
 
+``random_sleep``
+    time in seconds, default: 0
+
+    Maximal random delay before downloading.  Note that, by default, the ``systemd`` timers also apply a random delay of up to 5 minutes.
+
 .. _upgrade_type_automatic-label:
 
 ``upgrade_type``
     either one of ``default``, ``security``, default: ``default``
 
     What kind of upgrades to look at. ``default`` signals looking for all available updates, ``security`` only those with an issued security advisory.
-
-``random_sleep``
-    time in seconds, default: 0
-
-    Maximal random delay before downloading.  Note that, by default, the ``systemd`` timers also apply a random delay of up to 5 minutes.
 
 ----------------------
 ``[emitters]`` section
@@ -130,11 +130,6 @@ The command email emitter configuration. Variables usable in format string argum
 
     The shell command to execute.
 
-``stdin_format``
-    format string, default: ``{body}``
-
-    The data to pass to the command on stdin.
-
 ``email_from``
     string, default: ``root``
 
@@ -144,6 +139,11 @@ The command email emitter configuration. Variables usable in format string argum
     list, default: ``root``
 
     List of recipients of the message.
+
+``stdin_format``
+    format string, default: ``{body}``
+
+    The data to pass to the command on stdin.
 
 -------------------
 ``[email]`` section
@@ -156,15 +156,15 @@ The email emitter configuration.
 
     Message's "From:" address.
 
-``email_to``
-    list, default: ``root``
-
-    List of recipients of the message.
-
 ``email_host``
     string, default: ``localhost``
 
     Hostname of the SMTP server used to send the message.
+
+``email_to``
+    list, default: ``root``
+
+    List of recipients of the message.
 
 ------------------
 ``[base]`` section

--- a/etc/dnf/automatic.conf
+++ b/etc/dnf/automatic.conf
@@ -5,6 +5,10 @@
 upgrade_type = default
 random_sleep = 0
 
+# Maximum time in seconds to wait until the system is on-line and able to
+# connect to remote repositories.
+network_online_timeout = 60
+
 # To just receive updates use dnf-automatic-notifyonly.timer
 
 # Whether updates should be downloaded when they are available, by


### PR DESCRIPTION
The dnf-automatic* timers are set to 6AM by default. This works
fine for servers running 24x7 but there is great deal of probability
that workstations are suspended by that time. In that case the timers
are fired as soon as possible after the machine is resumed - even before
the network being properly set-up.
Now dnf-automatic waits until it can establish a connection to at
least one of enabled remote repositories.

https://bugzilla.redhat.com/show_bug.cgi?id=1816308