### PR TITLE
Fix remove when no repos are enabled (RhBz:2064341)

### DIFF
--- a/dnf/cli/commands/group.py
+++ b/dnf/cli/commands/group.py
@@ -358,7 +358,8 @@ class GroupCommand(commands.Command):
         else:
             demands.available_repos = True
 
-        commands._checkEnabledRepo(self.base)
+        if cmd not in ('remove'):
+            commands._checkEnabledRepo(self.base)
 
         if cmd in ('install', 'upgrade'):
             commands._checkGPGKey(self.base, self.cli)


### PR DESCRIPTION
msg: When no repositories are enabled, dnf group exits and does not
remove an installed group.
resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2064341
type: bugfix

test: https://github.com/rpm-software-management/ci-dnf-stack/pull/1061