### PR TITLE
Lazy-load base.comps instead of explicitly

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -242,6 +242,8 @@ class Base(object):
     @property
     def comps(self):
         # :api
+        if self._comps is None:
+            self.read_comps(arch_filter=True)
         return self._comps
 
     @property
@@ -1874,7 +1876,6 @@ class Base(object):
             no_match_module_specs = install_specs.grp_specs
 
         if no_match_module_specs:
-            self.read_comps(arch_filter=True)
             exclude_specs.grp_specs = self._expand_groups(exclude_specs.grp_specs)
             self._install_groups(no_match_module_specs, exclude_specs, no_match_group_specs, strict)
 
@@ -2077,7 +2078,6 @@ class Base(object):
                     msg = _('Not a valid form: %s')
                     logger.warning(msg, grp_spec)
             elif grp_specs:
-                self.read_comps(arch_filter=True)
                 if self.env_group_remove(grp_specs):
                     done = True
 

--- a/dnf/cli/commands/group.py
+++ b/dnf/cli/commands/group.py
@@ -110,9 +110,6 @@ class GroupCommand(commands.Command):
 
         return installed, available
 
-    def _grp_setup(self):
-        self.base.read_comps(arch_filter=True)
-
     def _info(self, userlist):
         for strng in userlist:
             group_matched = False
@@ -369,8 +366,6 @@ class GroupCommand(commands.Command):
     def run(self):
         cmd = self.opts.subcmd
         extcmds = self.opts.args
-
-        self._grp_setup()
 
         if cmd == 'summary':
             return self._summary(extcmds)

--- a/dnf/cli/commands/history.py
+++ b/dnf/cli/commands/history.py
@@ -266,8 +266,6 @@ class HistoryCommand(commands.Command):
         ret = None
 
         if vcmd == 'replay':
-            self.base.read_comps(arch_filter=True)
-
             self.replay = TransactionReplay(
                 self.base,
                 self.opts.transaction_filename,

--- a/dnf/cli/commands/install.py
+++ b/dnf/cli/commands/install.py
@@ -151,7 +151,6 @@ class InstallCommand(commands.Command):
         return err_pkgs
 
     def _install_groups(self, grp_specs):
-        self.base.read_comps(arch_filter=True)
         try:
             self.base.env_group_install(grp_specs,
                                         tuple(self.base.conf.group_package_types),

--- a/dnf/cli/commands/remove.py
+++ b/dnf/cli/commands/remove.py
@@ -142,7 +142,6 @@ class RemoveCommand(commands.Command):
                 skipped_grps = self.opts.grp_specs
 
             if skipped_grps:
-                self.base.read_comps(arch_filter=True)
                 for group in skipped_grps:
                     try:
                         if self.base.env_group_remove([group]):

--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -632,7 +632,6 @@ class RepoQueryCommand(commands.Command):
                 print("\n".join(sorted(pkgs)))
 
     def _group_member_report(self, query):
-        self.base.read_comps(arch_filter=True)
         package_conf_dict = {}
         for group in self.base.comps.groups:
             package_conf_dict[group.id] = set([pkg.name for pkg in group.packages_iter()])

--- a/dnf/cli/commands/shell.py
+++ b/dnf/cli/commands/shell.py
@@ -239,6 +239,9 @@ exit (or quit)           exit the shell""")
             if fill_sack:
                 self.base.fill_sack()
 
+            # reset base._comps, as it has changed due to changing the repos
+            self.base._comps = None
+
         else:
             self._help('repo')
 

--- a/dnf/cli/commands/upgrade.py
+++ b/dnf/cli/commands/upgrade.py
@@ -124,7 +124,6 @@ class UpgradeCommand(commands.Command):
 
     def _update_groups(self):
         if self.skipped_grp_specs:
-            self.base.read_comps(arch_filter=True)
             self.base.env_group_upgrade(self.skipped_grp_specs)
             return True
         return False

--- a/tests/api/test_dnf_base.py
+++ b/tests/api/test_dnf_base.py
@@ -34,9 +34,7 @@ class DnfBaseApiTest(TestCase):
     def test_comps(self):
         # Base.comps
         self.assertHasAttr(self.base, "comps")
-
-        # blank initially
-        self.assertEqual(self.base.comps, None)
+        self.assertHasType(self.base.comps, dnf.comps.Comps)
 
         self.base.read_comps()
         self.assertHasType(self.base.comps, dnf.comps.Comps)


### PR DESCRIPTION
Loading base.comps was done by calling a method at arbitrary places in
the code, this is hard to maintain and get right. The method could be
inadvertedly called multiple times per dnf run too.

Instead load the comps data lazily on first access. In case of the
shell, using "repo enable/disable" can cause the comps data to change
mid-run. Instead of explicitly reloading, clear the comps attribute and
let it be lazy-loaded again when needed.

This fixes an error with transaction store/replay when there are no packages, but there are group actions in the transaction.