### PR TITLE
Packaging changes for DNF => DNF5 upgrade path

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -283,11 +283,8 @@ popd
 %dir %{confdir}/modules.d
 %dir %{confdir}/modules.defaults.d
 %dir %{pluginconfpath}
-%dir %{confdir}/protected.d
-%dir %{confdir}/vars
 %dir %{confdir}/aliases.d
 %exclude %{confdir}/aliases.d/zypper.conf
-%config(noreplace) %{confdir}/%{name}.conf
 # No longer using `noreplace` here. Older versions of DNF 4 marked `dnf` as a
 # protected package, but since Fedora 39, DNF needs to be able to update itself
 # to DNF 5, so we need to replace the old /etc/dnf/protected.d/dnf.conf.

--- a/dnf.spec
+++ b/dnf.spec
@@ -142,7 +142,6 @@ Obsoletes:      %{name}-yum < 5
 %package -n python3-%{name}
 Summary:        Python 3 interface to DNF
 %{?python_provide:%python_provide python3-%{name}}
-Requires:       libdnf5
 BuildRequires:  python3-devel
 BuildRequires:  python3-hawkey >= %{hawkey_version}
 BuildRequires:  python3-libdnf >= %{hawkey_version}
@@ -176,7 +175,7 @@ Python 3 interface to DNF.
 %package automatic
 Summary:        %{pkg_summary} - automated upgrades
 BuildRequires:  systemd
-Requires:       %{name} = %{version}-%{release}
+Requires:       python3-%{name} = %{version}-%{release}
 %{?systemd_requires}
 
 %description automatic

--- a/dnf.spec
+++ b/dnf.spec
@@ -118,6 +118,7 @@ Conflicts:      python3-dnf-plugins-extras-common < %{conflicts_dnf_plugins_extr
 %package data
 Summary:        Common data and configuration files for DNF
 Requires:       libreport-filesystem
+Requires:       libdnf5
 Obsoletes:      %{name}-conf <= %{version}-%{release}
 Provides:       %{name}-conf = %{version}-%{release}
 
@@ -141,6 +142,7 @@ Obsoletes:      %{name}-yum < 5
 %package -n python3-%{name}
 Summary:        Python 3 interface to DNF
 %{?python_provide:%python_provide python3-%{name}}
+Requires:       libdnf5
 BuildRequires:  python3-devel
 BuildRequires:  python3-hawkey >= %{hawkey_version}
 BuildRequires:  python3-libdnf >= %{hawkey_version}

--- a/etc/dnf/CMakeLists.txt
+++ b/etc/dnf/CMakeLists.txt
@@ -1,3 +1,3 @@
-INSTALL (FILES "dnf-strict.conf" "dnf.conf" "automatic.conf" DESTINATION ${SYSCONFDIR}/dnf)
+INSTALL (FILES "dnf-strict.conf" "automatic.conf" DESTINATION ${SYSCONFDIR}/dnf)
 ADD_SUBDIRECTORY (aliases.d)
 ADD_SUBDIRECTORY (protected.d)


### PR DESCRIPTION
For the DNF => DNF5 upgrade path in Fedora 39. Part of https://github.com/rpm-software-management/dnf5/pull/469.

~~See also https://github.com/rpm-software-management/libdnf/pull/1599.~~

~~It seems that `dnf` and `yum` can't be marked as protected even if DNF5 is still going to provide them.~~

EDIT: The change to unprotect the `dnf` package would happen before the other changes, so it has been moved to https://github.com/rpm-software-management/dnf/pull/1926.