### PR TITLE
Drop --timer from ExecStart in dnf-makecache.service

### DIFF
--- a/etc/systemd/dnf-makecache.service
+++ b/etc/systemd/dnf-makecache.service
@@ -13,4 +13,4 @@ Nice=19
 IOSchedulingClass=2
 IOSchedulingPriority=7
 Environment="ABRT_IGNORE_PYTHON=1"
-ExecStart=/usr/bin/dnf makecache --timer
+ExecStart=/usr/bin/dnf makecache


### PR DESCRIPTION
Through various trial and error, I have found this to be the simplest solution to the issue reported.  The --timer option restricts makecache to a short execution window, errors be damned.  The problem reported is that 'dnf makecache' when run by systemd will fail if one of the mirrors causes a libcurl error.  The report notes the failure is an expired certificate, but it can also happen if DNS lookups fail. The problem does not show up when run at the command line.  The only noticable difference between the two execution modes is the use of --timer in the systemd unit file.  Removing that causes makecache to complete [as best as possible] in one execution run.

Resolves: RHEL-1342