### PR TITLE
dnf/comps.py: fix __eq__ in class CompsTransPkg

### DIFF
--- a/dnf/comps.py
+++ b/dnf/comps.py
@@ -471,9 +471,9 @@ class CompsTransPkg(object):
 
     def __eq__(self, other):
         return (self.name == other.name and
-                self.basearchonly == self.basearchonly and
-                self.optional == self.optional and
-                self.requires == self.requires)
+                self.basearchonly == other.basearchonly and
+                self.optional == other.optional and
+                self.requires == other.requires)
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
This method compares the fields of the objects `self` and `other`, but the comparison was performed only by the name `self.name == other.name`. The rest of the parameters were compared with themselves.
For example, `self.basearchonly == self.basearchonly`.