### PR TITLE
Prevent memory leaks of Query from security filters and for plugins

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -466,6 +466,7 @@ class Base(object):
         self._closed = True
         self._finalize_base()
         self.reset(sack=True, repos=True, goal=True)
+        self._plugins = None
 
     def read_all_repos(self, opts=None):
         # :api
@@ -497,6 +498,7 @@ class Base(object):
                 self.history.close()
             self._comps_trans = dnf.comps.TransactionBunch()
             self._transaction = None
+        self._update_security_filters = []
 
     def _closeRpmDB(self):
         """Closes down the instances of rpmdb that could be open."""

--- a/tests/api/test_dnf_subject.py
+++ b/tests/api/test_dnf_subject.py
@@ -35,6 +35,7 @@ class DnfSubjectApiTest(TestCase):
                 with_filenames=False,
                 forms=None
             ), dnf.query.Query)
+        b.close()
 
     def test_get_best_selector(self):
         # Subject.get_best_selector
@@ -48,6 +49,7 @@ class DnfSubjectApiTest(TestCase):
                 obsoletes=False,
                 reponame=None
             ), dnf.selector.Selector)
+        b.close()
 
     def test_get_nevra_possibilities(self):
         # Subject.get_nevra_possibilities


### PR DESCRIPTION
I am not really sure how this works but if we keep a reference to a
Hawkey object after calling reset (close), which are called by \_\_del\_\_
and \_\_exit\_\_, the reference doesn't get decremented and the Hawkey object
leaks memory.

I am a little worried its hiding some other issue but like I said I don't know.

With these changes running ci-dnf-stack with sanitizers (meaning libdnf
is compiled with them) doesn't report any memory leaks.

The dnf unittests however report memory problems but I think this is caused
by all the mock and stub setups since running dnf normally is fine.
My second commit fixes a couple but there is more in the more complex unittests.