### PR TITLE
Expose plugin unload method to API (RhBug:2047251)

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -317,6 +317,11 @@ class Base(object):
         """Run plugins configure() method."""
         self._plugins._run_config()
 
+    def unload_plugins(self):
+        # :api
+        """Run plugins unload() method."""
+        self._plugins._unload()
+
     def update_cache(self, timer=False):
         # :api
 

--- a/dnf/plugin.py
+++ b/dnf/plugin.py
@@ -164,6 +164,7 @@ class Plugins(object):
         self._caller('transaction')
 
     def _unload(self):
+        logger.debug(_('Plugins were unloaded'))
         del sys.modules[DYNAMIC_PACKAGE]
 
     def unload_removed_plugins(self, transaction):

--- a/doc/api_base.rst
+++ b/doc/api_base.rst
@@ -97,6 +97,10 @@
 
      Configure plugins by running their configure() method.
 
+  .. method:: unload_plugins()
+
+     Unload all plugins.
+
   .. method:: fill_sack([load_system_repo=True, load_available_repos=True])
 
     Setup the package sack. If `load_system_repo` is ``True``, load information about packages in the local RPMDB into the sack. Else no package is considered installed during dependency solving. If `load_available_repos` is ``True``, load information about packages from the available repositories into the sack.

--- a/tests/api/test_dnf_base.py
+++ b/tests/api/test_dnf_base.py
@@ -95,6 +95,13 @@ class DnfBaseApiTest(TestCase):
 
         self.base.configure_plugins()
 
+    def test_unload_plugins(self):
+        # Base.unload_plugins()
+        self.assertHasAttr(self.base, "unload_plugins")
+
+        self.base.init_plugins()
+        self.base.unload_plugins()
+
     def test_update_cache(self):
         # Base.update_cache(self, timer=False)
         self.assertHasAttr(self.base, "update_cache")


### PR DESCRIPTION
Add method `unload_plugins` for plugin unloading to API.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2047251.