### PR TITLE
Fix regression in verifying signatures using rpmkeys

### DIFF
--- a/dnf/rpm/miscutils.py
+++ b/dnf/rpm/miscutils.py
@@ -71,10 +71,12 @@ def _verifyPackageUsingRpmkeys(package, installroot):
     args = ('rpmkeys', '--checksig', '--root', installroot, '--verbose',
             '--define=_pkgverify_level signature', '--define=_pkgverify_flags 0x0',
             '-')
+    env = dict(os.environ)
+    env['LC_ALL'] = 'C'
     with subprocess.Popen(
             args=args,
             executable=rpmkeys_binary,
-            env={'LC_ALL': 'C'},
+            env=env,
             stdout=subprocess.PIPE,
             cwd='/',
             stdin=package) as p:


### PR DESCRIPTION
= changelog =
msg: Fix regression in verifying signatures using rpmkeys
type: bugfix
related: https://github.com/rpm-software-management/dnf/pull/1752

With previous versions of the DNF reposync command, the verification of RPM package signatures would respect the user's `HOME` environment variable, which impacts the discovered GPG keys. We discovered this after using an upgraded version of DNF and reposync causing many of our RPM packages to suddenly get deleted as the GPG keys were not found:
https://github.com/rpm-software-management/dnf-plugins-core/blob/bdfb8ed33b54683057364df729d45e782d19e708/plugins/reposync.py#L170

Documentation on the HOME variable usage with RPM commands: https://github.com/rpm-software-management/rpm/blob/8338fe60ebc49fc0334f754e2a7ef165ddbd4f05/INSTALL#L292

By passing the user's environment instead of overriding it, the user's current HOME is still respected here. 

cc @kontura 