### PR TITLE
Increase required version to rpm-4.18.0 for new signal handling

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -5,7 +5,7 @@
 %global hawkey_version 0.66.0
 %global libcomps_version 0.1.8
 %global libmodulemd_version 2.9.3
-%global rpm_version 4.14.0
+%global rpm_version 4.18.0
 
 # conflicts
 %global conflicts_dnf_plugins_core_version 4.0.26


### PR DESCRIPTION
Since https://github.com/rpm-software-management/dnf/pull/1854 dnf uses rpm API to block signals.
The rpm API behavior was changed in rpm-4.18.0, it no longer polls for caught signals and terminates on `SIGPIPE` during the unblock call (`rpm.blockSignals(False)`).
This version is present since fedora 37.

This is desired in dnf as it wants to ignore `SIGPIPE` and has even overridden handler for it: https://github.com/rpm-software-management/dnf/blob/master/dnf/i18n.py#L102-L103

dnf can recieve `SIGPIPE` for example when running in a `podman build` called from Dockerfile.
This was discovered because of a failing CI.
Related PR: https://github.com/rpm-software-management/ci-dnf-stack/pull/1168

Alternatively we could change dnf and use [python signal module](https://docs.python.org/3/library/signal.html) instead of rpm API to block the signals.