### PR TITLE
automatic: Return an error when transaction fails (RhBug:2170093)

### DIFF
--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -342,6 +342,13 @@ def main(args):
 
             gpgsigcheck(base, trans.install_set)
             base.do_transaction()
+
+            # In case of no global error occurred within the transaction,
+            # we need to check state of individual transaction items.
+            for tsi in trans:
+                if tsi.state == libdnf.transaction.TransactionItemState_ERROR:
+                    raise dnf.exceptions.Error(_('Transaction failed'))
+
             emitters.notify_applied()
             emitters.commit()
 


### PR DESCRIPTION
In case of no global error occurred within the transaction, we still need to check state of individual transaction items for any failure.

This is matching the logic in [`BaseCli.do_transaction`](https://github.com/rpm-software-management/dnf/blob/5306910d06631bc93fa3ece0e70ed27ee592b0aa/dnf/cli/cli.py#L262) method, where the error is emitted after printing the transaction summary.