### PR TITLE
Fix: Python dnf API does not respect cacheonly (RhBug:1862970)

### DIFF
--- a/dnf/repo.py
+++ b/dnf/repo.py
@@ -434,7 +434,7 @@ class Repo(dnf.conf.RepoConf):
         self._pkgdir = None
         self._key_import = _NullKeyImport()
         self.metadata = None  # :api
-        self._repo.setSyncStrategy(self.DEFAULT_SYNC)
+        self._repo.setSyncStrategy(SYNC_ONLY_CACHE if parent_conf and parent_conf.cacheonly else self.DEFAULT_SYNC)
         if parent_conf:
             self._repo.setSubstitutions(parent_conf.substitutions)
         self._substitutions = dnf.conf.substitutions.Substitutions()

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -137,6 +137,9 @@ configuration file by your distribution to override the DNF defaults.
     If set to ``True`` DNF will run entirely from system cache, will not update
     the cache and will use it even in case it is expired. Default is ``False``.
 
+    API Notes: Must be set before repository objects are created. Plugins must set
+    this in the pre_config hook. Later changes are ignored.
+
 .. _check_config_file_age-label:
 
 ``check_config_file_age``


### PR DESCRIPTION
`Repo` object has always been constructed with default synchronization
strategy. The configuration option `cacheonly` was ignored. DNF
application set synchronization strategy later in the `Cli` object
during processing demands.

The fix takes into account the `cacheonly` option during the construction
of the `Repo` object. Synchronization strategy may still be overriden
during demand processing.

https://bugzilla.redhat.com/show_bug.cgi?id=1862970