### PR TITLE
Fix broken dependencies error reporting (RhBug:2088422)

### DIFF
--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -1180,7 +1180,7 @@ class Output(object):
                     lines.append(format_line(group))
                 pkglist_lines.append((action, lines))
         # show skipped conflicting packages
-        if not self.conf.best and self.base._goal.actions & forward_actions:
+        if (not self.conf.best or not self.conf.strict) and self.base._goal.actions & forward_actions:
             lines = []
             skipped_conflicts, skipped_broken = self.base._skipped_packages(
                 report_problems=True, transaction=transaction)


### PR DESCRIPTION
Add broken dependencies error reporting when `strict` option is off and `best` is on.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2088422.