### PR TITLE
Revert "Unprotect dnf and yum, protect python3-dnf"

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -299,15 +299,10 @@ popd
 %dir %{confdir}/aliases.d
 %exclude %{confdir}/aliases.d/zypper.conf
 %if %{without dnf5_obsoletes_dnf}
+# If DNF5 does not obsolete DNF ownership of dnf.conf should be DNF's
 %config(noreplace) %{confdir}/%{name}.conf
 %endif
-
-# No longer using `noreplace` here. Older versions of DNF 4 marked `dnf` as a
-# protected package, but since Fedora 39, DNF needs to be able to update itself
-# to DNF 5, so we need to replace the old /etc/dnf/protected.d/dnf.conf.
-%config %{confdir}/protected.d/%{name}.conf
-# Protect python3-dnf instead, which does not conflict with DNF 5
-%config(noreplace) %{confdir}/protected.d/python3-%{name}.conf
+%config(noreplace) %{confdir}/protected.d/%{name}.conf
 %config(noreplace) %{_sysconfdir}/logrotate.d/%{name}
 %ghost %attr(644,-,-) %{_localstatedir}/log/hawkey.log
 %ghost %attr(644,-,-) %{_localstatedir}/log/%{name}.log
@@ -333,10 +328,16 @@ popd
 %{_mandir}/man5/yum.conf.5.*
 %{_mandir}/man8/yum-shell.8*
 %{_mandir}/man1/yum-aliases.1*
+%if %{without dnf5_obsoletes_dnf}
+# If DNF5 does not obsolete DNF, protected.d/yum.conf should be owned by DNF
+%config(noreplace) %{confdir}/protected.d/yum.conf
+%else
+# If DNF5 obsoletes DNF
 # No longer using `noreplace` here. Older versions of DNF 4 marked `yum` as a
 # protected package, but since Fedora 39, DNF needs to be able to update itself
 # to DNF 5, so we need to replace the old /etc/dnf/protected.d/yum.conf.
 %config %{confdir}/protected.d/yum.conf
+%endif
 %else
 %exclude %{_sysconfdir}/yum.conf
 %exclude %{_sysconfdir}/yum/pluginconf.d

--- a/etc/dnf/protected.d/CMakeLists.txt
+++ b/etc/dnf/protected.d/CMakeLists.txt
@@ -1,1 +1,1 @@
-INSTALL (FILES "dnf.conf" "yum.conf" "python3-dnf.conf" DESTINATION ${SYSCONFDIR}/dnf/protected.d)
+INSTALL (FILES "dnf.conf" "yum.conf" DESTINATION ${SYSCONFDIR}/dnf/protected.d)

--- a/etc/dnf/protected.d/dnf.conf
+++ b/etc/dnf/protected.d/dnf.conf
@@ -1,3 +1,1 @@
-# DNF is obsoleted in Fedora 39 by DNF 5 and should no longer be marked as protected.
-
-# dnf
+dnf

--- a/etc/dnf/protected.d/python3-dnf.conf
+++ b/etc/dnf/protected.d/python3-dnf.conf
@@ -1,1 +1,0 @@
-python3-dnf

--- a/etc/dnf/protected.d/yum.conf
+++ b/etc/dnf/protected.d/yum.conf
@@ -1,4 +1,1 @@
-# In Fedora 39, yum is obsoleted/provided by the dnf5 package rather than dnf,
-# and DNF cannot replace itself with DNF5 if yum is marked as protected.
-
-# yum
+yum


### PR DESCRIPTION
This reverts commit 352b174a0b4ce2048ef1a25b785f20449e2addc2. adding the condition %{witout dnf5_obsoletes_dnf} to keep the unprotected directive for chroots that build dnf with rpm option with=dnf5_obsoletes_dnf