### PR TITLE
Fix ELN by not providing /etc/dnf/dnf.conf in RHEL > 9

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -95,7 +95,7 @@ Conflicts:      python3-dnf-plugins-extras-common < %{conflicts_dnf_plugins_extr
 %package data
 Summary:        Common data and configuration files for DNF
 Requires:       libreport-filesystem
-%if 0%{?fedora} > 38
+%if 0%{?fedora} > 38 || 0%{?rhel} > 9
 Requires:       /etc/dnf/dnf.conf
 %endif
 Obsoletes:      %{name}-conf <= %{version}-%{release}
@@ -234,7 +234,7 @@ ln -sr  %{buildroot}%{confdir}/protected.d %{buildroot}%{_sysconfdir}/yum/protec
 ln -sr  %{buildroot}%{confdir}/vars %{buildroot}%{_sysconfdir}/yum/vars
 %endif
 
-%if 0%{?fedora} > 38
+%if 0%{?fedora} > 38 || 0%{?rhel} > 9
 rm %{buildroot}%{confdir}/%{name}.conf
 %endif
 
@@ -289,13 +289,13 @@ popd
 %dir %{confdir}/modules.d
 %dir %{confdir}/modules.defaults.d
 %dir %{pluginconfpath}
-%if 0%{?fedora} <= 38
+%if 0%{?fedora} <= 38 || 0%{?rhel} <= 9
 %dir %{confdir}/protected.d
 %dir %{confdir}/vars
 %endif
 %dir %{confdir}/aliases.d
 %exclude %{confdir}/aliases.d/zypper.conf
-%if 0%{?fedora} <= 38
+%if 0%{?fedora} <= 38 || 0%{?rhel} <= 9
 %config(noreplace) %{confdir}/%{name}.conf
 %endif
 


### PR DESCRIPTION
DNF 4 should not provide /etc/dnf/dnf.conf in distributions that ship DNF 5.

See https://bugzilla.redhat.com/show_bug.cgi?id=2219600

Doc page on resolving ELN build failures: https://docs.fedoraproject.org/en-US/eln/ftbfs/

I haven't tested this yet.