### PR TITLE
Don't use undocumented re.template()

### DIFF
--- a/dnf/cli/term.py
+++ b/dnf/cli/term.py
@@ -290,6 +290,7 @@ class Term(object):
             flags = re.I if ignore_case else 0
             haystack = re.sub(pat, render, haystack, flags=flags)
         return haystack
+
     def sub_norm(self, haystack, beg, needles, **kwds):
         """Search the string *haystack* for all occurrences of any
         string in the list *needles*.  Prefix each occurrence with

--- a/dnf/cli/term.py
+++ b/dnf/cli/term.py
@@ -287,9 +287,8 @@ class Term(object):
         render = lambda match: beg + match.group() + end
         for needle in needles:
             pat = escape(needle)
-            if ignore_case:
-                pat = re.template(pat, re.I)
-            haystack = re.sub(pat, render, haystack)
+            flags = re.I if ignore_case else 0
+            haystack = re.sub(pat, render, haystack, flags=flags)
         return haystack
     def sub_norm(self, haystack, beg, needles, **kwds):
         """Search the string *haystack* for all occurrences of any


### PR DESCRIPTION
Python 3.11.0b1 removed it: https://github.com/python/cpython/commit/b09184bf05

It might be resurrected for a proper deprecation period, but it is going away.

See https://github.com/python/cpython/issues/92728

I've looked at the original commit that introduced this code: 6707f479bb
There is no clear indication that would suggest why re.template was used.