### PR TITLE
Use methods from libdnf to get local baseurl

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -1,5 +1,5 @@
 # default dependencies
-%global hawkey_version 0.53.0
+%global hawkey_version 0.54.0
 %global libcomps_version 0.1.8
 %global libmodulemd_version 1.4.0
 %global rpm_version 4.14.0

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1149,7 +1149,7 @@ class Base(object):
         if self.conf.destdir:
             for pkg in local_pkgs:
                 if pkg.baseurl:
-                    location = os.path.join(pkg.baseurl.replace("file://", ""),
+                    location = os.path.join(pkg.get_local_baseurl(),
                                             pkg.location.lstrip("/"))
                 else:
                     location = os.path.join(pkg.repo.pkgdir, pkg.location.lstrip("/"))

--- a/dnf/package.py
+++ b/dnf/package.py
@@ -244,7 +244,7 @@ class Package(hawkey.Package):
             return self.location
         loc = self.location
         if self.repo._repo.isLocal() and self.baseurl and self.baseurl.startswith('file://'):
-            return os.path.join(self.baseurl, loc.lstrip("/"))[7:]
+            return os.path.join(self.get_local_baseurl(), loc.lstrip("/"))
         if not self._is_local_pkg():
             loc = os.path.basename(loc)
         return os.path.join(self.pkgdir, loc.lstrip("/"))

--- a/dnf/repo.py
+++ b/dnf/repo.py
@@ -460,7 +460,7 @@ class Repo(dnf.conf.RepoConf):
     def pkgdir(self):
         # :api
         if self._repo.isLocal():
-            return dnf.util.strip_prefix(self.baseurl[0], 'file://')
+            return self._repo.getLocalBaseurl()
         return self.cache_pkgdir()
 
     def cache_pkgdir(self):


### PR DESCRIPTION
The methods decode the URL in addition to stripping the leading
"file://".

= changelog =
msg: Fix handling local baseurls with encoded characters
type: bugfix
resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1853349

Requires: https://github.com/rpm-software-management/libdnf/pull/1035
Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/894