### PR TITLE
Improve command emmitter in dnf-automatic

### DIFF
--- a/dnf/automatic/emitter.py
+++ b/dnf/automatic/emitter.py
@@ -140,6 +140,10 @@ class CommandEmitterMixIn(object):
 
 
 class CommandEmitter(CommandEmitterMixIn, Emitter):
+    def __init__(self, system_name, conf):
+        super(CommandEmitter, self).__init__(system_name)
+        self._conf = conf
+
     def _prepare_msg(self):
         return {'body': super(CommandEmitter, self)._prepare_msg()}
 

--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -58,6 +58,9 @@ def build_emitters(conf):
             elif name == 'motd':
                 emitter = dnf.automatic.emitter.MotdEmitter(system_name)
                 emitters.append(emitter)
+            elif name == 'command':
+                emitter = dnf.automatic.emitter.CommandEmitter(system_name, conf.command)
+                emitters.append(emitter)
             elif name == 'command_email':
                 emitter = dnf.automatic.emitter.CommandEmailEmitter(system_name, conf.command_email)
                 emitters.append(emitter)
@@ -88,6 +91,7 @@ class AutomaticConfig(object):
         self.commands = CommandsConfig()
         self.email = EmailConfig()
         self.emitters = EmittersConfig()
+        self.command = CommandConfig()
         self.command_email = CommandEmailConfig()
         self._parser = None
         self._load(filename)
@@ -118,6 +122,8 @@ class AutomaticConfig(object):
         self.email.populate(parser, 'email', filename, libdnf.conf.Option.Priority_AUTOMATICCONFIG)
         self.emitters.populate(parser, 'emitters', filename,
                                libdnf.conf.Option.Priority_AUTOMATICCONFIG)
+        self.command.populate(parser, 'command', filename,
+                              libdnf.conf.Option.Priority_AUTOMATICCONFIG)
         self.command_email.populate(parser, 'command_email', filename,
                                     libdnf.conf.Option.Priority_AUTOMATICCONFIG)
         self._parser = parser


### PR DESCRIPTION
I'm not sure why, but #635 seems to miss some code which prevents the usage of the Command emitter in dnf-automatic. They could be some code lost on rebase or something, but trying to make it work on my system, it turned out the following changes are required.

There are still some things which could be improved (such as explaining why `output.list_transaction(trans, total_width=80)` still generates output with 120 characters, but it's outside the scope of that PR which just makes the command emmiter possible to use.

Btw, I'm not a Python programmer, so please tell me if there is something done in the non idiomatic way.