### PR TITLE
api: cleanup package_remove and make it api

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -2114,8 +2114,14 @@ class Base(object):
         raise dnf.exceptions.MarkingError(_('No match for argument: %s') % pkg.location, pkg.name)
 
     def package_remove(self, pkg):
-        self._goal.erase(pkg)
-        return 1
+        # :api
+        clean_deps = self.conf.clean_requirements_on_remove
+        if (self.sack.query().installed().filterm(name=pkg.name, evr=pkg.evr, arch=pkg.arch)):
+            self._goal.erase(pkg, clean_deps=clean_deps)
+            return 1
+        msg = _("Package %s not installed, cannot remove it.")
+        logger.warning(msg, str(pkg))
+        raise dnf.exceptions.MarkingError(_("No match for argument: %s") % pkg.location, pkg.name)
 
     def package_upgrade(self, pkg):
         # :api

--- a/doc/api_base.rst
+++ b/doc/api_base.rst
@@ -289,6 +289,10 @@
   .. method:: package_install(pkg, strict=True)
 
     Mark `pkg` (a :class:`dnf.package.Package` instance) for installation. Ignores package that is already installed. `strict` has the same meaning as in :meth:`install`.
+  
+  .. method:: package_remove(pkg)
+
+    Mark `pkg` (a :class:`dnf.package.Package` instance) for removal.
 
   .. method:: package_upgrade(pkg)
 

--- a/tests/api/test_dnf_base.py
+++ b/tests/api/test_dnf_base.py
@@ -286,6 +286,11 @@ class DnfBaseApiTest(TestCase):
         pkg = self._get_pkg()
         self.assertRaises(dnf.exceptions.MarkingError, self.base.package_upgrade, pkg=pkg)
 
+    def test_package_remove(self):
+        # Base.package_remove(self, pkg)
+        pkg = self._get_pkg()
+        self.assertRaises(dnf.exceptions.MarkingError, self.base.package_remove, pkg=pkg)
+
     def test_upgrade(self):
         # Base.upgrade(self, pkg_spec, reponame=None)
         self.base.fill_sack(load_system_repo=False, load_available_repos=False)


### PR DESCRIPTION
- Added check for if the package is installed
- raise dnf.exceptions.MarkingError is not installed.
- added clean_deps flag to goal.erase to handle removal of deps (same as in dnf.Base.remove)

dnfdaemon and yumex-ng uses the dnf.Base.package_remove to mark a installed package for installation, but need workarounds because it don't handle deps in the current state.
And using non public API is not a good thing.
