### PR TITLE
test SQL write a readonly folder

### DIFF
--- a/tests/api/test_dnf_base.py
+++ b/tests/api/test_dnf_base.py
@@ -14,6 +14,7 @@ from .common import TOUR_4_4
 class DnfBaseApiTest(TestCase):
     def setUp(self):
         self.base = dnf.Base(dnf.conf.Conf())
+        self.base.conf.persistdir = "/tmp/tests"
 
     def tearDown(self):
         self.base.close()

--- a/tests/api/test_dnf_db_group.py
+++ b/tests/api/test_dnf_db_group.py
@@ -12,6 +12,7 @@ from .common import TestCase
 class DnfRPMTransactionApiTest(TestCase):
     def setUp(self):
         self.base = dnf.Base(dnf.conf.Conf())
+        self.base.conf.persistdir = "/tmp/tests"
         self.base.fill_sack(False, False)
         self.base.resolve()
         self.rpmTrans = self.base.transaction


### PR DESCRIPTION
fixes on rhel8.4 for test_dnf_base and test_dnf_db_group
```
libdnf._error.Error: SQLite error on "/var/lib/dnf/history.sqlite":
Executing an SQL statement failed: attempt to write a readonly
database
```