### PR TITLE
Replace python-nose with unittest

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -150,7 +150,6 @@ BuildRequires:  python3-libcomps >= %{libcomps_version}
 BuildRequires:  python3-libdnf
 BuildRequires:  libmodulemd >= %{libmodulemd_version}
 Requires:       libmodulemd >= %{libmodulemd_version}
-BuildRequires:  python3-nose
 BuildRequires:  python3-gpg
 Requires:       python3-gpg
 Requires:       %{name}-data = %{version}-%{release}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,7 @@
-ADD_TEST(test ${PYTHON_EXECUTABLE} -m nose -s ${CMAKE_CURRENT_SOURCE_DIR})
+ADD_TEST(
+    NAME test
+    COMMAND ${PYTHON_EXECUTABLE} -m unittest discover -s tests
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
 # For libdnf built with sanitizers, has no effect otherwise.
 # dnf tests do some wild stuff and cause a lot of leaks, hence turn leak

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -17,9 +17,11 @@
 # Red Hat, Inc.
 #
 
+import locale
 import os
 
 # run tests with C locales
 os.environ["LC_ALL"] = "C.UTF-8"
 os.environ["LANG"] = "C.UTF-8"
 os.environ["LANGUAGE"] = "en_US:en"
+locale.setlocale(locale.LC_ALL, "C.UTF-8")


### PR DESCRIPTION
This also needed setting locale for testing, because for some reason,
the default locale is different when running unittest instead of
python-nose.

= changelog =
resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1916783