### PR TITLE
Add `add` alias

### DIFF
--- a/dnf/cli/commands/install.py
+++ b/dnf/cli/commands/install.py
@@ -43,7 +43,7 @@ class InstallCommand(commands.Command):
                    'install-nevra': hawkey.FORM_NEVRA}
     alternatives_provide = 'alternative-for({})'
 
-    aliases = ('install', 'localinstall', 'in') + tuple(nevra_forms.keys())
+    aliases = ('install', 'localinstall', 'in', 'add') + tuple(nevra_forms.keys())
     summary = _('install a package or packages on your system')
 
     @staticmethod

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -812,7 +812,7 @@ Install Command
 ---------------
 
 | Command: ``install``
-| Aliases: ``in``
+| Aliases: ``in``, ``add``
 | Aliases for :ref:`explicit NEVRA matching <specifying_nevra_matching_explicitly-label>`: ``install-n``, ``install-na``, ``install-nevra``
 | Deprecated aliases: ``localinstall``
 


### PR DESCRIPTION
Adds an `add` alias to the install command, for `dnf add <package>`