### PR TITLE
Move system-upgrade plugin to core (RhBug:2054235)

### DIFF
--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -189,8 +189,7 @@ Options
 ``--downloaddir=<path>, --destdir=<path>``
     Redirect downloaded packages to provided directory. The option has to be used together with the \-\
     :ref:`-downloadonly <downloadonly-label>` command line option, with the
-    ``download``, ``modulesync`` or ``reposync`` commands (dnf-plugins-core) or with the ``system-upgrade`` command
-    (dnf-plugins-extras).
+    ``download``, ``modulesync``, ``reposync`` or ``system-upgrade`` commands (dnf-plugins-core).
 
 .. _downloadonly-label:
 


### PR DESCRIPTION
Move `system-upgrade` plugin from `dnf-plugins-extras` to `dnf-plugins-core` to enable offline upgrades on RHEL systems.

Just a doc fix here.

Related PRs from other components:

`dnf-plugins-core`: https://github.com/rpm-software-management/dnf-plugins-core/pull/462
`dnf-plugins-extras`: https://github.com/rpm-software-management/dnf-plugins-extras/pull/210
`ci-dnf-stack`: https://github.com/rpm-software-management/ci-dnf-stack/pull/1150

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2054235.