### PR TITLE
Do not show list of installed or removed packages with two -q options

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -256,9 +256,10 @@ class BaseCli(dnf.Base):
             # the post transaction summary is already written to log during
             # Base.do_transaction() so here only print the messages to the
             # user arranged in columns
-            print()
-            print('\n'.join(self.output.post_transaction_output(trans)))
-            print()
+            if not self._really_quiet:
+                print()
+                print('\n'.join(self.output.post_transaction_output(trans)))
+                print('')
             for tsi in trans:
                 if tsi.state == libdnf.transaction.TransactionItemState_ERROR:
                     raise dnf.exceptions.Error(_('Transaction failed'))
@@ -790,6 +791,7 @@ class Cli(object):
             opts.errorlevel = 2
         if opts.verbose:
             opts.debuglevel = opts.errorlevel = dnf.const.VERBOSE_LEVEL
+        self.base._really_quiet = opts.quiet and len(opts.quiet)>1
 
         # Read up configuration options and initialize plugins
         try:

--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -177,7 +177,7 @@ class OptionParser(argparse.ArgumentParser):
                                  default=None, metavar='[config file]',
                                  help=_("config file location"))
         general_grp.add_argument("-q", "--quiet", dest="quiet",
-                                 action="store_true", default=None,
+                                 action="append_const", default=None, const=True,
                                  help=_("quiet operation"))
         general_grp.add_argument("-v", "--verbose", action="store_true",
                                  default=None, help=_("verbose operation"))

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -321,6 +321,7 @@ Options
 
 ``-q, --quiet``
     In combination with a non-interactive command, shows just the relevant content. Suppresses messages notifying about the current state or actions of DNF.
+    -qq More quiet output, suppress the list of installed or removed packages.
 
 ``-R <minutes>, --randomwait=<minutes>``
     Maximum command wait time.


### PR DESCRIPTION
Yum and early versions of dnf did not display any output with -q option
Current dnf version shows list of installed or removed packages even with -q option

= changelog =
msg: Do not show list of installed or removed packages with two -q options type: bugfix
resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1985667 related: