### PR TITLE
Be more specific about libunound requirement

### DIFF
--- a/dnf/dnssec.py
+++ b/dnf/dnssec.py
@@ -166,7 +166,7 @@ class DNSSECKeyVerification:
             import unbound
         except ImportError as e:
             msg = _("Configuration option 'gpgkey_dns_verification' requires "
-                    "libunbound ({})".format(e))
+                    "python3-unbound ({})".format(e))
             raise dnf.exceptions.Error(msg)
 
         ctx = unbound.ub_ctx()

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -199,17 +199,18 @@ configuration file by your distribution to override the DNF defaults.
     :ref:`boolean <boolean-label>`
 
     Should the dnf attempt to automatically verify GPG verification keys using the DNS
-    system. This option requires libunbound to be installed on the client system. This
-    system has two main features. The first one is to check if any of the already
-    installed keys have been revoked. Automatic removal of the key is not yet available,
-    so it is up to the user, to remove revoked keys from the system. The second feature is
-    automatic verification of new keys when a repository is added to the system. In
-    interactive mode, the result is written to the output as a suggestion to the user. In
-    non-interactive mode (i.e. when -y is used), this system will automatically accept
-    keys that are available in the DNS and are correctly signed using DNSSEC. It will also
-    accept keys that do not exist in the DNS system and their NON-existence is
-    cryptographically proven using DNSSEC. This is mainly to preserve backward
-    compatibility.
+    system. This option requires the unbound python module (python3-unbound) to
+    be installed on the client system. This system has two main features. The first
+    one is to check if any of the already installed keys have been revoked. Automatic
+    removal of the key is not yet available, so it is up to the user, to remove
+    revoked keys from the system. The second feature is automatic verification
+    of new keys when a repository is added to the system. In interactive mode, the
+    result is written to the output as a suggestion to the user. In
+    non-interactive mode (i.e. when -y is used), this system will automatically
+    accept keys that are available in the DNS and are correctly signed using
+    DNSSEC. It will also accept keys that do not exist in the DNS system and
+    their NON-existence is cryptographically proven using DNSSEC. This is mainly to
+    preserve backward compatibility.
     Default is ``False``.
 
 


### PR DESCRIPTION
We do not need libunbound. We need python3-unbound, which needs libunbound.so provided by unbound-libs.