### PR TITLE
Add option --refreshrepo

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -33,7 +33,6 @@ import datetime
 import logging
 import operator
 import os
-import pprint
 import random
 import rpm
 import sys

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -33,6 +33,7 @@ import datetime
 import logging
 import operator
 import os
+import pprint
 import random
 import rpm
 import sys
@@ -616,6 +617,7 @@ class Cli(object):
         self.cli_commands = {}
         self.command = None
         self.demands = dnf.cli.demand.DemandSheet()  # :api
+        self.freshest_metadata_repo = []
 
         self.register_command(dnf.cli.commands.alias.AliasCommand)
         self.register_command(dnf.cli.commands.autoremove.AutoremoveCommand)
@@ -734,6 +736,11 @@ class Cli(object):
             elif not demands.fresh_metadata:
                 for repo in repos.values():
                     repo._repo.setSyncStrategy(dnf.repo.SYNC_LAZY)
+            if self.freshest_metadata_repo:
+                for repo in repos.values():
+                    for refresh_repo in self.freshest_metadata_repo:
+                        if refresh_repo.lower() in repo.name.lower():
+                            repo._repo.expire()
 
         if demands.sack_activation:
             self.base.fill_sack(
@@ -862,6 +869,8 @@ class Cli(object):
             self.base._allow_erasing = True
         if opts.freshest_metadata:
             self.demands.freshest_metadata = opts.freshest_metadata
+        if opts.freshest_metadata_repo:
+            self.freshest_metadata_repo = opts.freshest_metadata_repo
         if opts.debugsolver:
             self.base.conf.debug_solver = True
         if opts.obsoletes:

--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -304,6 +304,11 @@ class OptionParser(argparse.ArgumentParser):
                                  action="store_true",
                                  help=_("set metadata as expired before running"
                                         " the command"))
+        general_grp.add_argument("--refreshrepo", dest="freshest_metadata_repo",
+                                 action=self._SplitCallback,
+                                 metavar='[repo]',
+                                 help=_("set metadata as expired for given repos before running"
+                                        " the command"))
         general_grp.add_argument("-4", dest="ip_resolve", default=None,
                                  help=_("resolve to IPv4 addresses only"),
                                  action="store_const", const='ipv4')

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -322,6 +322,9 @@ Options
 ``--refresh``
     Set metadata as expired before running the command.
 
+``--refreshrepo``
+    Set metadata as expired for specified repositories before running the command.
+
 ``--releasever=<release>``
     Configure DNF as if the distribution release was ``<release>``. This can
     affect cache paths, values in configuration files and mirrorlist URLs.


### PR DESCRIPTION
With this, one can tell dnf to refresh specific repos, like so:
```
dnf upgrade --refreshrepo='fedora,remi'
```

Please let me know what can be improved!

By the way, I'm making use of the _SplitCallback, which splits on `,` or whitespace. I'd like to just split on the `,` character. Is there an existing callback I can reuse for that?