### PR TITLE
Improve "dnf module provides" help text

### DIFF
--- a/dnf/cli/commands/module.py
+++ b/dnf/cli/commands/module.py
@@ -299,7 +299,7 @@ class ModuleCommand(commands.Command):
     class ProvidesSubCommand(SubCommand):
 
         aliases = ("provides", )
-        summary = _('list modular packages')
+        summary = _('locate a module the modular packages belong to')
 
         def configure(self):
             demands = self.cli.demands


### PR DESCRIPTION
"dnf module --help" documented "dnf module provides" as "list modular packages". That was missing an idea that the command searches module builds for a modular package.

<https://github.com/rpm-software-management/dnf/issues/1886>