### PR TITLE
tests: ensure default LANG to C and LANGUAGE to en_US

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -21,3 +21,5 @@ import os
 
 # run tests with C locales
 os.environ["LC_ALL"] = "C"
+os.environ["LANG"] = "C.UTF-8"
+os.environ["LANGUAGE"] = "en_US:en"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -20,6 +20,6 @@
 import os
 
 # run tests with C locales
-os.environ["LC_ALL"] = "C"
+os.environ["LC_ALL"] = "C.UTF-8"
 os.environ["LANG"] = "C.UTF-8"
 os.environ["LANGUAGE"] = "en_US:en"


### PR DESCRIPTION
This PR intends to:

1. Fix build issue on Debian with detect of releasever and 
2. Enforce locales env for tests only. It has been observed that manipulating locales in at least in Debian environment, `LC_ALL=C` is not sufficient and it breaks reproducible tests doing random changes of locales.

I welcome any suggestions and if needed, I can split it into two PRs.