### PR TITLE
Fix deltarpm messages

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1210,11 +1210,11 @@ class Base(object):
         if real != full:
             if real < full:
                 msg = _("Delta RPMs reduced %.1f MB of updates to %.1f MB "
-                        "(%d.1%% saved)")
+                        "(%.1f%% saved)")
                 percent = 100 - real / full * 100
             elif real > full:
                 msg = _("Failed Delta RPMs increased %.1f MB of updates to %.1f MB "
-                        "(%d.1%% wasted)")
+                        "(%.1f%% wasted)")
                 percent = 100 - full / real * 100
             logger.info(msg, full / 1024 ** 2, real / 1024 ** 2, percent)
 

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1211,10 +1211,11 @@ class Base(object):
             if real < full:
                 msg = _("Delta RPMs reduced %.1f MB of updates to %.1f MB "
                         "(%d.1%% saved)")
+                percent = 100 - real / full * 100
             elif real > full:
                 msg = _("Failed Delta RPMs increased %.1f MB of updates to %.1f MB "
                         "(%d.1%% wasted)")
-            percent = 100 - real / full * 100
+                percent = 100 - full / real * 100
             logger.info(msg, full / 1024 ** 2, real / 1024 ** 2, percent)
 
     def download_packages(self, pkglist, progress=None, callback_total=None):


### PR DESCRIPTION
This fixes two minor things:
- DNF was printing negative percentages when delta RPMs failed
- Percentages were printed with a bad format specifier (which was always adding ".1" to any number)

This pull request splits the percentage calculation into the if-cases and changes the format specifier.
I don't know, how translations are handled, but the original string must be changed for all supported languages (I guess?). I committed everything separately, because of that.