### PR TITLE
Does not print Verify: package (RhBug:1908253)

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1180,7 +1180,7 @@ class Base(object):
 
         # sync up what just happened versus what is in the rpmdb
         if not self._ts.isTsFlagSet(rpm.RPMTRANS_FLAG_TEST):
-            self._verify_transaction(cb.verify_tsi_package)
+            self._verify_transaction()
 
         return tid
 


### PR DESCRIPTION
It was replace by RPM transaction item return code and it only prints a message to terminal. It was not remove to keep compatibility of outputs, but it does nothing.

https://bugzilla.redhat.com/show_bug.cgi?id=1908253