### PR TITLE
automatic: use email_port specified in config

### DIFF
--- a/dnf/automatic/emitter.py
+++ b/dnf/automatic/emitter.py
@@ -95,6 +95,7 @@ class EmailEmitter(Emitter):
         message.set_charset('utf-8')
         email_from = self._conf.email_from
         email_to = self._conf.email_to
+        email_port = self._conf.email_port
         message['Date'] = email.utils.formatdate()
         message['From'] = email_from
         message['Subject'] = subj
@@ -103,7 +104,7 @@ class EmailEmitter(Emitter):
 
         # Send the email
         try:
-            smtp = smtplib.SMTP(self._conf.email_host, timeout=300)
+            smtp = smtplib.SMTP(self._conf.email_host, self._conf.email_port, timeout=300)
             smtp.sendmail(email_from, email_to, message.as_string())
             smtp.close()
         except OSError as exc:

--- a/doc/automatic.rst
+++ b/doc/automatic.rst
@@ -178,6 +178,11 @@ The email emitter configuration.
 
     Hostname of the SMTP server used to send the message.
 
+``email_port``
+    integer, default: ``25``
+
+    Port number to connect to at the SMTP server.
+
 ``email_to``
     list, default: ``root``
 

--- a/etc/dnf/automatic.conf
+++ b/etc/dnf/automatic.conf
@@ -58,6 +58,8 @@ email_to = root
 # Name of the host to connect to to send email messages.
 email_host = localhost
 
+# Port number to connect to at the email host.
+email_port = 25
 
 [command]
 # The shell command to execute. This is a Python format string, as used in


### PR DESCRIPTION
This allows user to override the default SMTP port.

Resolves #1955.