### PR TITLE
Revert "Block signals during RPM transaction processing (RhBug:2127943)"

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1028,9 +1028,6 @@ class Base(object):
                 for display_ in cb.displays:
                     display_.output = False
 
-            # block signals to disallow external interruptions of the transaction
-            rpm.blockSignals(True)
-
             self._plugins.run_pre_transaction()
 
             logger.info(_('Running transaction'))
@@ -1047,9 +1044,6 @@ class Base(object):
             return msgs
         for msg in dnf.util._post_transaction_output(self, self.transaction, _pto_callback):
             logger.debug(msg)
-
-        # unblock signals as we are done with the transaction
-        rpm.blockSignals(False)
 
         return tid
 


### PR DESCRIPTION
The fix has unintended consequences and the proper solution is not that simple. Therefore the original fix is reverted and proper fix is postponed for now.

Discovered in PR: https://github.com/rpm-software-management/dnf/pull/1855.
Original Bugzilla link: https://bugzilla.redhat.com/show_bug.cgi?id=2127943.