### PR TITLE
fix typo in czech translation

### DIFF
--- a/po/cs.po
+++ b/po/cs.po
@@ -4059,7 +4059,7 @@ msgstr "Ověřuje se"
 
 #: dnf/transaction.py:97
 msgid "Running scriptlet"
-msgstr "Probíhá skriplet"
+msgstr "Probíhá skriptlet"
 
 #: dnf/transaction.py:99
 msgid "Preparing"


### PR DESCRIPTION
Fixed a small typo I have noticed - it sounds very weird in Czech.