### PR TITLE
Stop `--setopt=cachedir` writing outside of installroot

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -974,8 +974,6 @@ class Cli(object):
 
         self.base.configure_plugins()
 
-        self.base.conf._configure_from_options(opts)
-
         self.command.configure()
 
         if self.base.conf.destdir:


### PR DESCRIPTION
This removes the second time that `configure()` calls `_configure_from_options()`. The first one is here:

https://github.com/rpm-software-management/dnf/blob/0d3b4213cf0ebecb96a638ac6e946aefcd9688bf/dnf/cli/cli.py#L896-L897

If you peek inside `_read_conf_file`, you'll see that it calls `prepend_installroot` on `cachedir` among others.

https://github.com/rpm-software-management/dnf/blob/0d3b4213cf0ebecb96a638ac6e946aefcd9688bf/dnf/cli/cli.py#L1043-L1044

This correct, prepended value is used to construct the repo configs. 

https://github.com/rpm-software-management/dnf/blob/0d3b4213cf0ebecb96a638ac6e946aefcd9688bf/dnf/cli/cli.py#L973-L977

Unfortunately, this is followed up by the second `_configure_from_options()` that this PR deletes. This sets the main `cachedir` to be host-relative again (and not `installroot`-relative, as it should be).

This has at least two nasty effects if you combine `--installroot` with one of the 3 affected `--setopt` calls:
 - you effectively cannot pre-populate the cache in your installroot (repro below)
 - you write to the cache on the base OS instead of the container

# Repro

Make sure the cache is warm.
```
dnf makecache
```

Temporarily break the host cache, REMEMBER TO FIX THIS :)
```
mv /var/cache/dnf /var/cache/dnf.REAL
touch /var/cache/dnf
```

This works as expected, the `install` call uses the cache.
```
td=$(mktemp -d)
mkdir -p "$td"/var/cache/ 
cp -ar --reflink=always /var/cache/dnf.REAL "$td"/var/cache/dnf
time dnf install -y --installroot="$td" jq
rm -rf "$td"
```

This only differs in the `setopt` line, but it does NOT use the  installroot cache. In fact, it will try to write to the decoy `dnf` file on the host and fail. 

So you should first try without removing the bad `dnf` file, see it fail, and then `rm /var/cache/dnf` and try again:

```
td=$(mktemp -d)
mkdir -p "$td"/var/cache/ 
cp -ar --reflink=always /var/cache/dnf.REAL "$td"/var/cache/dnf
time dnf install -y --installroot="$td" --setopt=cachedir=/var/cache/dnf jq
rm -rf "$td"
```

On the second try, you end up waiting to re-fetch all the repodata. And then it turns out that you wrote to both the host and the installroot:

```
$ du -sh /var/cache/dnf/ "$td"/var/cache/dnf/
390M    /var/cache/dnf/
392M    /tmp/tmp.wz0qslgZb0/var/cache/dnf/
```

Yikes.