### PR TITLE
Fix persistor activate problem when called in API

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -316,6 +316,8 @@ class Base(object):
         # :api
 
         period = self.conf.metadata_timer_sync
+        if self._repo_persistor is None:
+            self._activate_persistor()
         persistor = self._repo_persistor
         if timer:
             if dnf.util.on_metered_connection():


### PR DESCRIPTION
When using API, the following code will throw an error:

```python
import dnf
with dnf.Base() as base:
    base.read_all_repos()
    base.update_cache(True)
```

```bash
Traceback (most recent call last):
  File "/home/******/python.py", line 4, in <module>
    base.update_cache(True)
  File "/usr/lib/python3.9/site-packages/dnf/base.py", line 333, in update_cache
    since_last_makecache = persistor.since_last_makecache()
AttributeError: 'NoneType' object has no attribute 'since_last_makecache'
```

I believe that the problem is caused by `persistor` being not initialized, and a workaround is to add a `base._activate_persistor()` before `base.update_cache(True)`:

```python
import dnf
with dnf.Base() as base:
    base.read_all_repos()
    base._activate_persistor()
    base.update_cache(True)
```

So this PR is aimed to fix the problem since `_activate_persistor()` is not included in the `# :api`

Signed-off-by: Hollow Man <hollowman@hollowman.ml>