### PR TITLE
Don't turn off stdout/stderr logging longer than necessary (RhBug:1843280)

### DIFF
--- a/dnf/logging.py
+++ b/dnf/logging.py
@@ -172,8 +172,6 @@ class Logging(object):
         handler = _create_filehandler(logfile, log_size, log_rotate)
         handler.setLevel(logfile_level)
         logger_dnf.addHandler(handler)
-        # put the marker in the file now:
-        _paint_mark(logger_dnf)
 
         # setup Python warnings
         logger_warnings = logging.getLogger("py.warnings")
@@ -189,15 +187,10 @@ class Logging(object):
         logfile = os.path.join(logdir, dnf.const.LOG_RPM)
         handler = _create_filehandler(logfile, log_size, log_rotate)
         logger_rpm.addHandler(handler)
-        _paint_mark(logger_rpm)
 
     @only_once
     def _setup(self, verbose_level, error_level, logfile_level, logdir, log_size, log_rotate):
         self._presetup()
-
-        # temporarily turn off stdout/stderr handlers:
-        self.stdout_handler.setLevel(SUPERCRITICAL)
-        self.stderr_handler.setLevel(SUPERCRITICAL)
 
         self._setup_file_loggers(logfile_level, logdir, log_size, log_rotate)
 
@@ -209,6 +202,12 @@ class Logging(object):
         logger_rpm.addHandler(self.stdout_handler)
         logger_rpm.addHandler(self.stderr_handler)
 
+        logger_dnf = logging.getLogger("dnf")
+        # temporarily turn off stdout/stderr handlers:
+        self.stdout_handler.setLevel(WARNING)
+        self.stderr_handler.setLevel(WARNING)
+        _paint_mark(logger_dnf)
+        _paint_mark(logger_rpm)
         # bring std handlers to the preferred level
         self.stdout_handler.setLevel(verbose_level)
         self.stderr_handler.setLevel(error_level)


### PR DESCRIPTION
When _setup failed (for example due to missing permissions to create the
log file), the error was not printed to stderr because of turning off
the sdtout/stderr handlers temporarily.

However, the stdout/stderr handlers need to be turned off only when
creating the logging marker.

https://bugzilla.redhat.com/show_bug.cgi?id=1843280