### PR TITLE
Fix upgrade from file to noarch pkg (RhBug:2006018)

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -2128,7 +2128,11 @@ class Base(object):
             sltr.set(pkg=[pkg])
             self._goal.upgrade(select=sltr)
             return 1
-        q = installed.filter(name=pkg.name, arch=[pkg.arch, "noarch"])
+        # do not filter by arch if the package is noarch
+        if pkg.arch == "noarch":
+            q = installed.filter(name=pkg.name)
+        else:
+            q = installed.filter(name=pkg.name, arch=[pkg.arch, "noarch"])
         if not q:
             msg = _("Package %s not installed, cannot update it.")
             logger.warning(msg, pkg.name)


### PR DESCRIPTION
= changelog =
msg: Fix upgrade pkg from file when installed pkg is noarch and upgrades
to a different arch
type: bugfix
resolves: https://bugzilla.redhat.com/bugzilla/show_bug.cgi?id=2006018
test: https://github.com/rpm-software-management/ci-dnf-stack/pull/1143