### PR TITLE
[doc] Added proxy ssl configuration options, increase libdnf require

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -2,7 +2,7 @@
 %undefine __cmake_in_source_build
 
 # default dependencies
-%global hawkey_version 0.57.0
+%global hawkey_version 0.59.0
 %global libcomps_version 0.1.8
 %global libmodulemd_version 2.9.3
 %global rpm_version 4.14.0

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -849,6 +849,37 @@ configuration.
     Defaults to ``any``
 
 
+.. _proxy_sslcacert-label:
+
+``proxy_sslcacert``
+    :ref:`string <string-label>`
+
+    Path to the file containing the certificate authorities to verify proxy SSL certificates.
+    Empty by default - uses system default.
+
+.. _proxy_sslverify-label:
+
+``proxy_sslverify``
+    :ref:`boolean <boolean-label>`
+
+    When enabled, proxy SSL certificates are verified. If the client can not be authenticated, connecting fails and the repository is not used any further. If ``False``, SSL connections can be used, but certificates are not verified. Default is ``True``.
+
+.. _proxy_sslclientcert-label:
+
+``proxy_sslclientcert``
+    :ref:`string <string-label>`
+
+    Path to the SSL client certificate used to connect to proxy server.
+    Empty by default.
+
+.. _proxy_sslclientkey-label:
+
+``proxy_sslclientkey``
+    :ref:`string <string-label>`
+
+    Path to the SSL client key used to connect to proxy server.
+    Empty by default.
+
 .. _repo_gpgcheck-label:
 
 ``repo_gpgcheck``

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -881,7 +881,7 @@ configuration.
 ``sslcacert``
     :ref:`string <string-label>`
 
-    Path to the directory or file containing the certificate authorities to verify SSL certificates.
+    Path to the file containing the certificate authorities to verify SSL certificates.
     Empty by default - uses system default.
 
 .. _sslverify-label:


### PR DESCRIPTION
Added options: `proxy_sslcacert`, `proxy_sslverify`, `proxy_sslclientcert`, `proxy_sslclientkey`

Requires "libdnf >= 0.59.0".
https://github.com/rpm-software-management/libdnf/pull/1128

Related to: https://bugzilla.redhat.com/show_bug.cgi?id=1920991