### PR TITLE
Change dnf-automatic motd emitter location to /etc/motd.d/dnf

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -76,7 +76,7 @@ DNF CONTRIBUTORS
     Kevin Kofler <kevin.kofler@chello.at>
     Kushal Das <kushaldas@gmail.com>
     Lubomír Sedlář <lsedlar@redhat.com>
-    Matt Sturgeon <matt@sturgeon.me.uk
+    Matt Sturgeon <matt@sturgeon.me.uk>
     Matthew Miller <mattdm@mattdm.org>
     Max Prokhorov <prokhorov.max@outlook.com>
     Michael Dunphy <mdunphy@uwaterloo.ca>
@@ -95,3 +95,4 @@ DNF CONTRIBUTORS
     Vladan Kudlac <vladankudlac@gmail.com>
     Will Woods <wwoods@redhat.com>
     Furkan Karcıoğlu <krc440002@gmail.com>
+    Jason Bowman <jason.c.bowman@live.com>

--- a/dnf/automatic/emitter.py
+++ b/dnf/automatic/emitter.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 from dnf.i18n import _
+from os import makedirs
 import logging
 import dnf.pycomp
 import smtplib
@@ -168,7 +169,8 @@ class StdIoEmitter(Emitter):
 
 class MotdEmitter(Emitter):
     def commit(self):
+        makedirs('/etc/motd.d/', exist_ok=True)
         msg = self._prepare_msg()
-        with open('/etc/motd', 'w') as fobj:
+        with open('/etc/motd.d/dnf', 'w') as fobj:
             fobj.write(msg)
 

--- a/doc/automatic.rst
+++ b/doc/automatic.rst
@@ -101,7 +101,7 @@ Choosing how the results should be reported.
 ``emit_via``
     list, default: ``email, stdio, motd``
 
-    List of emitters to report the results through. Available emitters are ``stdio`` to print the result to standard output, ``command`` to send the result to a custom command, ``command_email`` to send an email using a command, and ``email`` to send the report via email and ``motd`` sends the result to */etc/motd* file.
+    List of emitters to report the results through. Available emitters are ``stdio`` to print the result to standard output, ``command`` to send the result to a custom command, ``command_email`` to send an email using a command, and ``email`` to send the report via email and ``motd`` sends the result to */etc/motd.d/dnf* file.
 
 ``system_name``
     string, default: hostname of the given system

--- a/etc/dnf/automatic.conf
+++ b/etc/dnf/automatic.conf
@@ -31,7 +31,7 @@ apply_updates = no
 # emit_via includes stdio, messages will be sent to stdout; this is useful
 # to have cron send the messages.  If emit_via includes email, this
 # program will send email itself according to the configured options.
-# If emit_via includes motd, /etc/motd file will have the messages. if
+# If emit_via includes motd, /etc/motd.d/dnf file will have the messages. If
 # emit_via includes command_email, then messages will be send via a shell
 # command compatible with sendmail.
 # Default is email,stdio.

--- a/etc/dnf/plugins/post-transaction-actions.d/clear-dnf-auto-motd.action
+++ b/etc/dnf/plugins/post-transaction-actions.d/clear-dnf-auto-motd.action
@@ -1,0 +1,4 @@
+# If the python3-dnf-plugin-post-transaction-actions package is installed,
+# this action will clear the dnf-automatic motd after ideally an upgrade,
+# but also an install or downgrade, of one or more packages.
+*:in:echo '' > /etc/motd.d/dnf


### PR DESCRIPTION
The motd emitter for dnf-automatic should not overwrite the /etc/motd file as some organizations require a specified message (e.g. warning the user that they are being monitored) in that file to be displayed upon login. The better location is into a text file inside of /etc/motd.d/.