### PR TITLE
Refactor GPG key downloading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ TAGS
 build/
 package/dnf.spec
 dnf/const.py
+dnf/cli/completion_helper.py
+doc/conf.py
 bin/dnf*-2
 bin/dnf*-3
 bin/yum-2


### PR DESCRIPTION
Refactor the GPG key downloading into its own discrete method than can be called independently of a package installation operation. Changes made to support rpm-software-management/dnf-plugins-core#472.

Tests on their way. Looking for feedback on the implementation. 