### PR TITLE
Clarify inline 'dnf provides' documentation a bit

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -601,7 +601,9 @@ class BaseCli(dnf.Base):
         self.conf.showdupesfromrepos = old_sdup
 
         if not matches:
-            raise dnf.exceptions.Error(_('No Matches found'))
+            raise dnf.exceptions.Error(_('No matches found. If searching for a file, '
+                                         'try specifying the full path or using a '
+                                         'wildcard prefix ("*/") at the beginning.'))
 
     def _promptWanted(self):
         # shortcut for the always-off/always-on options


### PR DESCRIPTION
This command is currently a bit confusing to use because it requires
either a full file path, or else a glob. Simply searching for a
filename alone does not work unless you add a glob, but this requirement
is implicit and never explicitly mentioned in the command's help text.

This commit makes that explicit by mentioning it in the command usage,
and also by adding a hint when no matches are returned.

Resolves https://bugzilla.redhat.com/show_bug.cgi?id=1963704