### PR TITLE
Clean up history command error handling

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -506,7 +506,7 @@ class BaseCli(dnf.Base):
             # XXX put this into the ListCommand at some point
             if len(ypl.obsoletes) > 0 and basecmd == 'list':
             # if we've looked up obsolete lists and it's a list request
-                rop = [0, '']
+                rop = len(ypl.obsoletes)
                 print(_('Obsoleting Packages'))
                 for obtup in sorted(ypl.obsoletesTuples,
                                     key=operator.itemgetter(0)):
@@ -518,8 +518,7 @@ class BaseCli(dnf.Base):
             rrap = self.output.listPkgs(ypl.recent, _('Recently Added Packages'),
                                  basecmd, columns=columns)
             if len(patterns) and \
-                rrap[0] and rop[0] and rup[0] and rep[0] and rap[0] and \
-                raep[0] and rip[0]:
+                    rrap == 0 and rop == 0 and rup == 0 and rep == 0 and rap == 0 and raep == 0 and rip == 0:
                 raise dnf.exceptions.Error(_('No matching Packages to list'))
 
     def returnPkgLists(self, pkgnarrow='all', patterns=None,

--- a/dnf/cli/commands/history.py
+++ b/dnf/cli/commands/history.py
@@ -187,7 +187,7 @@ class HistoryCommand(commands.Command):
 
     def _hcmd_undo(self, extcmds):
         old = self._history_get_transaction(extcmds)
-        return self._revert_transaction(old)
+        self._revert_transaction(old)
 
     def _hcmd_rollback(self, extcmds):
         old = self._history_get_transaction(extcmds)
@@ -209,7 +209,7 @@ class HistoryCommand(commands.Command):
                 else:
                     merged_trans.merge(trans)
 
-        return self._revert_transaction(merged_trans)
+        self._revert_transaction(merged_trans)
 
     def _revert_transaction(self, trans):
         action_map = {
@@ -321,7 +321,6 @@ class HistoryCommand(commands.Command):
 
     def run(self):
         vcmd = self.opts.transactions_action
-        ret = None
 
         if vcmd == 'replay':
             self.replay = TransactionReplay(
@@ -336,17 +335,17 @@ class HistoryCommand(commands.Command):
             tids, merged_tids = self._args2transaction_ids()
 
             if vcmd == 'list' and (tids or not self.opts.transactions):
-                ret = self.output.historyListCmd(tids, reverse=self.opts.reverse)
+                self.output.historyListCmd(tids, reverse=self.opts.reverse)
             elif vcmd == 'info' and (tids or not self.opts.transactions):
-                ret = self.output.historyInfoCmd(tids, self.opts.transactions, merged_tids)
+                self.output.historyInfoCmd(tids, self.opts.transactions, merged_tids)
             elif vcmd == 'undo':
-                ret = self._hcmd_undo(tids)
+                self._hcmd_undo(tids)
             elif vcmd == 'redo':
-                ret = self._hcmd_redo(tids)
+                self._hcmd_redo(tids)
             elif vcmd == 'rollback':
-                ret = self._hcmd_rollback(tids)
+                self._hcmd_rollback(tids)
             elif vcmd == 'userinstalled':
-                ret = self._hcmd_userinstalled()
+                self._hcmd_userinstalled()
             elif vcmd == 'store':
                 tid = self._history_get_transaction(tids)
                 data = serialize_transaction(tid)

--- a/dnf/cli/commands/history.py
+++ b/dnf/cli/commands/history.py
@@ -251,7 +251,9 @@ class HistoryCommand(commands.Command):
     def _hcmd_userinstalled(self):
         """Execute history userinstalled command."""
         pkgs = tuple(self.base.iter_userinstalled())
-        return self.output.listPkgs(pkgs, 'Packages installed by user', 'nevra')
+        n_listed = self.output.listPkgs(pkgs, 'Packages installed by user', 'nevra')
+        if n_listed == 0:
+            raise dnf.cli.CliError(_('No packages to list'))
 
     def _args2transaction_ids(self):
         """Convert commandline arguments to transaction ids"""

--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -597,18 +597,10 @@ class Output(object):
                        number
                  '>' - highlighting used when the package has a higher version
                        number
-        :return: (exit_code, [errors])
-
-        exit_code is::
-
-            0 = we're done, exit
-            1 = we've errored, exit with error string
-
+        :return: number of packages listed
         """
         if outputType in ['list', 'info', 'name', 'nevra']:
-            thingslisted = 0
             if len(lst) > 0:
-                thingslisted = 1
                 print('%s' % description)
                 info_set = set()
                 if outputType == 'list':
@@ -645,9 +637,7 @@ class Output(object):
                 if info_set:
                     print("\n".join(sorted(info_set)))
 
-            if thingslisted == 0:
-                return 1, [_('No packages to list')]
-            return 0, []
+            return len(lst)
 
     def userconfirm(self, msg=None, defaultyes_msg=None):
         """Get a yes or no from the user, and default to No


### PR DESCRIPTION
The removal of `ret` value error handling which was removed previously was not
complete. Most of it is was no-op as no errors were really propagated through
it, but the `history userinstalled` command was still relying on it.

The commit removes the last bit and replaces it with raising an exception.