### PR TITLE
Determine the default plugin path at configure time, rather than runtime

### DIFF
--- a/dnf/const.py.in
+++ b/dnf/const.py.in
@@ -19,7 +19,6 @@
 #
 
 from __future__ import unicode_literals
-import sysconfig
 
 CONF_FILENAME='/etc/dnf/dnf.conf' # :api
 CONF_AUTOMATIC_FILENAME='/etc/dnf/automatic.conf'
@@ -50,7 +49,7 @@ VERBOSE_LEVEL=6
 PREFIX=NAME.lower()
 PROGRAM_NAME=NAME.lower()  # Deprecated - no longer used, Argparser prints program name based on sys.argv
 PLUGINCONFPATH = '/etc/dnf/plugins'  # :api
-PLUGINPATH = '%s/dnf-plugins' % sysconfig.get_path('purelib')
+PLUGINPATH = '@PYTHON_INSTALL_DIR@/dnf-plugins'
 VERSION='@DNF_VERSION@'
 USER_AGENT = "dnf/%s" % VERSION
 


### PR DESCRIPTION
DNF currently gets the default plugin path using [`sysconfig.get_path()`](https://docs.python.org/3/library/sysconfig.html#installation-paths).
This function can be used to determine where files *should* be installed, but it doesn't necessarily tell you where they *have* been installed.
For DNF specifically, installing system packages (RPMs) might use different locations than packages installed by tools like pip, setuptools and distutils.
DNF works now (we've ben careful not to break it), but there will likely be larger changes in this area (see [a discuss.python.org thread](https://discuss.python.org/t/mechanism-for-distributors-to-add-site-install-schemes-to-python-installations/8467/14)). It would be nice to get ready for that ahead of time.

Here is one way to set the default plugin path to the location DNF will install the plugin to, using CMake interpolation.

Another way would be to see where `dnf` is imported from, and look for `dnf-plugins` next to that directory.
Yet another would be to treat `dnf-plugins` as a "normal" package and import it using.e.g. `importlib.import_module('dnf-plugins')` – but there might be security concerns since the Python package path can be easily changed.