### PR TITLE
Split $releasever to $releasever_major and $releasever_minor

### DIFF
--- a/dnf/exceptions.py
+++ b/dnf/exceptions.py
@@ -180,6 +180,12 @@ class ProcessLockError(LockError):
         return (ProcessLockError, (self.value, self.pid))
 
 
+class ReadOnlyVariableError(Error):
+    def __init__(self, value, variable_name):
+        super(ReadOnlyVariableError, self).__init__(value)
+        self.variable_name = variable_name
+
+
 class RepoError(Error):
     # :api
     pass


### PR DESCRIPTION
Whenever the `releasever` substitution variable is set, automatically derive and set the `releasever_major` and `releasever_minor` vars by splitting `releasever` on the first ".".

Companion to the DNF 5 implementation here: https://github.com/rpm-software-management/dnf5/pull/800. This implementation is kept similar to the implementation in DNF 5, including the caveat/potentially breaking change that setting a substitution variable can now raise an exception. If we don't want to raise an error, a simple solution would be simply to allow setting of `$releasever_major` and `$releasever_minor` and take out the `ReadOnlyVariableError`.

DNF 5 issue: https://github.com/rpm-software-management/dnf5/issues/710

For https://bugzilla.redhat.com/show_bug.cgi?id=1789346, but merging this does not close the bug yet; the shell-style variable expansion still needs to be implemented.