### PR TITLE
Remove key regex matching, rpm sprintf output varies too much

### DIFF
--- a/dnf/rpm/miscutils.py
+++ b/dnf/rpm/miscutils.py
@@ -30,12 +30,12 @@ logger = logging.getLogger('dnf')
 
 def _verifyPkgUsingRpmkeys(package, installroot):
     rpmkeys_binary = '/usr/bin/rpmkeys'
-    if not rpmkeys_binary:
+    if not os.path.isfile(rpmkeys_binary):
         rpmkeys_binary = which("rpmkeys")
         logger.info(_('Using rpmkeys executable from {path} to verify signature for package: {package}.').format(
             path=rpmkeys_binary, package=package))
 
-    if not rpmkeys_binary:
+    if not os.path.isfile(rpmkeys_binary):
         logger.critical(_('Cannot find rpmkeys executable to verify signatures.'))
         return 0
 

--- a/dnf/rpm/miscutils.py
+++ b/dnf/rpm/miscutils.py
@@ -18,7 +18,6 @@ from __future__ import unicode_literals
 
 import rpm
 import os
-import re
 import subprocess
 import logging
 
@@ -82,11 +81,10 @@ def checkSig(ts, package):
         try:
             siginfo = hdr.sprintf(string)
             siginfo = ucd(siginfo)
-            rpm_pgpsig_format_regex = re.compile(r'[0-9]{2}:[0-9]{2}:[0-9]{2} [0-9]{4}, Key ID [0-9a-f]{16}\Z')
 
             if siginfo == '(none)':
                 value = 4
-            elif rpm_pgpsig_format_regex.search(siginfo) and _verifyPkgUsingRpmkeys(package, ts.ts.rootDir):
+            elif "Key ID" in siginfo and _verifyPkgUsingRpmkeys(package, ts.ts.rootDir):
                 value = 0
             else:
                 raise ValueError('Unexpected return value %r from hdr.sprintf when checking signature.' % siginfo)


### PR DESCRIPTION
Depending on locale it can return:
`RSA/SHA256, Fri 19 Feb 2021 12:14:18 AM CET, Key ID db4639719867c58f`
vs
`RSA/SHA256, Fri Feb 19 00:14:18 2021, Key ID db4639719867c58f`
(with LC_ALL=C.UTF-8)

We only check presence of the signature header to distinguish between
signed and unsigned RPMs. The actual signature validation is done by
calling rpmkeys in _verifyPkgUsingRpmkeys().

CVE-2021-3445
RhBug:1915990

Related: CVE-2021-3421, CVE-2021-20271