### PR TITLE
[doc] Add a note about multiple excludepkgs

### DIFF
--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -871,7 +871,7 @@ configuration.
     Exclude packages of this repository, specified by a name or a glob and
     separated by a comma, from all operations.
     Do not add multiple excludepkgs lines in the configuration file,
-    because yum only consider the last excludepkgs entry.
+    because only consider the last excludepkgs entry.
     Can be disabled using ``--disableexcludes`` command line switch.
     Defaults to ``[]``.
 

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -870,6 +870,8 @@ configuration.
 
     Exclude packages of this repository, specified by a name or a glob and
     separated by a comma, from all operations.
+    Do not add multiple excludepkgs lines in the configuration file,
+    because yum only consider the last excludepkgs entry.
     Can be disabled using ``--disableexcludes`` command line switch.
     Defaults to ``[]``.
 


### PR DESCRIPTION
It is common mistake to add multiple excludepkgs if one want
to exclude multiple RPMs.
This patch adds a note that the dnf only use the last one.