### PR TITLE
Add recommends for libreport (RhBug:2120960)

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -96,7 +96,9 @@ Conflicts:      python3-dnf-plugins-extras-common < %{conflicts_dnf_plugins_extr
 
 %package data
 Summary:        Common data and configuration files for DNF
-Requires:       libreport-filesystem
+
+#  We provide a configuration file (/etc/libreport/events.d/collect_dnf.conf) for libreport
+Recommends:     libreport-filesystem
 %if %{with dnf5_obsoletes_dnf}
 Requires:       /etc/dnf/dnf.conf
 %endif


### PR DESCRIPTION
This is an optional feature and dnf-data only provides a configuration file for libreport therefore we dont have to require it.

https://bugzilla.redhat.com/show_bug.cgi?id=2120960