### PR TITLE
Fix "console" width on non real terminals (pipe)

### DIFF
--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -205,7 +205,7 @@ class Output(object):
                     full_columns.append(col[-1][0])
                 else:
                     full_columns.append(columns[d] + 1)
-            full_columns[0] += len(indent)
+            full_columns[0] += len(indent) * 2
             # if possible, try to keep default width (usually 80 columns)
             default_width = self.term.columns
             if sum(full_columns) > default_width:


### PR DESCRIPTION
**Before**
```
# dnf install --assumeno --skip-broken gstreamer1-plugins-bad-free | cat
Dependencies resolved.
================================================================================
 Package                    Arch   Version                        Repo     Size
================================================================================
Installing:
 gstreamer1-plugins-bad-free
                            x86_64 1.20.5-1.fc37                  updates 2.9 M

```
**After**
```
# dnf install --assumeno --skip-broken gstreamer1-plugins-bad-free | cat
Dependencies resolved.
======================================================================================
 Package                         Arch    Version                        Repo      Size
======================================================================================
Installing:
 gstreamer1-plugins-bad-free     x86_64  1.20.5-1.fc37                  updates  2.9 M
```