### PR TITLE
smtplib: catch OSError, not SMTPException

### DIFF
--- a/dnf/automatic/emitter.py
+++ b/dnf/automatic/emitter.py
@@ -106,7 +106,7 @@ class EmailEmitter(Emitter):
             smtp = smtplib.SMTP(self._conf.email_host, timeout=300)
             smtp.sendmail(email_from, email_to, message.as_string())
             smtp.close()
-        except smtplib.SMTPException as exc:
+        except OSError as exc:
             msg = _("Failed to send an email via '%s': %s") % (
                 self._conf.email_host, exc)
             logger.error(msg)


### PR DESCRIPTION
Some, but not all, types of connection error are caught by smtplib and reraised as an smtplib.SMTPException. Notably, TimeoutError, socket.gaierror (name resolution failure), and ConnectionRefusedError and are not caught.

The more generic OSError should be caught here instead.

Resolves #1905