### PR TITLE
Add `reboot` option to DNF Automatic

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -69,6 +69,7 @@ DNF CONTRIBUTORS
     Dave Johansen <davejohansen@gmail.com>
     Dylan Pindur <dylanpindur@gmail.com>
     Eduard Cuba <ecuba@redhat.com>
+    Evan Goode <egoode@redhat.com>
     Filipe Brandenburger <filbranden@gmail.com>
     Frank Dana <ferdnyc@gmail.com>
     George Machitidze <giomac@gmail.com>

--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -182,7 +182,7 @@ class CommandsConfig(Config):
         self.add_option('network_online_timeout', libdnf.conf.OptionNumberInt32(60))
         self.add_option('reboot', libdnf.conf.OptionEnumString('never',
                         libdnf.conf.VectorString(['never', 'when-changed', 'when-needed'])))
-        self.add_option('reboot_command', libdnf.conf.OptionString('shutdown -r'))
+        self.add_option('reboot_command', libdnf.conf.OptionString('shutdown -r +5 \'Rebooting after applying package updates\''))
 
     def imply(self):
         if self.apply_updates:

--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -347,7 +347,9 @@ def main(args):
 
             if (conf.commands.reboot == 'when-changed' or
                (conf.commands.reboot == 'when-needed' and base.reboot_needed())):
-                if os.waitstatus_to_exitcode(os.system(conf.commands.reboot_command)) != 0:
+                exit_code = os.waitstatus_to_exitcode(os.system(conf.commands.reboot_command))
+                if exit_code != 0:
+                    logger.error('Error: reboot command returned nonzero exit code: %d', exit_code)
                     return 1
     except dnf.exceptions.Error as exc:
         logger.error(_('Error: %s'), ucd(exc))

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -2794,6 +2794,20 @@ class Base(object):
 
         return skipped_conflicts, skipped_dependency
 
+    def reboot_needed(self):
+        """Check whether a system reboot is recommended following the transaction
+
+        :return: bool
+        """
+        if not self.transaction:
+            return False
+
+        # List taken from DNF needs-restarting
+        need_reboot = frozenset(('kernel', 'kernel-rt', 'glibc',
+                                'linux-firmware', 'systemd', 'dbus',
+                                'dbus-broker', 'dbus-daemon'))
+        changed_pkgs = self.transaction.install_set | self.transaction.remove_set
+        return any(pkg.name in need_reboot for pkg in changed_pkgs)
 
 def _msg_installed(pkg):
     name = ucd(pkg)

--- a/doc/automatic.rst
+++ b/doc/automatic.rst
@@ -96,9 +96,9 @@ Setting the mode of operation of the program.
     When the system should reboot following upgrades. ``never`` does not reboot the system. ``when-changed`` triggers a reboot after any upgrade. ``when-needed`` triggers a reboot only when rebooting is necessary to apply changes, such as when systemd or the kernel is upgraded.
 
 ``reboot_command``
-    string, default: ``shutdown -r``
+    string, default: ``shutdown -r +5 'Rebooting after applying package updates'``
 
-    Specify the command to run to trigger a reboot of the system. For example, add a 5-minute delay and a wall message by using ``shutdown -r +5 'Rebooting after upgrading packages'`` 
+    Specify the command to run to trigger a reboot of the system. For example, to skip the 5-minute delay and wall message, use ``shutdown -r``
 
 
 

--- a/doc/automatic.rst
+++ b/doc/automatic.rst
@@ -90,6 +90,18 @@ Setting the mode of operation of the program.
 
     What kind of upgrades to look at. ``default`` signals looking for all available updates, ``security`` only those with an issued security advisory.
 
+``reboot``
+    either one of ``never``, ``when-changed``, ``when-needed``, default: ``never``
+
+    When the system should reboot following upgrades. ``never`` does not reboot the system. ``when-changed`` triggers a reboot after any upgrade. ``when-needed`` triggers a reboot only when rebooting is necessary to apply changes, such as when systemd or the kernel is upgraded.
+
+``reboot_command``
+    string, default: ``shutdown -r``
+
+    Specify the command to run to trigger a reboot of the system. For example, add a 5-minute delay and a wall message by using ``shutdown -r +5 'Rebooting after upgrading packages'`` 
+
+
+
 ----------------------
 ``[emitters]`` section
 ----------------------

--- a/etc/dnf/automatic.conf
+++ b/etc/dnf/automatic.conf
@@ -21,6 +21,15 @@ download_updates = yes
 # install.timer override this setting.
 apply_updates = no
 
+# When the system should reboot following upgrades:
+# never                              = don't reboot after upgrades
+# when-changed                       = reboot after any changes
+# when-needed                        = reboot when necessary to apply changes
+reboot = never
+
+# The command that is run to trigger a system reboot.
+reboot_command = "shutdown -r"
+
 
 [emitters]
 # Name to use for this system in messages that are emitted.  Default is the

--- a/etc/dnf/automatic.conf
+++ b/etc/dnf/automatic.conf
@@ -28,7 +28,7 @@ apply_updates = no
 reboot = never
 
 # The command that is run to trigger a system reboot.
-reboot_command = "shutdown -r"
+reboot_command = "shutdown -r +5 'Rebooting after applying package updates'"
 
 
 [emitters]

--- a/tests/automatic/test_main.py
+++ b/tests/automatic/test_main.py
@@ -49,3 +49,7 @@ class TestConfig(tests.support.TestCase):
         conf = dnf.automatic.main.AutomaticConfig(FILE, downloadupdates=True, installupdates=False)
         self.assertTrue(conf.commands.download_updates)
         self.assertFalse(conf.commands.apply_updates)
+
+        # test that reboot is "never" by default
+        conf = dnf.automatic.main.AutomaticConfig(FILE)
+        self.assertEqual(conf.commands.reboot, 'never')


### PR DESCRIPTION
Add ability in DNF Automatic to automatically trigger a reboot after an upgrade. The `reboot` option supports three settings: ``never`` does not reboot the system (current behavior). ``when-changed`` triggers a reboot after any upgrade. ``when-needed`` triggers a reboot only when rebooting is necessary to apply changes, such as when systemd or the kernel is upgraded.

Then `when-needed` option follows `dnf needs-restarting`'s approach for determining whether a reboot is needed; we just look to see whether any "core" packages are involved in the transaction, e.g. the kernel, systemd, dbus, glibc.

I'm still not sure the best way to write a test for this feature, maybe someone has suggestions.

See https://bugzilla.redhat.com/show_bug.cgi?id=2124793