### PR TITLE
Add base.needs_rebooting() to documented API (RhBug:2164835)

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -2795,6 +2795,7 @@ class Base(object):
         return skipped_conflicts, skipped_dependency
 
     def reboot_needed(self):
+        # :api
         """Check whether a system reboot is recommended following the transaction
 
         :return: bool

--- a/doc/api_base.rst
+++ b/doc/api_base.rst
@@ -336,3 +336,6 @@
         base.download_packages(base.transaction.install_set, progress)
         print("Installing...")
         base.do_transaction()
+  .. method:: reboot_needed()
+
+    Check whether a system reboot is recommended following the transaction. If the transaction involves `kernel`, `glibc`, `dbus`, or some other "core" package, then a reboot is recommended, and this function returns `true`. Otherwise, a reboot is probably not necessary, and this function returns `false`.


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=2124793

A customer wants to check whether installing a package will require a system reboot. They want the functionality of `dnf needs-restarting` but without having to first install the package.

The method we use to decide whether to recommend a reboot is quite primitive: we simply check whether the transaction involves any package in a hardcoded list of "core" packages, which includes `kernel`, `glibc`, and `systemd`. But it would still be nice to expose this functionality in the API.

We already have `base.needs_rebooting()` so we would just need to add it to the docs. Then the user could use something like:

```
import dnf

package = "glibc"

base = dnf.Base()
base.read_all_repos()
base.fill_sack()

base.install_specs([package])
base.resolve()

# Is reboot needed?
if base.reboot_needed():
    print("Reboot is recommended")
elif:
    print("Reboot should not be necessary")
```