### PR TITLE
Fix python3.11 build: remove deprecated, update traceback regex

### DIFF
--- a/scripts/update_releasenotes.py
+++ b/scripts/update_releasenotes.py
@@ -724,7 +724,7 @@ class TestCase(unittest.TestCase):
         """
         with tests.mock.patch(stream, io.BytesIO()) as mock:
             yield
-            self.assertRegexpMatches(mock.getvalue(), regex)
+            self.assertRegex(mock.getvalue(), regex)
 
     def _assert_iter_equal(self, actual, expected):
         """Test whether two iterables are equal.

--- a/tests/support.py
+++ b/tests/support.py
@@ -77,7 +77,8 @@ skip = unittest.skip
 TRACEBACK_RE = re.compile(
     r'(Traceback \(most recent call last\):\n'
     r'(?:  File "[^"\n]+", line \d+, in \w+\n'
-    r'(?:    .+\n)?)+'
+    r'(?:    .+\n)?'
+    r'(?:    \s*\~*\^+\~*\n)?)+'
     r'\S.*\n)')
 REASONS = {
     'hole': 'group',
@@ -585,7 +586,6 @@ class TestCase(unittest.TestCase):
 
     if not dnf.pycomp.PY3:
         assertCountEqual = unittest.TestCase.assertItemsEqual
-        assertRegex = unittest.TestCase.assertRegexpMatches
 
     def assertEmpty(self, collection):
         return self.assertEqual(len(collection), 0)


### PR DESCRIPTION
https://docs.python.org/3.11/whatsnew/3.11.html#enhanced-error-locations-in-tracebacks
Tracebacks were updated with `^^^^^..` locators surrounded by optional
`~~~..` so add an optional line that matches them into the traceback regex.

Removes unused variable and deprecated `assertRegexpMatches`.