### PR TITLE
Add report about demodularized rpms into module info (RhBug:1805260)

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -2,7 +2,7 @@
 %define __cmake_in_source_build 1
 
 # default dependencies
-%global hawkey_version 0.61.1
+%global hawkey_version 0.64.0
 %global libcomps_version 0.1.8
 %global libmodulemd_version 2.9.3
 %global rpm_version 4.14.0

--- a/dnf/module/module_base.py
+++ b/dnf/module/module_base.py
@@ -641,6 +641,9 @@ class ModuleBase(object):
                         for mod_require, stream in require_dict.items():
                             req_set.add("{}:[{}]".format(mod_require, ",".join(stream)))
                 lines["Requires"] = "\n".join(sorted(req_set))
+                demodularized = modulePackage.getDemodularizedRpms()
+                if demodularized:
+                    lines["Demodularized rpms"] = "\n".join(demodularized)
                 lines["Artifacts"] = "\n".join(sorted(modulePackage.getArtifacts()))
                 output.add(self._create_simple_table(lines).toString())
         str_table = "\n\n".join(sorted(output))

--- a/doc/modularity.rst
+++ b/doc/modularity.rst
@@ -66,6 +66,13 @@ name or provide matches against a modular package name from any enabled, default
 or dependent stream. Modular source packages will not cause non-modular binary
 packages to be filtered out.
 
+
+Demodularized rpms
+==================
+Contains names of RPMs excluded from package filtering for particular module stream. When defined in the latest active
+module, non-modular RPMs with the same name or provide which were previously filtered out will reappear.
+
+
 =====================
  Hotfix repositories
 =====================


### PR DESCRIPTION
It is required to provide a possibility for debugging of the modular
filtering. Demodularized rpms will be not shoved when empty. It will
make a shorter output and allows to focus on important information.

https://bugzilla.redhat.com/show_bug.cgi?id=1805260

Requires: https://github.com/rpm-software-management/libdnf/pull/1327