### PR TITLE
Ensure locking is honored in clean command

### DIFF
--- a/dnf/cli/commands/clean.py
+++ b/dnf/cli/commands/clean.py
@@ -99,7 +99,7 @@ class CleanCommand(commands.Command):
         rpmdb_lock = dnf.lock.build_rpmdb_lock(self.base.conf.persistdir, True)
         while True:
             try:
-                with md_lock and download_lock and rpmdb_lock:
+                with md_lock, download_lock, rpmdb_lock:
                     types = set(t for c in self.opts.type for t in _CACHE_TYPES[c])
                     files = list(_tree(cachedir))
                     logger.debug(_('Cleaning data: ' + ' '.join(types)))


### PR DESCRIPTION
The `with` statement in `dnf/cli/commands/clean.py`does not currently engage all three context managers (`md_lock` `download_lock` `rpmdb_lock`).  This leads to a scenario where one process, running `dnf makecache` can have its metadata files _removed_ by a concurrent process calling `dnf clean all`.

I discovered this on CentOS 8, but confirmed the same behavior on F34:

```
[terminal session 1]
# dnf makecache 

[terminal session 2 -- while the above is running]
# dnf clean all
35 files removed

[back on terminal session 1]
# dnf makecache
Fedora 34 - x86_64                                                                                     19 MB/s |  74 MB     00:03    
Error: Failed to download metadata for repo 'fedora': Cannot open /var/cache/dnf/fedora-e21c25ac3662d294/repodata/repomd.xml: No such file or directory
```

This PR makes a small change, replacing "and" with commas, to ensure all three locks are checked/acquired.
