### PR TITLE
Add logfilelevel configuration (RhBug:1802074)

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -1,5 +1,5 @@
 # default dependencies
-%global hawkey_version 0.48.0
+%global hawkey_version 0.50.0
 %global libcomps_version 0.1.8
 %global libmodulemd_version 1.4.0
 %global rpm_version 4.14.0

--- a/dnf/logging.py
+++ b/dnf/logging.py
@@ -43,6 +43,7 @@ DEBUG = logging.DEBUG
 DDEBUG = 8  # used by anaconda (pyanaconda/payload/dnfpayload.py)
 SUBDEBUG = 6
 TRACE = 4
+ALL = 2
 
 def only_once(func):
     """Method decorator turning the method into noop on second or later calls."""
@@ -73,6 +74,7 @@ _VERBOSE_VAL_MAPPING = {
     7 : DDEBUG,
     8 : SUBDEBUG,
     9 : TRACE,
+    10: ALL,   # more verbous librepo and hawkey
     }
 
 def _cfg_verbose_val2level(cfg_errval):
@@ -138,6 +140,7 @@ class Logging(object):
         logging.addLevelName(DDEBUG, "DDEBUG")
         logging.addLevelName(SUBDEBUG, "SUBDEBUG")
         logging.addLevelName(TRACE, "TRACE")
+        logging.addLevelName(ALL, "ALL")
         logging.captureWarnings(True)
         logging.raiseExceptions = False
 
@@ -160,7 +163,7 @@ class Logging(object):
         self.stderr_handler = stderr
 
     @only_once
-    def _setup_file_loggers(self, logfile_level, verbose_level, logdir, log_size, log_rotate):
+    def _setup_file_loggers(self, logfile_level, logdir, log_size, log_rotate):
         logger_dnf = logging.getLogger("dnf")
         logger_dnf.setLevel(TRACE)
 
@@ -177,7 +180,7 @@ class Logging(object):
         logger_warnings.addHandler(handler)
 
         lr_logfile = os.path.join(logdir, dnf.const.LOG_LIBREPO)
-        libdnf.repo.LibrepoLog.addHandler(lr_logfile, verbose_level <= DEBUG)
+        libdnf.repo.LibrepoLog.addHandler(lr_logfile, logfile_level <= ALL)
 
         # setup RPM callbacks logger
         logger_rpm = logging.getLogger("dnf.rpm")
@@ -196,7 +199,7 @@ class Logging(object):
         self.stdout_handler.setLevel(SUPERCRITICAL)
         self.stderr_handler.setLevel(SUPERCRITICAL)
 
-        self._setup_file_loggers(logfile_level, verbose_level, logdir, log_size, log_rotate)
+        self._setup_file_loggers(logfile_level, logdir, log_size, log_rotate)
 
         logger_warnings = logging.getLogger("py.warnings")
         logger_warnings.addHandler(self.stderr_handler)
@@ -218,7 +221,7 @@ class Logging(object):
         log_size = conf.log_size
         log_rotate = conf.log_rotate
         if file_loggers_only:
-            return self._setup_file_loggers(logfile_level_r, verbose_level_r, logdir, log_size, log_rotate)
+            return self._setup_file_loggers(logfile_level_r, logdir, log_size, log_rotate)
         else:
             return self._setup(verbose_level_r, error_level_r, logfile_level_r, logdir, log_size, log_rotate)
 

--- a/dnf/sack.py
+++ b/dnf/sack.py
@@ -53,7 +53,7 @@ def _build_sack(base):
                 arch=base.conf.substitutions["arch"],
                 cachedir=cachedir, rootdir=base.conf.installroot,
                 logfile=os.path.join(base.conf.logdir, dnf.const.LOG_HAWKEY),
-                logdebug=base.conf.debuglevel > 2)
+                logdebug=base.conf.logfilelevel > 9)
 
 
 def _rpmdb_sack(base):

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -268,6 +268,12 @@ configuration file by your distribution to override the DNF defaults.
 
     Directory where the log files will be stored. Default is ``/var/log``.
 
+``logfilelevel``
+    :ref:`integer <integer-label>`
+
+    Log file messages output level, in the range 0 to 10. The higher the number the
+    more debug output is put to logs. Default is 9.
+
 .. _log_rotate-label:
 
 ``log_rotate``

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -274,6 +274,9 @@ configuration file by your distribution to override the DNF defaults.
     Log file messages output level, in the range 0 to 10. The higher the number the
     more debug output is put to logs. Default is 9.
 
+    This option controls dnf.log, dnf.librepo.log and hawkey.log. Although dnf.librepo.log
+    and hawkey.log are affected only by setting the logfilelevel to 10.
+
 .. _log_rotate-label:
 
 ``log_rotate``

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -88,7 +88,7 @@ class TestLogging(tests.support.TestCase):
         logger = logging.getLogger("dnf")
         with tests.support.patch_std_streams() as (stdout, stderr):
             self.logging._setup(
-                logging.INFO, logging.ERROR, self.logdir, self.log_size, self.log_rotate)
+                logging.INFO, logging.ERROR, dnf.logging.TRACE, self.logdir, self.log_size, self.log_rotate)
             self._bench(logger)
         self.assertEqual("i\n", stdout.getvalue())
         self.assertEqual("e\n", stderr.getvalue())
@@ -97,7 +97,7 @@ class TestLogging(tests.support.TestCase):
         logger = logging.getLogger("dnf")
         with tests.support.patch_std_streams() as (stdout, stderr):
             self.logging._setup(
-                logging.DEBUG, logging.WARNING, self.logdir, self.log_size, self.log_rotate)
+                logging.DEBUG, logging.WARNING, dnf.logging.TRACE, self.logdir, self.log_size, self.log_rotate)
             self._bench(logger)
         self.assertEqual("d\ni\n", stdout.getvalue())
         self.assertEqual("w\ne\n", stderr.getvalue())
@@ -105,20 +105,22 @@ class TestLogging(tests.support.TestCase):
     @mock.patch('dnf.logging.Logging._setup')
     def test_setup_from_dnf_conf(self, setup_m):
         conf = mock.Mock(
-            debuglevel=2, errorlevel=3, logdir=self.logdir,
+            debuglevel=2, errorlevel=3, logfilelevel=2, logdir=self.logdir,
             log_size=self.log_size, log_rotate=self.log_rotate)
         self.logging._setup_from_dnf_conf(conf)
         self.assertEqual(setup_m.call_args, mock.call(dnf.logging.INFO,
                                                       dnf.logging.WARNING,
+                                                      dnf.logging.INFO,
                                                       self.logdir,
                                                       self.log_size,
                                                       self.log_rotate))
         conf = mock.Mock(
-            debuglevel=6, errorlevel=6, logdir=self.logdir,
+            debuglevel=6, errorlevel=6, logfilelevel=6, logdir=self.logdir,
             log_size=self.log_size, log_rotate=self.log_rotate)
         self.logging._setup_from_dnf_conf(conf)
         self.assertEqual(setup_m.call_args, mock.call(dnf.logging.DEBUG,
                                                       dnf.logging.WARNING,
+                                                      dnf.logging.DEBUG,
                                                       self.logdir,
                                                       self.log_size,
                                                       self.log_rotate))
@@ -126,7 +128,7 @@ class TestLogging(tests.support.TestCase):
     def test_file_logging(self):
         # log nothing to the console:
         self.logging._setup(
-            dnf.logging.SUPERCRITICAL, dnf.logging.SUPERCRITICAL,
+            dnf.logging.SUPERCRITICAL, dnf.logging.SUPERCRITICAL, dnf.logging.TRACE,
             self.logdir, self.log_size, self.log_rotate)
         logger = logging.getLogger("dnf")
         with tests.support.patch_std_streams() as (stdout, stderr):
@@ -145,7 +147,7 @@ class TestLogging(tests.support.TestCase):
     def test_rpm_logging(self):
         # log everything to the console:
         self.logging._setup(
-            dnf.logging.SUBDEBUG, dnf.logging.SUBDEBUG,
+            dnf.logging.SUBDEBUG, dnf.logging.SUBDEBUG, dnf.logging.TRACE,
             self.logdir, self.log_size, self.log_rotate)
         logger = logging.getLogger("dnf.rpm")
         with tests.support.patch_std_streams() as (stdout, stderr):
@@ -167,7 +169,7 @@ class TestLogging(tests.support.TestCase):
         logger = logging.getLogger("dnf")
         self.assertLength(logger.handlers, 0)
         self.logging._setup(
-            dnf.logging.SUBDEBUG, dnf.logging.SUBDEBUG,
+            dnf.logging.SUBDEBUG, dnf.logging.SUBDEBUG, dnf.logging.TRACE,
             self.logdir, self.log_size, self.log_rotate)
         cnt = len(logger.handlers)
         self.assertGreater(cnt, 0)


### PR DESCRIPTION
It also moves hawkey and librepo log verbosity control from debuglevel to logfilelevel

https://bugzilla.redhat.com/show_bug.cgi?id=1802074

Requires: https://github.com/rpm-software-management/libdnf/pull/973