### PR TITLE
Initial error_level and installonly_limit documentation change

### DIFF
--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -148,7 +148,7 @@ class BaseConfig(object):
                     try:
                         self._config.optBinds().at(name).newString(priority, value)
                     except RuntimeError as e:
-                        logger.debug(_('Unknown configuration value: %s=%s in %s; %s'),
+                        logger.error(_('Invalid configuration value: %s=%s in %s; %s'),
                                      ucd(name), ucd(value), ucd(filename), str(e))
                 else:
                     if name == 'arch' and hasattr(self, name):

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -250,8 +250,9 @@ configuration file by your distribution to override the DNF defaults.
     :ref:`integer <integer-label>`
 
     Number of :ref:`installonly packages <installonlypkgs-label>` allowed to be installed
-    concurrently. Defaults to 3. The minimal number of installonly packages is 2. Value 0 or 1 means
-    unlimited number of installonly packages.
+    concurrently. Defaults to 3. The minimal number of installonly packages is 2. Value 0 means
+    unlimited number of installonly packages. Value 1 is explicitely not allowed since it
+    complicates kernel upgrades due to protection of the running kernel from removal.
 
 ``installroot``
     :ref:`string <string-label>`


### PR DESCRIPTION
With this patch user is informed about unknown / invalid options in the main configuration file.

Requires: https://github.com/rpm-software-management/libdnf/pull/1155