### PR TITLE
Remove no needed 0 available message

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -2367,18 +2367,19 @@ class Base(object):
             if warning:
                 q = q.upgrades()
                 count = len(q._name_dict().keys())
-                if pkg_spec is None:
-                    msg1 = _("No security updates needed, but {} update "
-                             "available").format(count)
-                    msg2 = _("No security updates needed, but {} updates "
-                             "available").format(count)
-                    logger.warning(P_(msg1, msg2, count))
-                else:
-                    msg1 = _('No security updates needed for "{}", but {} '
-                             'update available').format(pkg_spec, count)
-                    msg2 = _('No security updates needed for "{}", but {} '
-                             'updates available').format(pkg_spec, count)
-                    logger.warning(P_(msg1, msg2, count))
+                if count > 0:
+                    if pkg_spec is None:
+                        msg1 = _("No security updates needed, but {} update "
+                                "available").format(count)
+                        msg2 = _("No security updates needed, but {} updates "
+                                "available").format(count)
+                        logger.warning(P_(msg1, msg2, count))
+                    else:
+                        msg1 = _('No security updates needed for "{}", but {} '
+                                'update available').format(pkg_spec, count)
+                        msg2 = _('No security updates needed for "{}", but {} '
+                                'updates available').format(pkg_spec, count)
+                        logger.warning(P_(msg1, msg2, count))
         return merged_queries
 
     def _get_key_for_package(self, po, askcb=None, fullaskcb=None):

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -2370,15 +2370,15 @@ class Base(object):
                 if count > 0:
                     if pkg_spec is None:
                         msg1 = _("No security updates needed, but {} update "
-                                "available").format(count)
+                                 "available").format(count)
                         msg2 = _("No security updates needed, but {} updates "
-                                "available").format(count)
+                                 "available").format(count)
                         logger.warning(P_(msg1, msg2, count))
                     else:
                         msg1 = _('No security updates needed for "{}", but {} '
-                                'update available').format(pkg_spec, count)
+                                 'update available').format(pkg_spec, count)
                         msg2 = _('No security updates needed for "{}", but {} '
-                                'updates available').format(pkg_spec, count)
+                                 'updates available').format(pkg_spec, count)
                         logger.warning(P_(msg1, msg2, count))
         return merged_queries
 


### PR DESCRIPTION
This fix removes a message:
"No security updates needed, but 0 updates available"
as it has no value.
