### PR TITLE
automatic: Add 'always' as possible value to reboot option

### DIFF
--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -181,7 +181,7 @@ class CommandsConfig(Config):
         self.add_option('random_sleep', libdnf.conf.OptionNumberInt32(300))
         self.add_option('network_online_timeout', libdnf.conf.OptionNumberInt32(60))
         self.add_option('reboot', libdnf.conf.OptionEnumString('never',
-                        libdnf.conf.VectorString(['never', 'when-changed', 'when-needed'])))
+                        libdnf.conf.VectorString(['never', 'when-changed', 'when-needed', 'always'])))
         self.add_option('reboot_command', libdnf.conf.OptionString(
             'shutdown -r +5 \'Rebooting after applying package updates\''))
 
@@ -334,6 +334,11 @@ def main(args):
             output = dnf.cli.output.Output(base, base.conf)
             trans = base.transaction
             if not trans:
+                if (conf.commands.reboot == 'always'):
+                    exit_code = os.waitstatus_to_exitcode(os.system(conf.commands.reboot_command))
+                    if exit_code != 0:
+                        logger.error('Error: reboot command returned nonzero exit code: %d', exit_code)
+                        return 1
                 return 0
 
             lst = output.list_transaction(trans, total_width=80)

--- a/doc/automatic.rst
+++ b/doc/automatic.rst
@@ -91,9 +91,9 @@ Setting the mode of operation of the program.
     What kind of upgrades to look at. ``default`` signals looking for all available updates, ``security`` only those with an issued security advisory.
 
 ``reboot``
-    either one of ``never``, ``when-changed``, ``when-needed``, default: ``never``
+    either one of ``never``, ``when-changed``, ``when-needed``, ``always``, default: ``never``
 
-    When the system should reboot following upgrades. ``never`` does not reboot the system. ``when-changed`` triggers a reboot after any upgrade. ``when-needed`` triggers a reboot only when rebooting is necessary to apply changes, such as when systemd or the kernel is upgraded.
+    When the system should reboot following upgrades. ``never`` does not reboot the system. ``when-changed`` triggers a reboot after any upgrade. ``when-needed`` triggers a reboot only when rebooting is necessary to apply changes, such as when systemd or the kernel is upgraded. ``always`` triggers a reboot regardless of any changes.
 
 ``reboot_command``
     string, default: ``shutdown -r +5 'Rebooting after applying package updates'``

--- a/etc/dnf/automatic.conf
+++ b/etc/dnf/automatic.conf
@@ -25,6 +25,7 @@ apply_updates = no
 # never                              = don't reboot after upgrades
 # when-changed                       = reboot after any changes
 # when-needed                        = reboot when necessary to apply changes
+# always                             = reboot regardless of any changes
 reboot = never
 
 # The command that is run to trigger a system reboot.


### PR DESCRIPTION
Allows reboot_command to be executed regardless of any changes.

Implements: https://github.com/rpm-software-management/dnf/issues/1928