### PR TITLE
api:  cleanup dnf.Base.package_remove and make it public api

### DIFF
--- a/doc/api_base.rst
+++ b/doc/api_base.rst
@@ -290,6 +290,10 @@
 
     Mark `pkg` (a :class:`dnf.package.Package` instance) for installation. Ignores package that is already installed. `strict` has the same meaning as in :meth:`install`.
 
+  .. method:: package_remove(pkg)
+
+    Mark `pkg` (a :class:`dnf.package.Package` instance) for removal. 
+
   .. method:: package_upgrade(pkg)
 
     If `pkg` is a :class:`dnf.package.Package` in an available repository, mark the matching installed package for upgrade to `pkg`.

--- a/tests/api/test_dnf_base.py
+++ b/tests/api/test_dnf_base.py
@@ -286,6 +286,11 @@ class DnfBaseApiTest(TestCase):
         pkg = self._get_pkg()
         self.assertRaises(dnf.exceptions.MarkingError, self.base.package_upgrade, pkg=pkg)
 
+    def test_package_remove(self):
+        # Base.package_remove(self, pkg)
+        pkg = self._get_pkg()
+        self.assertRaises(dnf.exceptions.MarkingError, self.base.package_remove, pkg=pkg)
+
     def test_upgrade(self):
         # Base.upgrade(self, pkg_spec, reponame=None)
         self.base.fill_sack(load_system_repo=False, load_available_repos=False)


### PR DESCRIPTION
- Added check for if the package is installed
- raise dnf.exceptions.MarkingError is not installed.
- added clean_deps flag to goal.erase to handle removal of deps (same as in dnf.Base.remove)

dnfdaemon and yumex-ng uses the dnf.Base.package_remove to mark a installed package for installation, but need workarounds because it don't handle deps in the current state.
And using non public API is not a good thing.