### PR TITLE
Ignore missing package in `SCRIPT_START` callback

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -80,6 +80,7 @@ DNF CONTRIBUTORS
     Matt Sturgeon <matt@sturgeon.me.uk
     Matthew Miller <mattdm@mattdm.org>
     Max Prokhorov <prokhorov.max@outlook.com>
+    Mia Stoaks <mia@mia.jetzt>
     Michael Dunphy <mdunphy@uwaterloo.ca>
     Michael Scherer <misc@redhat.com>
     Neal Gompa <ngompa13@gmail.com>

--- a/dnf/yum/rpmtrans.py
+++ b/dnf/yum/rpmtrans.py
@@ -243,7 +243,7 @@ class RPMTransaction(object):
     def __del__(self):
         self._shutdownOutputLogging()
 
-    def _extract_cbkey(self, cbkey):
+    def _extract_cbkey(self, cbkey, throw=True):
         """Obtain the package related to the calling callback."""
 
         if hasattr(cbkey, "pkg"):
@@ -265,7 +265,8 @@ class RPMTransaction(object):
         if items:
             self._tsi_cache = items
             return items
-        raise RuntimeError("TransactionItem not found for key: %s" % cbkey)
+        if throw:
+            raise RuntimeError("TransactionItem not found for key: %s" % cbkey)
 
     def callback(self, what, amount, total, key, client_data):
         try:
@@ -421,7 +422,9 @@ class RPMTransaction(object):
         if key is None and self._te_list == []:
             pkg = 'None'
         else:
-            transaction_list = self._extract_cbkey(key)
+            transaction_list = self._extract_cbkey(key, throw=False)
+            if transaction_list == None:
+                return
             pkg = transaction_list[0].pkg
         complete = self.complete_actions if self.total_actions != 0 and self.complete_actions != 0 \
             else 1

--- a/dnf/yum/rpmtrans.py
+++ b/dnf/yum/rpmtrans.py
@@ -423,7 +423,7 @@ class RPMTransaction(object):
             pkg = 'None'
         else:
             transaction_list = self._extract_cbkey(key, throw=False)
-            if transaction_list == None:
+            if transaction_list is None:
                 return
             pkg = transaction_list[0].pkg
         complete = self.complete_actions if self.total_actions != 0 and self.complete_actions != 0 \


### PR DESCRIPTION
Somehow, a repo I made started getting this error during installation, but the installation itself went fine. Given that it's only used for updating the progress display, and if we don't know about it we're probably not displaying it's progress, it should be fine to ignore.