### PR TITLE
automatic: allow use of STARTTLS/TLS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -68,6 +68,7 @@ DNF CONTRIBUTORS
     Christopher Meng <cickumqt@gmail.com>
     Daniel Mach <dmach@redhat.com>
     Dave Johansen <davejohansen@gmail.com>
+    Dominik Mierzejewski <dominik@greysector.net>
     Dylan Pindur <dylanpindur@gmail.com>
     Eduard Cuba <ecuba@redhat.com>
     Evan Goode <egoode@redhat.com>

--- a/dnf/automatic/emitter.py
+++ b/dnf/automatic/emitter.py
@@ -96,6 +96,7 @@ class EmailEmitter(Emitter):
         email_from = self._conf.email_from
         email_to = self._conf.email_to
         email_port = self._conf.email_port
+        email_tls = self._conf.email_tls
         message['Date'] = email.utils.formatdate()
         message['From'] = email_from
         message['Subject'] = subj
@@ -104,7 +105,12 @@ class EmailEmitter(Emitter):
 
         # Send the email
         try:
-            smtp = smtplib.SMTP(self._conf.email_host, self._conf.email_port, timeout=300)
+            if self._conf.email_tls == 'yes':
+                smtp = smtplib.SMTP_SSL(self._conf.email_host, self._conf.email_port, timeout=300)
+            else:
+                smtp = smtplib.SMTP(self._conf.email_host, self._conf.email_port, timeout=300)
+                if self._conf.email_tls == 'starttls':
+                    smtp.starttls()
             smtp.sendmail(email_from, email_to, message.as_string())
             smtp.close()
         except OSError as exc:

--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -198,6 +198,7 @@ class EmailConfig(Config):
         self.add_option('email_from', libdnf.conf.OptionString("root"))
         self.add_option('email_host', libdnf.conf.OptionString("localhost"))
         self.add_option('email_port', libdnf.conf.OptionNumberInt32(25))
+        self.add_option('email_tls', libdnf.conf.OptionString("no"))
 
 
 class CommandConfig(Config):

--- a/doc/automatic.rst
+++ b/doc/automatic.rst
@@ -183,6 +183,11 @@ The email emitter configuration.
 
     Port number to connect to at the SMTP server.
 
+``email_tls``
+    either one of ``no``, ``yes``, ``starttls``, default: ``no``
+
+    Whether to use TLS, STARTTLS or no encryption to connect to the SMTP server.
+
 ``email_to``
     list, default: ``root``
 

--- a/etc/dnf/automatic.conf
+++ b/etc/dnf/automatic.conf
@@ -61,6 +61,10 @@ email_host = localhost
 # Port number to connect to at the email host.
 email_port = 25
 
+# Use TLS or STARTTLS to connect to the email host.
+email_tls = no
+
+
 [command]
 # The shell command to execute. This is a Python format string, as used in
 # str.format(). The format function will pass a shell-quoted argument called


### PR DESCRIPTION
Add the ability to use STARTTLS/TLS for sending e-mail via the `email`
emitter.
    
The `email_tls` option supports three settings: ``starttls``, used to
switch to TLS on plaintext ports like 25 or 587 and ``yes``, used to
wrap the entire connection in TLS, usually on port 465. Any other
setting (``off`` by default) will use plain unencrypted SMTP.
    
Note: this depends on #1956 .
    
= changelog =
msg: Add `email_tls` option to DNF Automatic
type: enhancement
resolves: #1954