### PR TITLE
Set ASAN_OPTIONS for tests (for sanitizer builds)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,1 +1,6 @@
 ADD_TEST(test ${PYTHON_EXECUTABLE} -m nose -s ${CMAKE_CURRENT_SOURCE_DIR})
+
+# For libdnf built with sanitizers, has no effect otherwise.
+# dnf tests do some wild stuff and cause a lot of leaks, hence turn leak
+# detection off for them.
+SET_PROPERTY(TEST test PROPERTY ENVIRONMENT "ASAN_OPTIONS=verify_asan_link_order=0,detect_leaks=0")


### PR DESCRIPTION
When built against libdnf with sanitizers, ASAN_OPTIONS needs to be set.
It has no effect when sanitizers aren't loaded.

We also turn leak detection off here, dnf tests cause a lot of leaks due
to the way they are set up.