### PR TITLE
Block signals during RPM transaction processing

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -5,7 +5,7 @@
 %global hawkey_version 0.66.0
 %global libcomps_version 0.1.8
 %global libmodulemd_version 2.9.3
-%global rpm_version 4.14.0
+%global rpm_version 4.18.0
 
 # conflicts
 %global conflicts_dnf_plugins_core_version 4.0.26

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1028,6 +1028,9 @@ class Base(object):
                 for display_ in cb.displays:
                     display_.output = False
 
+            # block signals to disallow external interruptions of the transaction
+            rpm.blockSignals(True)
+
             self._plugins.run_pre_transaction()
 
             logger.info(_('Running transaction'))
@@ -1044,6 +1047,9 @@ class Base(object):
             return msgs
         for msg in dnf.util._post_transaction_output(self, self.transaction, _pto_callback):
             logger.debug(msg)
+
+        # unblock signals as we are done with the transaction
+        rpm.blockSignals(False)
 
         return tid
 


### PR DESCRIPTION
Prevent signals to interrupt the processing of the RPM transaction inside the DNF.

If the signal is received between the blockSignals calls, SQL DB is not properly closed then as this is normally handled later during the base cleanup. But the changes are present in the SQLite write-ahead log and when the DB is accessed next time, changes are propagated into the main file. We could move the unblocking statement further in the code, but I tried to keep the source code inside the blocking part in the minimum possible amount. The transaction summary logs still could be omitted, but maybe it is useful for debugging.

**Note:**
This was originally merged within the [PR](https://github.com/rpm-software-management/dnf/pull/1854), but reverted soon as the provided API wasn't available on some RHEL and Fedora systems rebasing from upstream, which is not the case anymore.

Resolves https://issues.redhat.com/browse/RHEL-1235.