### PR TITLE
[doc] Add info that maximum parallel downloads is 20

### DIFF
--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -799,7 +799,7 @@ configuration.
 ``max_parallel_downloads``
     :ref:`integer <integer-label>`
 
-    Maximum number of simultaneous package downloads. Defaults to 3.
+    Maximum number of simultaneous package downloads. Defaults to 3. Maximum of 20.
 
 .. _metadata_expire-label:
 


### PR DESCRIPTION
This limit was set by https://github.com/rpm-software-management/librepo/commit/f33e17cb67c147a9390776d23c1f96cc2ffa7328 and it feels appropriate to mention in the docs here