### PR TITLE
[completion] fix overboard tilde expansion where tilde check warranted

### DIFF
--- a/etc/bash_completion.d/dnf
+++ b/etc/bash_completion.d/dnf
@@ -127,13 +127,10 @@ _dnf_commands_helper()
     echo "$( ${__dnf_python_exec} -c "$helper_cmd" "$@" $helper_opts 2>/dev/null </dev/null )"
 }
 
+# decide "path-like?" per initial: dot (./f.rpm, ../b.rpm), / (full path) or ~
 _dnf_is_path()
 {
-    if [[ "$1" == \.* ]] || [[ "$1" == \/* ]] || [[ "$1" == ~* ]]; then
-        return 0
-    else
-        return 1
-    fi
+    [[ "$1" = \.* ]] || [[ "$1" = \/* ]] || [[ "$1" = \~* ]]
 }
 
 _dnf_show_packages()


### PR DESCRIPTION
Apparently, it was never intended for "do we deal with FS-backed
argument?" check to do a possibly problematic[*] prefix check on
the whole home dir path, so get this right and also simplify the
function statement as it makes do without any conditionals.

[\*] This is three-fold:

   - first and foremost: whole NSS machinery would be, in accordance
      with _Tilde Expansion_, hard at work to figure out whether there
      is a '*' user (which is a long shot to say the least), possibly
      even accidentally crashing the process (as happened to me,
      leading to this very fix: https://bugzilla.redhat.com/1929936),

   - then, being entirely redundant (as long as `$HOME` always resolves
      to the absolute address) with the preceding slash-prefix-check,
      hence a futile work could be performed in a negative case,

   - and finally, not capturing the actual intention of user to
      complete `~/foo.rpm` (package starting with tilde would not
      be offered in the completion as originally intended, IMHO)