### PR TITLE
Remove incorrect Wants from dnf-makecache.timer

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -95,3 +95,4 @@ DNF CONTRIBUTORS
     Vladan Kudlac <vladankudlac@gmail.com>
     Will Woods <wwoods@redhat.com>
     Furkan Karcıoğlu <krc440002@gmail.com>
+    Penn Mackintosh <git@hack5.dev>

--- a/etc/systemd/dnf-makecache.timer
+++ b/etc/systemd/dnf-makecache.timer
@@ -3,7 +3,6 @@ Description=dnf makecache --timer
 ConditionKernelCommandLine=!rd.live.image
 # See comment in dnf-makecache.service
 ConditionPathExists=!/run/ostree-booted
-Wants=network-online.target
 
 [Timer]
 OnBootSec=10min


### PR DESCRIPTION
dnf-makecache.timer wants network-online.target, but this isn't needed because dnf-makecache.service also requires it. Worse, as dnf-makecache.target is required by timers.target (and hence graphical.target) this means that the system waits for network-online.target before booting, which delays my boot by about ~8 seconds. I tested this locally, and it works on my machine(TM).