### PR TITLE
Don't include resolved advisories for obsoletes with sec. filters (RhBug:2101421)

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1589,7 +1589,7 @@ class Base(object):
             obsoletes = query_for_repo(
                 self.sack.query()).filter(obsoletes_by_priority=inst)
             # reduce a query to security upgrades if they are specified
-            obsoletes = self._merge_update_filters(obsoletes, warning=False)
+            obsoletes = self._merge_update_filters(obsoletes, warning=False, upgrade=True)
             obsoletesTuples = []
             for new in obsoletes:
                 obsoleted_reldeps = new.obsoletes


### PR DESCRIPTION
This makes the obsoletes security filters consistent with upgrade
security filters.

This API is used from check-update and from Info and List commands.
- For check-update we don't want to include resolved advisories to have
  identical result to the actual update. That is bz2101421 use case.
- For Info and List commands the --obsoletes switch: "List packages
  installed on the system that are obsoleted by packages in any known
  repository." Given this specification in makes sense not to
  consider resolved advisories when security filters are used.

There is still a general case when someone uses the API or any potential
future use and I think it is best to have the behavior unified for
"upgrades" and "obsoletes".

= changelog =
msg:           Don't include resolved advisories for obsoletes filtering with security filters
type:          bugfix
resolves:      https://bugzilla.redhat.com/show_bug.cgi?id=2101421

Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1134