### PR TITLE
Make log rotated permissions match initial log permissions (RhBug:1894344)

### DIFF
--- a/etc/logrotate.d/dnf
+++ b/etc/logrotate.d/dnf
@@ -3,5 +3,5 @@
     notifempty
     rotate 4
     weekly
-    create 0600 root root
+    create
 }


### PR DESCRIPTION
The logs have [permission 644](https://github.com/rpm-software-management/dnf/blob/master/dnf.spec#L420), keep it after logrotate is invoked.


https://bugzilla.redhat.com/show_bug.cgi?id=1894344