### PR TITLE
Fix dnf-yum Provides on ELN

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -127,13 +127,12 @@ Common data and configuration files for DNF
 %package -n %{yum_subpackage_name}
 Requires:       %{name} = %{version}-%{release}
 Summary:        %{pkg_summary}
-%if 0%{?fedora}
-%if 0%{?fedora} >= 31
+
+%if 0%{?fedora} && 0%{?fedora} < 31
+Conflicts:      yum < 3.4.3-505
+%else
 Provides:       %{name}-yum = %{version}-%{release}
 Obsoletes:      %{name}-yum < 5
-%else
-Conflicts:      yum < 3.4.3-505
-%endif
 %endif
 
 %description -n %{yum_subpackage_name}


### PR DESCRIPTION
On ELN, the %{fedora} macro is not present. Instead, it has a
%{rhel} macro equal to the next major release of RHEL.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>