### PR TITLE
Handle existing name but non-existing type in DNS

### DIFF
--- a/dnf/dnssec.py
+++ b/dnf/dnssec.py
@@ -193,13 +193,14 @@ class DNSSECKeyVerification:
         if not result.secure:
             logger.debug("Result is not secured with DNSSEC")
             return Validity.RESULT_NOT_SECURE
-        if result.nxdomain:
+        if result.nxdomain or (result.rcode == unbound.RCODE_NOERROR and not result.havedata):
             logger.debug("Non-existence of this record was proven by DNSSEC")
             return Validity.PROVEN_NONEXISTENCE
         if not result.havedata:
             # TODO: This is weird result, but there is no way to perform validation, so just return
             # an error
-            logger.debug("Unknown error in DNS communication")
+            # Should handle only SERVFAIL, REFUSED and similar rcodes
+            logger.debug("Unknown error in DNS communication: {}".format(result.rcode_str))
             return Validity.ERROR
         else:
             data = result.data.as_raw_data()[0]

--- a/dnf/dnssec.py
+++ b/dnf/dnssec.py
@@ -56,7 +56,7 @@ def email2location(email_address, tag="_openpgpkey"):
     :param tag:
     :return:
     """
-    split = email_address.split("@")
+    split = email_address.rsplit("@", 1)
     if len(split) != 2:
         msg = "Email address must contain exactly one '@' sign."
         raise DnssecError(msg)


### PR DESCRIPTION
When NOERROR is returned, but response is missing answer data, it means
the mentioned name exists, but not with requested type.
Handle it the same way as NXDOMAIN, which means no such name with any
record exists.
Print returned rcode if not NOERROR in debug mode.

Observed missing state check, when looking at https://github.com/rpm-software-management/dnf/pull/1726