### PR TITLE
comps: Fix marking a group package as installed (RhBug:2066638)

### DIFF
--- a/dnf/comps.py
+++ b/dnf/comps.py
@@ -673,8 +673,9 @@ class Solver(object):
             raise CompsError(_("Group id '%s' does not exist.") % ucd(group_id))
 
         swdb_group = self.history.group.new(group_id, comps_group.name, comps_group.ui_name, pkg_types)
-        for i in comps_group.packages_iter():
-            swdb_group.addPackage(i.name, False, Package._OPT_MAP[i.type])
+        for pkg in comps_group.packages_iter():
+            pkg_installed = self.history.swdb.getPackageCompsGroups(pkg.name) != ()
+            swdb_group.addPackage(pkg.name, pkg_installed, Package._OPT_MAP[pkg.type])
         self.history.group.install(swdb_group)
 
         trans = TransactionBunch()
@@ -712,8 +713,9 @@ class Solver(object):
 
         # create a new record for current transaction
         swdb_group = self.history.group.new(group_id, comps_group.name, comps_group.ui_name, pkg_types)
-        for i in comps_group.packages_iter():
-            swdb_group.addPackage(i.name, False, Package._OPT_MAP[i.type])
+        for pkg in comps_group.packages_iter():
+            pkg_installed = self.history.swdb.getPackageCompsGroups(pkg.name) != ()
+            swdb_group.addPackage(pkg.name, pkg_installed, Package._OPT_MAP[pkg.type])
         self.history.group.upgrade(swdb_group)
 
         trans = TransactionBunch()


### PR DESCRIPTION
When a new group is being installed or an installed group is upgraded, do not mark the packages within the group as 'not installed' directly. Instead, check the actual package state in the database to determine if it was already installed by another group.

CI test: https://github.com/rpm-software-management/ci-dnf-stack/pull/1389.
Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2066638.