### PR TITLE
fix AttributeError when IO busy and press ctrl c

### DIFF
--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -251,8 +251,9 @@ class MainConf(BaseConfig):
         self.tempfiles = []
 
     def __del__(self):
-        for file_name in self.tempfiles:
-            os.unlink(file_name)
+        if hasattr(self, 'tempfiles'):
+            for file_name in self.tempfiles:
+                os.unlink(file_name)
 
     @property
     def get_reposdir(self):


### PR DESCRIPTION
Add attribute judgment before self use 'tempfiles'

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2172433