### PR TITLE
Github Actions workflow implementing CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,46 @@
+---
+name: DNF CI
+on: pull_request_target
+
+jobs:
+  integration-tests:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:latest
+      options: --privileged
+    steps:
+      - name: Install API token for Copr
+        id: copr
+        run: |
+          # hack: Github replaces secrets with *** in the whole output (even in
+          # e.g. Copr URLs printed by rpm-gitoverlay). If there's a comment (#)
+          # at the end of the secret (e.g.  "rpmsofwaremanagement #"), this
+          # will clean it up and since it is no longer the whole secret being
+          # printed, Github won't hide it anymore.
+          COPR_USER=${{secrets.COPR_USER}}
+          if [ -z "$COPR_USER" ]; then echo "COPR_USER secret is required to run the CI."; exit 1; fi
+          echo "::set-output name=copr-user::$COPR_USER"
+
+          mkdir -p "$HOME/.config"
+          echo "${{secrets.COPR_API_TOKEN}}" > "$HOME/.config/copr"
+
+      - name: Check out ci-dnf-stack
+        uses: actions/checkout@v2
+        with:
+          repository: rpm-software-management/ci-dnf-stack
+
+      - name: Setup CI
+        uses: ./.github/actions/setup-ci
+
+      - name: Check out sources
+        uses: actions/checkout@v2
+        with:
+          path: gits/${{github.event.pull_request.head.repo.name}}
+          ref: ${{github.event.pull_request.head.sha}}  # check out the PR HEAD
+          fetch-depth: 0
+
+      - name: Run CI
+        uses: ./.github/actions/run-ci
+        with:
+          copr-user: ${{steps.copr.outputs.copr-user}}


### PR DESCRIPTION
Requires: https://github.com/rpm-software-management/ci-dnf-stack/pull/952

This implements CI in Github Actions, running automatically on PR creation and updates. The CI builds the DNF stack in Copr and runs tests on the Github Workflow runners.

It is important to consider the security aspect here. I've discussed this with @martinpitt and this is the analysis, I would like a third opinion before merging:
* Since CI is run automatically on PR submission, an attacker could submit a PR with malicious code
* The CI runs on Github runners, so we don't need to concern ourselves with securing that infrastructure, but **all** organization secrets are available to the workflow and could be stolen
* It is not really possible to "hide" the secrets, we should consider any code running on the runners to have access to them (e.g. read them from the runner's RAM)
* The way the workflow is set up, the workflow code itself is taken from the target branch, not the PR code, so the attacker can't tamper with the workflow code itself
* Hence the attacker can only tamper with the application code, which:
  * Is packaged into a source package
  * Built in Copr
  * Installed into a testing container image
* The container is a podman user (non-root) container built for the tests and should under normal circumstances be considered secure - the untrusted code should be isolated in the container and shouldn't be able to break out to access the secrets

The impact if breached is theft of the organization secrets, which right now is the Copr API token, meaning an attacker could e.g. poison our nightly builds or any other repo.

An alternative to the proposed approach which completely mitigates this risk is to have automatic CI running on PRs from organization members only. For contributor PRs, a second (more complex) workflow would need to be added that would allow running CI on a command, after an organization member reviews the code.