### PR TITLE
Log scriptlets output also for API users (RhBug:1847340)

### DIFF
--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -37,7 +37,7 @@ import time
 from dnf.cli.format import format_number, format_time
 from dnf.i18n import _, C_, P_, ucd, fill_exact_width, textwrap_fill, exact_width, select_short_long
 from dnf.pycomp import xrange, basestring, long, unicode, sys_maxsize
-from dnf.yum.rpmtrans import LoggingTransactionDisplay
+from dnf.yum.rpmtrans import TransactionDisplay
 from dnf.db.history import MergedTransactionWrapper
 import dnf.base
 import dnf.callback
@@ -2071,7 +2071,7 @@ class CliKeyImport(dnf.callback.KeyImport):
         return self.output.userconfirm()
 
 
-class CliTransactionDisplay(LoggingTransactionDisplay):
+class CliTransactionDisplay(TransactionDisplay):
     """A YUM specific callback class for RPM operations."""
 
     width = property(lambda self: dnf.cli.term._term_width())
@@ -2093,7 +2093,7 @@ class CliTransactionDisplay(LoggingTransactionDisplay):
         :param package: the package involved in the event
         :param action: the type of action that is taking place.  Valid
            values are given by
-           :func:`rpmtrans.LoggingTransactionDisplay.action.keys()`
+           :func:`rpmtrans.TransactionDisplay.action.keys()`
         :param ti_done: a number representing the amount of work
            already done in the current transaction
         :param ti_total: a number representing the total amount of work
@@ -2143,15 +2143,6 @@ class CliTransactionDisplay(LoggingTransactionDisplay):
                 self.lastmsg = msg
                 if ti_done == ti_total:
                     print(" ")
-
-    def filelog(self, package, action):
-        pass
-
-    def error(self, message):
-        pass
-
-    def scriptout(self, msgs):
-        pass
 
     def _makefmt(self, percent, ts_done, ts_total, progress=True,
                  pkgname=None, wid1=15):

--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -2151,12 +2151,7 @@ class CliTransactionDisplay(LoggingTransactionDisplay):
         pass
 
     def scriptout(self, msgs):
-        """Print messages originating from a package script.
-
-        :param msgs: the messages coming from the script
-        """
-        if msgs:
-            self.rpm_logger.info(ucd(msgs))
+        pass
 
     def _makefmt(self, percent, ts_done, ts_total, progress=True,
                  pkgname=None, wid1=15):

--- a/dnf/yum/rpmtrans.py
+++ b/dnf/yum/rpmtrans.py
@@ -113,7 +113,10 @@ class TransactionDisplay(object):
         pass
 
     def scriptout(self, msgs):
-        """msgs is the messages that were output (if any)."""
+        """Hook for reporting an rpm scriptlet output.
+
+        :param msgs: the scriptlet output
+        """
         pass
 
     def error(self, message):
@@ -155,6 +158,10 @@ class LoggingTransactionDisplay(ErrorTransactionDisplay):
         action_str = dnf.transaction.FILE_ACTIONS[action]
         msg = '%s: %s' % (action_str, package)
         self.rpm_logger.log(dnf.logging.SUBDEBUG, msg)
+
+    def scriptout(self, msgs):
+        if msgs:
+            self.rpm_logger.info(ucd(msgs))
 
 
 class RPMTransaction(object):

--- a/dnf/yum/rpmtrans.py
+++ b/dnf/yum/rpmtrans.py
@@ -143,7 +143,7 @@ class ErrorTransactionDisplay(TransactionDisplay):
         dnf.util._terminal_messenger('print', message, sys.stderr)
 
 
-class LoggingTransactionDisplay(ErrorTransactionDisplay):
+class LoggingTransactionDisplay(TransactionDisplay):
     '''
     Base class for a RPMTransaction display callback class
     '''


### PR DESCRIPTION
Messages logged into /var/log/dnf.rpm.log are now the same for both
command line and API usage.

https://bugzilla.redhat.com/show_bug.cgi?id=1847340