### PR TITLE
Fix 'make gettext-update'

### DIFF
--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -8,6 +8,13 @@ find_package(Git)
 find_package(Gettext)
 
 if (GIT_FOUND)
+    # detect current git branch
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} branch --show-current
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        OUTPUT_VARIABLE CURRENT_BRANCH)
+
     # output _weblate-clone is never created so the clonning of weblate repo is always processed
     # and fresh *.po files are used
     add_custom_command(OUTPUT _weblate-clone
@@ -20,8 +27,8 @@ if (GIT_FOUND)
     add_custom_target(gettext-update
         COMMENT "Updating translation files from weblate repo"
 
-        COMMAND ${CMAKE_COMMAND} -E copy ${WEBLATE_REPO_PATH}/*.po .
-        COMMAND ${CMAKE_COMMAND} -E copy ${WEBLATE_REPO_PATH}/${PROJECT_NAME}.pot .
+        COMMAND ${CMAKE_COMMAND} -E copy ${WEBLATE_REPO_PATH}/${CURRENT_BRANCH}/*.po .
+        COMMAND ${CMAKE_COMMAND} -E copy ${WEBLATE_REPO_PATH}/${CURRENT_BRANCH}/${PROJECT_NAME}.pot .
         COMMAND ${CMAKE_SOURCE_DIR}/scripts/sanitize_po_files.py *.po
 
         DEPENDS _weblate-clone


### PR DESCRIPTION
In dnf-l10n repo we changed architecture and now the directories are
used instead of branches. The patch fixes locations from where *.po
files are copied.