### PR TITLE
automatic: Fix applying the color option

### DIFF
--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -73,7 +73,7 @@ class Output(object):
     def __init__(self, base, conf):
         self.conf = conf
         self.base = base
-        self.term = dnf.cli.term.Term()
+        self.term = dnf.cli.term.Term(color=base.conf.color)
         self.progress = None
 
     def _banner(self, col_data, row):


### PR DESCRIPTION
The `color` option value wasn't passed in `dnf-automatic` usage so far.

In the standard `dnf` command, the `Term` object is created before parsing the entire configuration, including command-line parameters. The `Term` is reinitialized within `Cli.configure` if the `color` option value was changed. In `dnf-automatic`, where configuration is processed in a single place, we can directly pass the value from the configuration.

This is a follow-up to the #2003.