### PR TITLE
Add more aliases (RhBug:1938333)

### DIFF
--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -231,7 +231,7 @@ class ProvidesCommand(Command):
     provides command.
     """
 
-    aliases = ('provides', 'whatprovides', 'prov')
+    aliases = ('provides', 'whatprovides', 'prov', 'wp')
     summary = _('find what package provides the given value')
 
     @staticmethod

--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -154,7 +154,7 @@ class InfoCommand(Command):
     info command.
     """
 
-    aliases = ('info',)
+    aliases = ('info', 'if')
     summary = _('display details about a package or group of packages')
     DEFAULT_PKGNARROW = 'all'
     pkgnarrows = {'available', 'installed', 'extras', 'updates', 'upgrades',

--- a/dnf/cli/commands/updateinfo.py
+++ b/dnf/cli/commands/updateinfo.py
@@ -59,7 +59,7 @@ class UpdateInfoCommand(commands.Command):
                        'info-security'      : 'info',
                        'info-sec'           : 'info',
                        'summary-updateinfo' : 'summary'}
-    aliases = ['updateinfo'] + list(direct_commands.keys())
+    aliases = ['updateinfo', 'upif'] + list(direct_commands.keys())
     summary = _('display advisories about packages')
     availability_default = 'available'
     availabilities = ['installed', 'updates', 'all', availability_default]

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -791,6 +791,7 @@ Info Command
 ------------
 
 | Command: ``info``
+| Aliases: ``if``
 
 ``dnf [options] info [<package-file-spec>...]``
     Lists description and summary information about installed and available packages.

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -1096,7 +1096,7 @@ Provides Command
 ----------------
 
 | Command: ``provides``
-| Aliases: ``prov``, ``whatprovides``
+| Aliases: ``prov``, ``whatprovides``, ``wp``
 
 ``dnf [options] provides <provide-spec>``
     Finds the packages providing the given ``<provide-spec>``. This is useful

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -1652,6 +1652,7 @@ Updateinfo Command
 ------------------
 
 | Command: ``updateinfo``
+| Aliases: ``upif``
 | Deprecated aliases: ``list-updateinfo``, ``list-security``, ``list-sec``, ``info-updateinfo``, ``info-security``, ``info-sec``, ``summary-updateinfo``
 
 ``dnf [options] updateinfo [--summary|--list|--info] [<availability>] [<spec>...]``


### PR DESCRIPTION
This PR adds a few more aliases to make it quicker to use, as well as adding an alias for Zypper compatibility.

I waffled on whether to add `wp` to the zypper alias file or to put it in the code, since `whatprovides` is a supported alias and it would make sense to me to put it in the code. In the end, I elected to put it in the config file and we can move it if everyone is okay with the idea of it being in the code instead.