### PR TITLE
Fix failing unit test if /etc/yum.repos.d didn't exist

### DIFF
--- a/tests/api/test_dnf_conf.py
+++ b/tests/api/test_dnf_conf.py
@@ -46,7 +46,8 @@ class DnfConfTest(TestCase):
         self.assertHasType(dnf.conf.config.PRIO_RUNTIME, int)
 
     def test_get_reposdir(self):
-        # Conf.get_reposiir
+        # Conf.get_reposdir
+        self.conf.reposdir = ["."]
         self.assertHasAttr(self.conf, "get_reposdir")
         self.assertHasType(self.conf.get_reposdir, str)
 


### PR DESCRIPTION
By default it tried to make sure /etc/yum.repos.d existed which leads to
a failure when it doens't (tests not running as root tried to create it).
Use "." as reposdir which should always exist and therefore no need to
create it.