### PR TITLE
Allow passing CLI options when loading remote cfg (RhBug:2060127)

### DIFF
--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -287,7 +287,7 @@ class MainConf(BaseConfig):
                 temp_fd, temp_path = tempfile.mkstemp(prefix='dnf-downloaded-config-')
                 self.tempfiles.append(temp_path)
                 try:
-                    downloader.downloadURL(None, val, temp_fd)
+                    downloader.downloadURL(self._config, val, temp_fd)
                 except RuntimeError as e:
                     raise dnf.exceptions.ConfigError(
                         _('Configuration file URL "{}" could not be downloaded:\n'


### PR DESCRIPTION
Pass existing configuration with parsed options from command-line when trying to download DNF remote configuration file. This allows setting parameters like `sslverify`, `username`, `password`, etc. when working with custom repos.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2060127.