### PR TITLE
Fix the license to quiet down rpmdiff

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -85,7 +85,7 @@ Version:        4.2.22
 Release:        1%{?dist}
 Summary:        %{pkg_summary}
 # For a breakdown of the licensing, see PACKAGE-LICENSING
-License:        GPLv2+ and GPLv2 and GPL
+License:        GPLv2+
 URL:            https://github.com/rpm-software-management/dnf
 Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
 BuildArch:      noarch


### PR DESCRIPTION
rpmdiff for DNF always fails with:
Invalid License Tag: GPLv2+ and GPLv2 and GPL.

DNF is licensed under GPLv2+.