### PR TITLE
Remove hardcoded logfile permissions

### DIFF
--- a/dnf/logging.py
+++ b/dnf/logging.py
@@ -139,9 +139,6 @@ def _create_filehandler(logfile, log_size, log_rotate, log_compress):
     if not os.path.exists(logfile):
         dnf.util.ensure_dir(os.path.dirname(logfile))
         dnf.util.touch(logfile)
-        # By default, make logfiles readable by the user (so the reporting ABRT
-        # user can attach root logfiles).
-        os.chmod(logfile, 0o644)
     handler = MultiprocessRotatingFileHandler(logfile, maxBytes=log_size, backupCount=log_rotate)
     formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s",
                                   "%Y-%m-%dT%H:%M:%S%z")


### PR DESCRIPTION
Permissions of the newly created logfiles shouldn't be hardcoded to
644, but should respect umask. By default, the permissions will
still be 644 due to the default umask for the root user being 022.

https://bugzilla.redhat.com/show_bug.cgi?id=1910084