### PR TITLE
Do not handle dnf.librepo.log with logrotate

### DIFF
--- a/etc/logrotate.d/dnf
+++ b/etc/logrotate.d/dnf
@@ -1,11 +1,3 @@
-/var/log/dnf.librepo.log {
-    missingok
-    notifempty
-    rotate 4
-    weekly
-    create 0600 root root
-}
-
 /var/log/hawkey.log {
     missingok
     notifempty


### PR DESCRIPTION
Since the log rotation for dnf.librepo.log is now handled in python,
there shouldn't be a logrotate config for this log anymore.

= changelog =
related: https://bugzilla.redhat.com/show_bug.cgi?id=1816573