### PR TITLE
Fix a syntax typo

### DIFF
--- a/dnf/comps.py
+++ b/dnf/comps.py
@@ -108,7 +108,7 @@ class _Langs(object):
         lcl = locale.getlocale(locale.LC_MESSAGES)
         if lcl == (None, None):
             return 'C'
-        return'.'.join(lcl)
+        return '.'.join(lcl)
 
     def get(self):
         current_locale = self._dotted_locale_str()


### PR DESCRIPTION
This is an error with Python 3.9.0a6+:

```
  File "/usr/lib/python3.9/site-packages/dnf/comps.py", line 111
    return'.'.join(lcl)
         ^
SyntaxError: invalid string prefix
```