### PR TITLE
Change the debug log timestamps from UTC to local time

### DIFF
--- a/dnf/logging.py
+++ b/dnf/logging.py
@@ -144,8 +144,8 @@ def _create_filehandler(logfile, log_size, log_rotate, log_compress):
         os.chmod(logfile, 0o644)
     handler = MultiprocessRotatingFileHandler(logfile, maxBytes=log_size, backupCount=log_rotate)
     formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s",
-                                  "%Y-%m-%dT%H:%M:%SZ")
-    formatter.converter = time.gmtime
+                                  "%Y-%m-%dT%H:%M:%S%z")
+    formatter.converter = time.localtime
     handler.setFormatter(formatter)
     if log_compress:
         handler.rotator = compression_rotator


### PR DESCRIPTION
Changes the debug log timestamps to use local time instead of UTC. Adds
the offset from UTC suffix to the timestamps instead of the Z, which was
there to indicate UTC according to ISO 8601.

Note hawkey.log already is in local time (in addition to the timestamps
having a different format).

msg: Change the debug log timestamps from UTC to local time
type: enhancement
resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1834538