### PR TITLE
[spec] Add Recommends %{_bindir}/sqlite3 for bash-completion for Fedora

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -85,6 +85,8 @@ Requires:       python3-%{name} = %{version}-%{release}
 %if 0%{?rhel} && 0%{?rhel} <= 7
 Requires:       python-dbus
 Requires:       %{_bindir}/sqlite3
+%elif 0%{?fedora}
+Recommends:     (%{_bindir}/sqlite3 if (bash-completion and python3-dnf-plugins-core))
 %else
 Recommends:     (python3-dbus if NetworkManager)
 %endif


### PR DESCRIPTION
https://github.com/rpm-software-management/dnf/pull/1817 added the ability to utilize sqlite cache when available.
https://discussion.fedoraproject.org/t/why-bash-auto-completion-is-so-slow-with-dnf/88944 and
https://discussion.fedoraproject.org/t/dnf-autocompletion-is-too-slow/64038 Are users noting that bash completion is slow without sqlite installed.

 = changelog =
 msg:   [spec] Add Recommends %{_bindir}/sqlite3 for bash-completion for Fedora
 type:  enhancement
 related: https://github.com/rpm-software-management/dnf/pull/1817
 related: https://discussion.fedoraproject.org/t/why-bash-auto-completion-is-so-slow-with-dnf/88944
 related: https://discussion.fedoraproject.org/t/dnf-autocompletion-is-too-slow/64038