### PR TITLE
Demote "No match for group package" to debug rather than warning.

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1655,7 +1655,7 @@ class Base(object):
                     package_string = comps_pkg.name
                     if comps_pkg.basearchonly:
                         package_string += '.' + basearch
-                    logger.warning(_('No match for group package "{}"').format(package_string))
+                    logger.debug(_('No match for group package "{}"').format(package_string))
                     continue
                 remove_query = fn(q, remove_query, comps_pkg)
                 self._goal.group_members.add(comps_pkg.name)


### PR DESCRIPTION
Rationale: this isn't useful for most end-users, and it indicates a problem
with a repo, not with the system. A quick search of trouble-shooting forums
will show many cases of users confused by this, focusing this message instead of
an actual transaction error.