### PR TITLE
Document handling of multiple baseurl URLs

### DIFF
--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -654,6 +654,8 @@ configuration file by your distribution to override the DNF defaults.
     :ref:`list <list-label>`
 
     List of URLs for the repository. Defaults to ``[]``.
+    
+    URLs are tried in the listed order (equivalent to yum's "failovermethod=priority" behaviour).
 
 .. _repo_cost-label:
 


### PR DESCRIPTION
As noted in the comments on https://bugzilla.redhat.com/show_bug.cgi?id=1653831,
it isn't currently clear if DNF implements yum's failovermethod=priority or
failovermethod=roundrobin, it's only clear that it isn't configurable any more.