### PR TITLE
Add modular obsoletes support to dnf

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -2,7 +2,7 @@
 %undefine __cmake_in_source_build
 
 # default dependencies
-%global hawkey_version 0.55.3
+%global hawkey_version 0.57.0
 %global libcomps_version 0.1.8
 %global libmodulemd_version 2.9.3
 %global rpm_version 4.14.0

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -161,7 +161,8 @@ class Base(object):
         try:
             solver_errors = self.sack.filter_modules(
                 self._moduleContainer, hot_fix_repos, self.conf.installroot,
-                self.conf.module_platform_id, update_only=False, debugsolver=self.conf.debug_solver)
+                self.conf.module_platform_id, update_only=False, debugsolver=self.conf.debug_solver,
+                module_obsoletes=self.conf.module_obsoletes)
         except hawkey.Exception as e:
             raise dnf.exceptions.Error(ucd(e))
         if solver_errors:


### PR DESCRIPTION
requires: https://github.com/rpm-software-management/libdnf/pull/1005
tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/869