### PR TITLE
Add api function: fill_sack_from_repos_in_cache (RhBug:1865803)

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -2,7 +2,7 @@
 %undefine __cmake_in_source_build
 
 # default dependencies
-%global hawkey_version 0.55.1
+%global hawkey_version 0.55.3
 %global libcomps_version 0.1.8
 %global libmodulemd_version 2.9.3
 %global rpm_version 4.14.0

--- a/tests/api/test_dnf_base.py
+++ b/tests/api/test_dnf_base.py
@@ -107,6 +107,12 @@ class DnfBaseApiTest(TestCase):
 
         self.base.fill_sack(load_system_repo=False, load_available_repos=False)
 
+    def test_fill_sack_from_repos_in_cache(self):
+        # Base.fill_sack_from_repos_in_cache(self, load_system_repo=True):
+        self.assertHasAttr(self.base, "fill_sack_from_repos_in_cache")
+
+        self.base.fill_sack_from_repos_in_cache(load_system_repo=False)
+
     def test_close(self):
         # Base.close()
         self.assertHasAttr(self.base, "close")


### PR DESCRIPTION
Requires: https://github.com/rpm-software-management/libdnf/pull/1106

This is an alternative solution to https://bugzilla.redhat.com/show_bug.cgi?id=1865803
It conflicts with: https://github.com/rpm-software-management/libdnf/pull/1076

This way original dnf workflow is untouched and only this new api is added. This approach is less dangerous.