### PR TITLE
DNSSEC improvements

### DIFF
--- a/dnf/dnssec.py
+++ b/dnf/dnssec.py
@@ -179,8 +179,11 @@ class DNSSECKeyVerification:
         if ctx.set_option("qname-minimisation:", "yes") != 0:
             logger.debug("Unbound context: Failed to set qname minimisation")
 
-        if ctx.resolvconf() != 0:
-            logger.debug("Unbound context: Failed to read resolv.conf")
+        # Current resolv.conf use systemd-resolved which cannot verify DNSSEC
+        # See https://github.com/systemd/systemd/issues/4621
+        # without local resolvconf unbound does full recursive query
+        # if ctx.resolvconf() != 0:
+        #     logger.debug("Unbound context: Failed to read resolv.conf")
 
         if ctx.add_ta_file("/var/lib/unbound/root.key") != 0:
             logger.debug("Unbound context: Failed to add trust anchor file")

--- a/dnf/dnssec.py
+++ b/dnf/dnssec.py
@@ -102,6 +102,9 @@ class KeyInfo:
         self.email = email
         self.key = key
 
+    def __repr__(self):
+        return 'KeyInfo("{}", "{}...")'.format(self.email, self.key.decode('ascii')[:6])
+
     @staticmethod
     def from_rpm_key_object(userid, raw_key):
         # type: (str, bytes) -> KeyInfo


### PR DESCRIPTION
Better representation of KeyInfo() to easy debugging.
Disable local resolve.conf for DNSSEC query (see commit).