### PR TITLE
Documentation: clarify effect of --enablerepo and --disablerepo options

### DIFF
--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -258,13 +258,18 @@ class OptionParser(argparse.ArgumentParser):
                                                       " for all questions"))
         general_grp.add_argument("--enablerepo", action=self._RepoCallback,
                                  dest='repos_ed', default=[], metavar='[repo]',
-                                 help=_("Enable additional repositories. List option. "
-                                        "Supports globs, can be specified multiple times."))
+                                 help=_("Temporarily enable repositories for the purpose"
+                                        "of the current dnf command. Accepts an id, a"
+                                        "comma-separated list of ids, or a glob of ids."
+                                        "This option can be specified multiple times."))
         repo_group = general_grp.add_mutually_exclusive_group()
         repo_group.add_argument("--disablerepo", action=self._RepoCallback,
                                 dest='repos_ed', default=[], metavar='[repo]',
-                                help=_("Disable repositories. List option. "
-                                       "Supports globs, can be specified multiple times."))
+                                help=_("Temporarily disable active repositories for the"
+                                       "purpose of the current dnf command. Accepts an id,"
+                                       "a comma-separated list of ids, or a glob of ids."
+                                       "This option can be specified multiple times, but"
+                                       "is mutually exclusive with `--repo`."))
         repo_group.add_argument('--repo', '--repoid', metavar='[repo]', dest='repo',
                                 action=self._SplitCallback, default=[],
                                 help=_('enable just specific repositories by an id or a glob, '

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -182,7 +182,9 @@ Options
     Disable the listed plugins specified by names or globs.
 
 ``--disablerepo=<repoid>``
-    Disable specific repositories by an id or a glob. This option is mutually exclusive with ``--repo``.
+    Temporarily disable active repositories for the purpose of the current dnf command.
+    Accepts an id, a comma-separated list of ids, or a glob of ids. This option can be
+    specified multiple times, but is mutually exclusive with ``--repo``.
 
 ``--downloaddir=<path>, --destdir=<path>``
     Redirect downloaded packages to provided directory. The option has to be used together with the \-\
@@ -207,7 +209,9 @@ Options
     Enable the listed plugins specified by names or globs.
 
 ``--enablerepo=<repoid>``
-    Enable additional repositories by an id or a glob.
+    Temporarily enable additional repositories for the purpose of the current dnf command.
+    Accepts an id, a comma-separated list of ids, or a glob of ids. This option can be
+    specified multiple times.
 
 ``--enhancement``
     Include enhancement relevant packages. Applicable for the install, repoquery, updateinfo and


### PR DESCRIPTION
These options are currently rather confusing because they do not make it
clear that they operate only temporarily on the currently-used dnf
command. This commit clarifies them by mentioning that.

Resolves https://bugzilla.redhat.com/show_bug.cgi?id=2031414