### PR TITLE
python3-dnf: Provide /usr/bin/dnf4 symlink to /usr/bin/dnf-3

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -214,6 +214,7 @@ mkdir -p %{buildroot}%{_localstatedir}/log/
 mkdir -p %{buildroot}%{_var}/cache/dnf/
 touch %{buildroot}%{_localstatedir}/log/%{name}.log
 ln -sr %{buildroot}%{_bindir}/dnf-3 %{buildroot}%{_bindir}/dnf
+ln -sr %{buildroot}%{_bindir}/dnf-3 %{buildroot}%{_bindir}/dnf4
 mv %{buildroot}%{_bindir}/dnf-automatic-3 %{buildroot}%{_bindir}/dnf-automatic
 rm -vf %{buildroot}%{_bindir}/dnf-automatic-*
 
@@ -358,6 +359,7 @@ popd
 
 %files -n python3-%{name}
 %{_bindir}/%{name}-3
+%{_bindir}/%{name}4
 %exclude %{python3_sitelib}/%{name}/automatic
 %{python3_sitelib}/%{name}/
 %dir %{py3pluginpath}


### PR DESCRIPTION
python3-dnf should provide `/usr/bin/dnf4`to match DNF 5's `/usr/bin/dnf5` and so users aren't confused why "dnf-3" is the binary for "DNF 4".