### PR TITLE
automatic: Use ngettext for string with numbers

### DIFF
--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -28,7 +28,7 @@ import random
 import socket
 import time
 
-from dnf.i18n import _, ucd
+from dnf.i18n import _, ucd, P_
 import dnf
 import dnf.automatic.emitter
 import dnf.cli
@@ -305,7 +305,7 @@ def main(args):
 
             if opts.timer:
                 sleeper = random.randint(0, conf.commands.random_sleep)
-                logger.debug(_('Sleep for %s seconds'), sleeper)
+                logger.debug(P_('Sleep for {} second', 'Sleep for {} seconds', sleeper).format(sleeper))
                 time.sleep(sleeper)
 
             base.pre_configure_plugins()


### PR DESCRIPTION
Currently, the “sleep for %s seconds” string is borderline unlocalizable, due to:

  1. the number being formatted as a string,
  2. showing blatant ignorance towards languages with more than one plural form.

This commit fixes the formatting of the debugging string in a way that
does not use a formatting string and changes the gettext() call to ngettext().