### PR TITLE
force garbage collection on dnf.Base.reset()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -75,6 +75,7 @@ DNF CONTRIBUTORS
     Haïkel Guémar <haikel.guemar@gmail.com>
     Kevin Kofler <kevin.kofler@chello.at>
     Kushal Das <kushaldas@gmail.com>
+    Laszlo Ersek <lersek@redhat.com>
     Lubomír Sedlář <lsedlar@redhat.com>
     Matt Sturgeon <matt@sturgeon.me.uk
     Matthew Miller <mattdm@mattdm.org>

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -72,6 +72,7 @@ import dnf.transaction
 import dnf.util
 import dnf.yum.rpmtrans
 import functools
+import gc
 import hawkey
 import itertools
 import logging
@@ -569,6 +570,46 @@ class Base(object):
             self._comps_trans = dnf.comps.TransactionBunch()
             self._transaction = None
         self._update_security_filters = []
+        if sack and goal:
+            # We've just done this, above:
+            #
+            #      _sack                     _goal
+            #         |                        |
+            #    -- [CUT] --              -- [CUT] --
+            #         |                        |
+            #         v                |       v
+            #    +----------------+   [C]  +-------------+
+            #    | DnfSack object | <-[U]- | Goal object |
+            #    +----------------+   [T]  +-------------+
+            #      |^    |^    |^      |
+            #      ||    ||    ||
+            #      ||    ||    ||         |
+            #   +--||----||----||---+    [C]
+            #   |  v|    v|    v|   | <--[U]-- _transaction
+            #   | Pkg1  Pkg2  PkgN  |    [T]
+            #   |                   |     |
+            #   | Transaction oject |
+            #   +-------------------+
+            #
+            # At this point, the DnfSack object would be released only
+            # eventually, by Python's generational garbage collector, due to the
+            # cyclic references DnfSack<->Pkg1 ... DnfSack<->PkgN.
+            #
+            # The delayed release is a problem: the DnfSack object may
+            # (indirectly) own "page file" file descriptors in libsolv, via
+            # libdnf. For example,
+            #
+            #   sack->priv->pool->repos[1]->repodata[1]->store.pagefd = 7
+            #   sack->priv->pool->repos[1]->repodata[2]->store.pagefd = 8
+            #
+            # These file descriptors are closed when the DnfSack object is
+            # eventually released, that is, when dnf_sack_finalize() (in libdnf)
+            # calls pool_free() (in libsolv).
+            #
+            # We need that to happen right now, as callers may want to unmount
+            # the filesystems which those file descriptors refer to immediately
+            # after reset() returns. Therefore, force a garbage collection here.
+            gc.collect()
 
     def _closeRpmDB(self):
         """Closes down the instances of rpmdb that could be open."""


### PR DESCRIPTION
The `DnfSack` object has two properties that together cause an obscure bug:
* `DnfSack` (very indirectly) *owns* the `libsolv` library's "page file file descriptors".
* `DnfSack` is not immediately released in `dnf.Base.reset()`, due to circular references -- instead, `DnfSack` is only released when Python's generational garbage collector thinks it's time to do so.

The result of this is that file descriptors can be leaked for an unspecified amount of time after `dnf.Base.reset()` -- potentially called from `dnf.Base.close()` -- returns, until the garbage collector eventually cleans them up. Because the kernel sees those leaked file descriptors, they can interfere with operations on the filesystem they point into. For example, they can prevent `livecd-creator` from unmounting the `/var/cache/dnf` filesystem within the `install_root` (chroot) filesystem.

The commit message on the first patch contains an excruciatingly detailed bug analysis; the code change itself is minimal.

You can read my original analysis / investigation at https://bugzilla.redhat.com/show_bug.cgi?id=2038105, comments 45 through 61.

Please **do not edit or squash** my commits. If updates are needed, ask me for a force-push please. Thanks.