### PR TITLE
Fix processing of download errors (RhBug: 2024527)

### DIFF
--- a/dnf/repo.py
+++ b/dnf/repo.py
@@ -108,7 +108,7 @@ def _download_payloads(payloads, drpm, fail_fast=True):
         callbacks = tgt.getCallbacks()
         payload = callbacks.package_pload
         pkg = payload.pkg
-        if err == _('Already downloaded'):
+        if err == 'Already downloaded':
             errs._skipped.add(pkg)
             continue
         pkg.repo._repo.expire()


### PR DESCRIPTION
Users with different than english locale are not able to update their
systems in case that some of updates are already downloaded in the dnf
cache (e.g. using dnf-automatic).

The error string is taken from librepo target where it is stored
untranslated. Therefore we need to compare untranslated versions of the
string.

= changelog =
msg:           Fix download errors handling in non-english locales
type:          bugfix
resolves:      https://bugzilla.redhat.com/show_bug.cgi?id=2024527