### PR TITLE
repoquery: Do not translate time format strings (RhBz: 2245773)

### DIFF
--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -721,8 +721,7 @@ class PackageWrapper(object):
     def _get_timestamp(timestamp):
         if timestamp > 0:
             dt = datetime.datetime.utcfromtimestamp(timestamp)
-            # TRANSLATORS: This is the default time format for dnf repoquery.
-            return dt.strftime(_("%Y-%m-%d %H:%M"))
+            return dt.strftime("%Y-%m-%d %H:%M")
         else:
             return ''
 


### PR DESCRIPTION
Given that the `--queryformat` option is commonly used to generate
machine-readable outputs from repoquery, we should ensure that the
output remains stable regardless of the locale used.

This partially reverts commit 1daf3467e60bbd54998cab79bcabe4e3a8d4d153.

= changelog =
msg:           Do not translate repoquery time format strings
type:          bugfix
resolves:      https://bugzilla.redhat.com/show_bug.cgi?id=2245773