### PR TITLE
Remove dnf and yum from protected packages

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -288,7 +288,12 @@ popd
 %dir %{confdir}/aliases.d
 %exclude %{confdir}/aliases.d/zypper.conf
 %config(noreplace) %{confdir}/%{name}.conf
-%config(noreplace) %{confdir}/protected.d/%{name}.conf
+# No longer using `noreplace` here. Older versions of DNF 4 marked `dnf` as a
+# protected package, but since Fedora 39, DNF needs to be able to update itself
+# to DNF 5, so we need to replace the old /etc/dnf/protected.d/dnf.conf.
+%config %{confdir}/protected.d/%{name}.conf
+# Protect python3-dnf instead, which does not conflict with DNF 5
+%config(noreplace) %{confdir}/protected.d/python3-%{name}.conf
 %config(noreplace) %{_sysconfdir}/logrotate.d/%{name}
 %ghost %attr(644,-,-) %{_localstatedir}/log/hawkey.log
 %ghost %attr(644,-,-) %{_localstatedir}/log/%{name}.log
@@ -314,7 +319,10 @@ popd
 %{_mandir}/man5/yum.conf.5.*
 %{_mandir}/man8/yum-shell.8*
 %{_mandir}/man1/yum-aliases.1*
-%config(noreplace) %{confdir}/protected.d/yum.conf
+# No longer using `noreplace` here. Older versions of DNF 4 marked `yum` as a
+# protected package, but since Fedora 39, DNF needs to be able to update itself
+# to DNF 5, so we need to replace the old /etc/dnf/protected.d/yum.conf.
+%config %{confdir}/protected.d/yum.conf
 %else
 %exclude %{_sysconfdir}/yum.conf
 %exclude %{_sysconfdir}/yum/pluginconf.d

--- a/etc/dnf/protected.d/CMakeLists.txt
+++ b/etc/dnf/protected.d/CMakeLists.txt
@@ -1,1 +1,1 @@
-INSTALL (FILES "dnf.conf" "yum.conf" DESTINATION ${SYSCONFDIR}/dnf/protected.d)
+INSTALL (FILES "dnf.conf" "yum.conf" "python3-dnf.conf" DESTINATION ${SYSCONFDIR}/dnf/protected.d)

--- a/etc/dnf/protected.d/dnf.conf
+++ b/etc/dnf/protected.d/dnf.conf
@@ -1,1 +1,3 @@
-dnf
+# DNF is obsoleted in Fedora 39 by DNF 5 and should no longer be marked as protected.
+
+# dnf

--- a/etc/dnf/protected.d/python3-dnf.conf
+++ b/etc/dnf/protected.d/python3-dnf.conf
@@ -1,0 +1,1 @@
+python3-dnf

--- a/etc/dnf/protected.d/yum.conf
+++ b/etc/dnf/protected.d/yum.conf
@@ -1,1 +1,4 @@
-yum
+# In Fedora 39, yum is obsoleted/provided by the dnf5 package rather than dnf,
+# and DNF cannot replace itself with DNF5 if yum is marked as protected.
+
+# yum


### PR DESCRIPTION
For the DNF => DNF5 upgrade path in Fedora 39.

See also https://github.com/rpm-software-management/libdnf/pull/1599.

This change should ideally be merged soon and released in Fedora 37. Versions of DNF 4 older than this change will not be able to replace `dnf` with `dnf5` when upgrading Fedora 37 to Fedora 39. The Fedora documentation [strongly urges](https://docs.fedoraproject.org/en-US/quick-docs/upgrading/) users to fully update their system before attempting an upgrade to a new Fedora release, but there will surely be a small set of users who disregard the documentation and attempt an upgrade from an old version of DNF4 on Fedora 37 straight to Fedora 39. In my opinion, we should therefore remove the protection soon to minimize the size of this group of users. But this concern should be weighed against the risks of leaving the `dnf` package unprotected. It could instead be argued that we should wait to merge this change until closer to the Fedora 39 release date. 

An alternative approach would be to change the behavior of `libdnf` such that the replacement of a package due to an `Obsoletes` would not be considered a removal of a protected package. Currently, it seems that `dnf` cannot upgrade itself to `dnf5` since `dnf` and `yum` are protected, even if `dnf5` provides and obsoletes `dnf` and `yum`. But it may not be worth the effort to make this change in `libdnf` when it is being replaced by DNF5 soon.