### PR TITLE
Switch install/remove parts of swap command (RhBug:2036434)

### DIFF
--- a/dnf/cli/commands/swap.py
+++ b/dnf/cli/commands/swap.py
@@ -58,5 +58,8 @@ class SwapCommand(commands.Command):
             cmd.run()
 
     def run(self):
-        self._perform('remove', self.opts.remove_spec)
+        # The install part must be performed before the remove one because it can
+        # operate on local rpm files. Command line packages cannot be added
+        # to the sack once the goal is created.
         self._perform('install', self.opts.install_spec)
+        self._perform('remove', self.opts.remove_spec)


### PR DESCRIPTION
In case the install spec refers to a local rpm file the swap command
would fail with this error:

Error: Cannot add local packages, because transaction job already exists

Changing the order in which the installation and removal parts are
performed fixes the issue.

= changelog =
msg:           Fix swap command to work with local rpm files correctly
type:          bugfix
resolves:      https://bugzilla.redhat.com/show_bug.cgi?id=2036434