### PR TITLE
dnf-makecache.timer: Add a randomized delay of one hour

### DIFF
--- a/etc/systemd/dnf-makecache.timer
+++ b/etc/systemd/dnf-makecache.timer
@@ -8,6 +8,7 @@ Wants=network-online.target
 [Timer]
 OnBootSec=10min
 OnUnitInactiveSec=1h
+RandomizedDelaySec=60m
 Unit=dnf-makecache.service
 
 [Install]


### PR DESCRIPTION
The time between makecache runs is now increased from one hour to something between one and two hours.

= changelog =
msg: Add a one hour randomized delay to the dnf-makecache.timer
type: enhancement
resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1857029