### PR TITLE
Continue when fail to load/store expired repos (RhBug:1843280)

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -782,7 +782,10 @@ class Cli(object):
         for repo in notmatch:
             logger.warning(_("No repository match: %s"), repo)
 
-        for rid in self.base._repo_persistor.get_expired_repos():
+        expired_repos = self.base._repo_persistor.get_expired_repos()
+        if expired_repos is None:
+            expired_repos = self.base.repos.keys()
+        for rid in expired_repos:
             repo = self.base.repos.get(rid)
             if repo:
                 repo._repo.expire()

--- a/dnf/persistor.py
+++ b/dnf/persistor.py
@@ -103,14 +103,14 @@ class RepoPersistor(JSONDB):
                 dnf.util.touch(self._last_makecache_path)
                 return True
             except IOError:
-                logger.info(_("Failed storing last makecache time."))
+                logger.warning(_("Failed storing last makecache time."))
                 return False
 
     def since_last_makecache(self):
         try:
             return int(dnf.util.file_age(self._last_makecache_path))
         except OSError:
-            logger.info(_("Failed determining last makecache time."))
+            logger.warning(_("Failed determining last makecache time."))
             return None
 
 

--- a/dnf/persistor.py
+++ b/dnf/persistor.py
@@ -84,12 +84,20 @@ class RepoPersistor(JSONDB):
         return os.path.join(self.cachedir, "last_makecache")
 
     def get_expired_repos(self):
-        self._check_json_db(self.db_path)
-        return set(self._get_json_db(self.db_path))
+        try:
+            self._check_json_db(self.db_path)
+            return set(self._get_json_db(self.db_path))
+        except OSError as e:
+            logger.warning(_("Failed to load expired repos cache: %s"), e)
+            return None
 
     def save(self):
-        self._check_json_db(self.db_path)
-        self._write_json_db(self.db_path, list(self.expired_to_add))
+        try:
+            self._check_json_db(self.db_path)
+            self._write_json_db(self.db_path, list(self.expired_to_add))
+        except OSError as e:
+            logger.warning(_("Failed to store expired repos cache: %s"), e)
+            return False
         if self.reset_last_makecache:
             try:
                 dnf.util.touch(self._last_makecache_path)


### PR DESCRIPTION
Failing to load/store this cache is not a critical issue and we can
just report it and continue.