### PR TITLE
Using 'dnf module list' for multiline 'summary' modular tag

### DIFF
--- a/dnf/module/module_base.py
+++ b/dnf/module/module_base.py
@@ -579,6 +579,9 @@ class ModuleBase(object):
                 else ", "
         return profiles_str[:-2]
 
+    def _summary_report_formatter(self, summary):
+        return summary.strip().replace("\n", " ")
+
     def _module_strs_formatter(self, modulePackage, markActive=False):
         default_str = ""
         enabled_str = ""
@@ -761,7 +764,8 @@ class ModuleBase(object):
                     column_stream).setData(
                     modulePackage.getStream() + default_str + enabled_str + disabled_str)
                 line.getColumnCell(column_profiles).setData(profiles_str)
-                line.getColumnCell(column_info).setData(modulePackage.getSummary())
+                summary_str = self._summary_report_formatter(modulePackage.getSummary())
+                line.getColumnCell(column_info).setData(summary_str)
 
         return table
 


### PR DESCRIPTION
Hello,

Here is brief explanation of proposed additions.

While it is expected to be like this (**libmodulemd v2 spec**):
<pre>
 # summary: 
 # A short summary describing the module
</pre>
 some maintainers don't think so, and have started producing multiline **summary:** description in the modulemd, for example like here:
 https://git.centos.org/modules/container-tools/blob/c8-stream-1.0/f/container-tools.yaml
 https://access.redhat.com/errata/RHSA-2021:0705
 
While everything seems to be OK, it is not because for such modules we might get something like:
<pre>
 dnf module list
 Name                 Stream        Profiles        Summary
 container-tools      1.0 [e]       common [d] [i]  Stable versions of podman 1.0, buildah 1.5, skopeo
                                                               0.1, runc, conmon, CRIU,\x0aUdica, etc as well as
                                                               dependencies such as container-selinux built and\x0a
                                                                tested together, and supported for 24 months.
</pre>
 
 As I understand, the `libdnf.smartcols.Table()` used in `dnf module list`, in particular it's column do not output multiline text well (with those `'\n'`or `'\x0a'` if you like) and shouldn't, what for?

Such output is unreadable. And I am 100% sure, more if such cases will be in the future, so the more unreadable the `dnf module list` will be.
So, the proposal is to format summary before print, so that it is represent the one big line without newline characters.