### PR TITLE
Revert "Block signals during RPM transaction processing"

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -5,7 +5,7 @@
 %global hawkey_version 0.71.0
 %global libcomps_version 0.1.8
 %global libmodulemd_version 2.9.3
-%global rpm_version 4.18.0
+%global rpm_version 4.14.0
 
 # conflicts
 %global conflicts_dnf_plugins_core_version 4.0.26

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1028,9 +1028,6 @@ class Base(object):
                 for display_ in cb.displays:
                     display_.output = False
 
-            # block signals to disallow external interruptions of the transaction
-            rpm.blockSignals(True)
-
             self._plugins.run_pre_transaction()
 
             logger.info(_('Running transaction'))
@@ -1047,9 +1044,6 @@ class Base(object):
             return msgs
         for msg in dnf.util._post_transaction_output(self, self.transaction, _pto_callback):
             logger.debug(msg)
-
-        # unblock signals as we are done with the transaction
-        rpm.blockSignals(False)
 
         return tid
 


### PR DESCRIPTION
As the change is causing problems when building other packages in Koji buildroot, reverting this until the root cause is properly resolved.

This is already patched in downstream.

Reverts: https://github.com/rpm-software-management/dnf/pull/1984.
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2236997.