### PR TITLE
repoquery: Properly sanitize queryformat strings

### DIFF
--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -42,14 +42,6 @@ logger = logging.getLogger('dnf')
 QFORMAT_DEFAULT = '%{name}-%{epoch}:%{version}-%{release}.%{arch}'
 # matches %[-][dd]{attr}
 QFORMAT_MATCH = re.compile(r'%(-?\d*?){([:\w]+?)}')
-
-QUERY_TAGS = """\
-name, arch, epoch, version, release, reponame (repoid), from_repo, evr,
-debug_name, source_name, source_debug_name,
-installtime, buildtime, size, downloadsize, installsize,
-provides, requires, obsoletes, conflicts, sourcerpm,
-description, summary, license, url, reason"""
-
 ALLOWED_QUERY_TAGS = ('name', 'arch', 'epoch', 'version', 'release',
                       'reponame', 'repoid', 'from_repo', 'evr', 'debug_name',
                       'source_name', 'source_debug_name', 'installtime',
@@ -443,7 +435,7 @@ class RepoQueryCommand(commands.Command):
 
     def run(self):
         if self.opts.querytags:
-            print(QUERY_TAGS)
+            print("\n".join(sorted(ALLOWED_QUERY_TAGS)))
             return
 
         self.cli._populate_update_security_filter(self.opts)

--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -41,7 +41,7 @@ logger = logging.getLogger('dnf')
 
 QFORMAT_DEFAULT = '%{name}-%{epoch}:%{version}-%{release}.%{arch}'
 # matches %[-][dd]{attr}
-QFORMAT_MATCH = re.compile(r'%(-?\d*?){([:.\w]+?)}')
+QFORMAT_MATCH = re.compile(r'%(-?\d*?){([:\w]+?)}')
 
 QUERY_TAGS = """\
 name, arch, epoch, version, release, reponame (repoid), from_repo, evr,
@@ -50,6 +50,13 @@ installtime, buildtime, size, downloadsize, installsize,
 provides, requires, obsoletes, conflicts, sourcerpm,
 description, summary, license, url, reason"""
 
+ALLOWED_QUERY_TAGS = ('name', 'arch', 'epoch', 'version', 'release',
+                      'reponame', 'repoid', 'from_repo', 'evr', 'debug_name',
+                      'source_name', 'source_debug_name', 'installtime',
+                      'buildtime', 'size', 'downloadsize', 'installsize',
+                      'provides', 'requires', 'obsoletes', 'conflicts',
+                      'sourcerpm', 'description', 'summary', 'license', 'url',
+                      'reason')
 OPTS_MAPPING = {
     'conflicts': 'conflicts',
     'enhances': 'enhances',
@@ -68,6 +75,8 @@ def rpm2py_format(queryformat):
     def fmt_repl(matchobj):
         fill = matchobj.groups()[0]
         key = matchobj.groups()[1]
+        if key not in ALLOWED_QUERY_TAGS:
+            return brackets(matchobj.group())
         if fill:
             if fill[0] == '-':
                 fill = '>' + fill[1:]


### PR DESCRIPTION
Previously, dnf repoquery --qf allowed looking up arbitrary attributes of the dnf.package.Package objects in the query and e.g. the current Base via the .base attribute. This checks that %{FOO} is a valid query string as per `dnf repoquery --querytags`. If it isn't, rpm2py_format will leave a literal "%{FOO}".

Before:

``` console
$ dnf repoquery dnf --qf='%{base}' --latest=1 --arch=noarch -q
<dnf.cli.cli.BaseCli object at ...>
```

After:

``` console
$ dnf repoquery dnf --qf='%{base}' --latest=1 --arch=noarch -q
%{base}
```

= changelog =
msg: repoqury: Properly sanitize queryformat strings
type: bugfix
resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2140884