### PR TITLE
bash-completion: remove unnecessary sub-shelling

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -83,7 +83,7 @@ DNF CONTRIBUTORS
     Michael Scherer <misc@redhat.com>
     Neal Gompa <ngompa13@gmail.com>
     Nathaniel McCallum <npmccallum@redhat.com>
-    Oğuz Ersen <oguzersen@protonmail.com>
+    Oğuz Ersen <oguz@ersen.moe>
     Olivier Andrieu <olivier.andrieu@esterel-technologies.com>
     Padraig Brady <P@draigBrady.com>
     Pavel Grunt <pgrunt@redhat.com>

--- a/etc/bash_completion.d/dnf
+++ b/etc/bash_completion.d/dnf
@@ -124,7 +124,7 @@ _dnf_commands_helper()
 {
     local helper_cmd="import sys; from dnf.cli import completion_helper as ch; ch.main(sys.argv[1:])"
     local helper_opts="-d 0 -q -C --assumeno --nogpgcheck"
-    echo "$( ${__dnf_python_exec} -c "$helper_cmd" "$@" $helper_opts 2>/dev/null </dev/null )"
+    "${__dnf_python_exec}" -c "$helper_cmd" "$@" $helper_opts 2>/dev/null </dev/null
 }
 
 # decide "path-like?" per initial: dot (./f.rpm, ../b.rpm), / (full path) or ~


### PR DESCRIPTION
Running a command in a sub-shell, capturing its output and then echoing that captured output seemed reduntant to me if I am not missing something.