### PR TITLE
repo: Improve *.repo config path ordering to fix a comps merging issue

### DIFF
--- a/dnf/conf/read.py
+++ b/dnf/conf/read.py
@@ -27,6 +27,7 @@ import dnf.exceptions
 import dnf.repo
 import glob
 import logging
+import os
 
 logger = logging.getLogger('dnf')
 
@@ -42,8 +43,16 @@ class RepoReader(object):
             yield r
 
         # read .repo files from directories specified by conf.reposdir
-        for repofn in (repofn for reposdir in self.conf.reposdir
-                       for repofn in sorted(glob.glob('{}/*.repo'.format(reposdir)))):
+        repo_configs = []
+        for reposdir in self.conf.reposdir:
+            for path in glob.glob(os.path.join(reposdir, "*.repo")):
+                repo_configs.append(path)
+
+        # remove .conf suffix before calling the sort function
+        # also split the path so the separators are not treated as ordinary characters
+        repo_configs.sort(key=lambda x: dnf.util.split_path(x[:-5]))
+
+        for repofn in repo_configs:
             try:
                 for r in self._get_repos(repofn):
                     yield r

--- a/dnf/util.py
+++ b/dnf/util.py
@@ -149,6 +149,27 @@ def ensure_dir(dname):
         if e.errno != errno.EEXIST or not os.path.isdir(dname):
             raise e
 
+
+def split_path(path):
+    """
+    Split path by path separators.
+    Use os.path.join() to join the path back to string.
+    """
+    result = []
+
+    head = path
+    while True:
+        head, tail = os.path.split(head)
+        if not tail:
+            if head or not result:
+                # if not result: make sure result is [""] so os.path.join(*result) can be called
+                result.insert(0, head)
+            break
+        result.insert(0, tail)
+
+    return result
+
+
 def empty(iterable):
     try:
         l = len(iterable)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import operator
+import os
 
 import dnf.util
 
@@ -209,6 +210,31 @@ class Util(tests.support.TestCase):
     def test_touch(self):
         self.assertRaises(OSError, dnf.util.touch,
                           tests.support.NONEXISTENT_FILE, no_create=True)
+
+    def test_split_path(self):
+        path_orig = ""
+        path_split = dnf.util.split_path(path_orig)
+        path_join = os.path.join(*path_split)
+        self.assertEqual(path_split, [""])
+        self.assertEqual(path_join, path_orig)
+
+        path_orig = "/"
+        path_split = dnf.util.split_path(path_orig)
+        path_join = os.path.join(*path_split)
+        self.assertEqual(path_split, ["/"])
+        self.assertEqual(path_join, path_orig)
+
+        path_orig = "abc"
+        path_split = dnf.util.split_path(path_orig)
+        path_join = os.path.join(*path_split)
+        self.assertEqual(path_split, ["abc"])
+        self.assertEqual(path_join, path_orig)
+
+        path_orig = "/a/bb/ccc/dddd.conf"
+        path_split = dnf.util.split_path(path_orig)
+        path_join = os.path.join(*path_split)
+        self.assertEqual(path_split, ["/", "a", "bb", "ccc", "dddd.conf"])
+        self.assertEqual(path_join, path_orig)
 
 
 class TestMultiCall(tests.support.TestCase):


### PR DESCRIPTION
Remove the '.repo' suffix to exclude it from the sort key.
Also split the paths into lists to exclude '/' from the sort key.

=changelog=
msg: Improve repo config path ordering to fix a comps merging issue
resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1928181