### PR TITLE
Support lists of KVP in kwargs when calling add_new_repo

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -63,6 +63,7 @@ DNF CONTRIBUTORS
     Adam Williamson <awilliam@redhat.com>
     Albert Uchytil <auchytil@redhat.com>
     Alberto Ruiz <aruiz@redhat.com>
+    Anish Bhatt <anish.bhatt@salesforce.com>
     Baurzhan Muftakhidinov <baurthefirst@gmail.com>
     Christopher Meng <cickumqt@gmail.com>
     Daniel Mach <dmach@redhat.com>

--- a/dnf/repodict.py
+++ b/dnf/repodict.py
@@ -79,8 +79,8 @@ class RepoDict(dict):
                     if isinstance(value, str):
                         substituted.append(
                             libdnf.conf.ConfigParser.substitute(value, conf.substitutions))
-                    if substituted:
-                        return substituted
+                if substituted:
+                    return substituted
             return values
 
         repo = dnf.repo.Repo(repoid, conf)


### PR DESCRIPTION
The loop in `substitute()` returns when `substitutions` is non-empty. When parsing over a list, this condition is met on the first member of the list and the rest of the list is not parsed and thrown away. This can be easily reproduced by using a repo that uses more than one gpgkey :
```
    base.repos.add_new_repo('foo_repo', conf,
        baseurl=['https://foo/bar'],
        gpgkey=['https://foo/bar/key1','https://foo/bar/key2'],
        gpgcheck=True)
```
At the end of of `add_new_repo`, the new repo will only contain one key and not a list like [this code](https://github.com/rpm-software-management/dnf/blob/41da7f09bc73b4f34bc90c0b7dca058780bee8e9/dnf/crypto.py#L104) expects