### PR TITLE
Change behaviour of Package().from_repo

### DIFF
--- a/dnf/package.py
+++ b/dnf/package.py
@@ -89,7 +89,9 @@ class Package(hawkey.Package):
     @property
     def from_repo(self):
         # :api
-        return self.base.history.repo(self)
+        if self._from_system:
+            return self.base.history.repo(self)
+        return ""
 
     @property
     def _header(self):

--- a/dnf/package.py
+++ b/dnf/package.py
@@ -73,6 +73,12 @@ class Package(hawkey.Package):
 
     @property
     def _from_repo(self):
+        """
+        For installed packages returns id of repository from which the package was installed
+        prefixed with '@' (if such information is available in the history database). Otherwise
+        returns id of repository the package belongs to (@System for installed packages of unknown
+        origin)
+        """
         pkgrepo = None
         if self._from_system:
             pkgrepo = self.base.history.repo(self)
@@ -83,7 +89,7 @@ class Package(hawkey.Package):
     @property
     def from_repo(self):
         # :api
-        return self._from_repo
+        return self.base.history.repo(self)
 
     @property
     def _header(self):

--- a/doc/api_package.rst
+++ b/doc/api_package.rst
@@ -76,9 +76,8 @@
 
   .. attribute:: from_repo
 
-    For installed packages returns id of repository from which the package was installed prefixed
-    with '@' (if such information is available in the history database). Otherwise returns id of
-    repository the package belongs to (@System for installed packages of unknown origin) (string).
+    For installed packages returns id of repository from which the package was installed if such
+    information is available in the history database. Otherwise returns an empty string (string).
 
   .. attribute:: group
 


### PR DESCRIPTION
The change makes a difference between private attribute _from_repo and
API attribute. _from_repo is required for `dnf info` and we have to keep
it, but for API the magic handling behind could be confusing.

Requires: https://github.com/rpm-software-management/ci-dnf-stack/pull/919
Updates: https://github.com/rpm-software-management/dnf/pull/1692
Fix for test: https://github.com/rpm-software-management/ci-dnf-stack/pull/920