### PR TITLE
Fix downloading packages with full URL as their location

### DIFF
--- a/dnf/package.py
+++ b/dnf/package.py
@@ -262,6 +262,9 @@ class Package(hawkey.Package):
     def _is_local_pkg(self):
         if self.repoid == "@System":
             return True
+        if '://' in self.location and not self.location.startswith('file://'):
+            # the package has a remote URL as its location
+            return False
         return self._from_cmdline or \
             (self.repo._repo.isLocal() and (not self.baseurl or self.baseurl.startswith('file://')))
 


### PR DESCRIPTION
In case the package has a full URL as its location, don't treat it as
local, even if it would be in a local repository.

Fixes an issue encountered by @kontura when writing tests for downloading packages with full URL in location: https://github.com/rpm-software-management/ci-dnf-stack/pull/819

The tests are for these PRs: 
https://github.com/rpm-software-management/librepo/pull/188
https://github.com/rpm-software-management/libdnf/pull/954