### PR TITLE
distro-sync: Print better info message when no match

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -2250,7 +2250,7 @@ class Base(object):
             sltrs = subject._get_best_selectors(self, solution=solution,
                                                 obsoletes=self.conf.obsoletes, reports=True)
             if not sltrs:
-                logger.info(_('No package %s installed.'), pkg_spec)
+                logger.info(_('No match for argument: %s'), pkg_spec)
                 return 0
             for sltr in sltrs:
                 self._goal.distupgrade(select=sltr)


### PR DESCRIPTION
If the package specified in the argument is installed but is not available in the currently enabled repositories, distro-sync will print an error when excluding the system repository.

System repo excluding was originally added here: https://github.com/rpm-software-management/dnf/pull/1148.

The originally posted fix was to simply revert the commit mentioned above (drop filtering the packages from system repo) as it was assumed as only an "optimization" change.

With regard to the comments mentioned below, the simplest and most straightforward solution, without breaking any existing workflow, is to improve the error message. The content of the message itself is also the main problem reported by the user in the linked ticket below.

CI tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1390.
Resolves: https://issues.redhat.com/browse/RHEL-7018.