### PR TITLE
Bring PYTHON_INSTALL_DIR logic in line with libdnf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,12 @@ ELSE ()
     MESSAGE (FATAL_ERROR "Invalid PYTHON_DESIRED value: " ${PYTHON_DESIRED})
 ENDIF()
 
-EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c "from sys import stdout; from distutils import sysconfig; stdout.write(sysconfig.get_python_lib())" OUTPUT_VARIABLE PYTHON_INSTALL_DIR)
+EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c "
+from sys import stdout
+from distutils import sysconfig
+path=sysconfig.get_python_lib(True, prefix='${CMAKE_INSTALL_PREFIX}')
+stdout.write(path)"
+OUTPUT_VARIABLE PYTHON_INSTALL_DIR)
 MESSAGE(STATUS "Python install dir is ${PYTHON_INSTALL_DIR}")
 
 ADD_SUBDIRECTORY (dnf)


### PR DESCRIPTION
See https://github.com/rpm-software-management/libdnf/commit/fd1f2028a122ab49fe6a623b78a7c4fcd5c5a2da

I'm currently having trouble building dnf on Github Actions because libdnf is installing its python modules to /usr/lib/python3.8/site-packages but dnf is installing its python modules to /opt/hostedtoolcache/Python/3.8.3/x64/lib/python3.8/site-packages. Bringing the PYTHON_INSTALL_DIR logic inline with the logic from libdnf should fix that issue.