### PR TITLE
Set top-level directory for unittest

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 ADD_TEST(
     NAME test
-    COMMAND ${PYTHON_EXECUTABLE} -m unittest discover -s tests
+    COMMAND ${PYTHON_EXECUTABLE} -m unittest discover -s tests -t ${PROJECT_SOURCE_DIR}
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
 # For libdnf built with sanitizers, has no effect otherwise.


### PR DESCRIPTION
In some build environments, the top-level directory is not added to
the sys.path and the tests fail. This fixes the issue.