### PR TITLE
Dnf automatic email on error

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -68,6 +68,7 @@ DNF CONTRIBUTORS
     Christopher Meng <cickumqt@gmail.com>
     Daniel Mach <dmach@redhat.com>
     Dave Johansen <davejohansen@gmail.com>
+    Derick Diaz <derickdiaz123@outlook.com>
     Dominik Mierzejewski <dominik@greysector.net>
     Dylan Pindur <dylanpindur@gmail.com>
     Eduard Cuba <ecuba@redhat.com>

--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -230,6 +230,7 @@ class EmittersConfig(Config):
             libdnf.conf.VectorString(['email', 'stdio'])))
         self.add_option('output_width', libdnf.conf.OptionNumberInt32(80))
         self.add_option('system_name', libdnf.conf.OptionString(socket.gethostname()))
+        self.add_option('send_error_messages', libdnf.conf.OptionBool(False))
 
 
 def gpgsigcheck(base, pkgs):
@@ -367,13 +368,10 @@ def main(args):
                (conf.commands.reboot == 'when-needed' and base.reboot_needed())):
                 exit_code = os.waitstatus_to_exitcode(os.system(conf.commands.reboot_command))
                 if exit_code != 0:
-                    logger.error('Error: reboot command returned nonzero exit code: %d', exit_code)
-                    emitters.notify_error('Error: reboot command returned nonzero exit code: %d', exit_code)
-                    emitters.commit()
-                    return 1
+                    raise dnf.exceptions.Error('reboot command returned nonzero exit code: %d', exit_code)
     except dnf.exceptions.Error as exc:
         logger.error(_('Error: %s'), ucd(exc))
-        if conf.emitters != None:
+        if conf.emitters.send_error_messages and emitters != None:
             emitters.notify_error(_('Error: %s') % str(exc))
             emitters.commit()
         return 1

--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -373,8 +373,9 @@ def main(args):
                     return 1
     except dnf.exceptions.Error as exc:
         logger.error(_('Error: %s'), ucd(exc))
-        emitters.notify_error(_('Error: %s') % str(exc))
-        emitters.commit()
+        if conf.emitters != None:
+            emitters.notify_error(_('Error: %s') % str(exc))
+            emitters.commit()
         return 1
     return 0
 

--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -305,6 +305,7 @@ def main(args):
     try:
         conf = AutomaticConfig(opts.conf_path, opts.downloadupdates,
                                opts.installupdates)
+        emitters = None
         with dnf.Base() as base:
             cli = dnf.cli.Cli(base)
             cli._read_conf_file()
@@ -367,9 +368,13 @@ def main(args):
                 exit_code = os.waitstatus_to_exitcode(os.system(conf.commands.reboot_command))
                 if exit_code != 0:
                     logger.error('Error: reboot command returned nonzero exit code: %d', exit_code)
+                    emitters.notify_error('Error: reboot command returned nonzero exit code: %d', exit_code)
+                    emitters.commit()
                     return 1
     except dnf.exceptions.Error as exc:
         logger.error(_('Error: %s'), ucd(exc))
+        emitters.notify_error(_('Error: %s') % str(exc))
+        emitters.commit()
         return 1
     return 0
 

--- a/doc/automatic.rst
+++ b/doc/automatic.rst
@@ -120,6 +120,11 @@ Choosing how the results should be reported.
 
     How the system is called in the reports.
 
+``send_error_messages``
+    boolean, default: False
+
+    Invokes emitters when an errors occurs
+
 ---------------------
 ``[command]`` section
 ---------------------

--- a/doc/automatic.rst
+++ b/doc/automatic.rst
@@ -123,7 +123,7 @@ Choosing how the results should be reported.
 ``send_error_messages``
     boolean, default: False
 
-    Invokes emitters when an errors occurs
+    Invokes emitters when an error occurs.
 
 ---------------------
 ``[command]`` section


### PR DESCRIPTION
The changes implemented in this PR are for: https://github.com/rpm-software-management/dnf/issues/1918

The changes allows the emitters to invoke when a DNF error occurs. I tested this out by setting the email_via = command_email and command_format = "echo {subject} {body} > /tmp/dnf_error" in the /etc/dnf/automatic.conf file. When I removed by GPG keys from the enabled repositories and run the def-automatic command it created the error file with the error description.