### PR TITLE
Preserve file mode during log rotation

### DIFF
--- a/dnf/logging.py
+++ b/dnf/logging.py
@@ -125,7 +125,10 @@ class MultiprocessRotatingFileHandler(logging.handlers.RotatingFileHandler):
             try:
                 if self.shouldRollover(record):
                     with self.rotate_lock:
+                        # Do rollover while preserving the mode of the new log file
+                        mode = os.stat(self.baseFilename).st_mode
                         self.doRollover()
+                        os.chmod(self.baseFilename, mode)
                 logging.FileHandler.emit(self, record)
                 return
             except (dnf.exceptions.ProcessLockError, dnf.exceptions.ThreadLockError):


### PR DESCRIPTION
Without this, the new log is created according to currently set umask
which is usually just a side effect of something else. For example,
rpm sets umask during a transaction run to 022 and new dnf.rpm.log is
then created with mode 644 regardless of the mode of previous log.

= changelog =
msg: Preserve file mode during log rotation
type: bugfix
resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1910084