### PR TITLE
Do not assume that a remote rpm is complete if present

### DIFF
--- a/dnf/util.py
+++ b/dnf/util.py
@@ -88,8 +88,6 @@ def _urlopen_progress(url, conf, progress=None):
     if progress is None:
         progress = dnf.callback.NullDownloadProgress()
     pload = dnf.repo.RemoteRPMPayload(url, conf, progress)
-    if os.path.exists(pload.local_path):
-        return pload.local_path
     est_remote_size = sum([pload.download_size])
     progress.start(1, est_remote_size)
     targets = [pload._librepo_target()]


### PR DESCRIPTION
We should not assume that a file present in the hashed directory for a remote url is complete if present.

This manifests in two ways:

1. `Can not load RPM file: ` if the headers are incomplete
2. `Payload SHA256 digest: BAD` error otherwise

This isn't a common error in the field because most sites use `keepcache=0` in `dnf.conf`. On the latter error the broken RPM is deleted, and the next run will retry the download from scratch, and probably succeeding.

This impacts us because we use `keepcache=1` so once we get an interrupted download, we can't (automatically) recover.

The fix here forces us to try to download/resume the file even if present on disk, because we don't have any higher level metadata like digests to falsify downloads without network.

This change makes an explicit decision to try to be more correct instead of using an incomplete optimization.