### PR TITLE
Revert "Fix --setopt=cachedir writing outside of installroot"

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -974,6 +974,8 @@ class Cli(object):
 
         self.base.configure_plugins()
 
+        self.base.conf._configure_from_options(opts)
+
         self.command.configure()
 
         if self.base.conf.destdir:


### PR DESCRIPTION
This reverts commit 70fffff61f7a006d406b46adc592d21a685c12a8.

The commit breaks resetting excludes with an empty --exclude= CLI switch
if the excludes were set in the config file.