### PR TITLE
Fix parsing PGP keys for DNS validation

### DIFF
--- a/dnf/dnssec.py
+++ b/dnf/dnssec.py
@@ -275,7 +275,16 @@ class RpmImportedKeys:
             packager = dnf.rpm.getheader(pkg, 'packager')
             email = re.search('<(.*@.*)>', packager).group(1)
             description = dnf.rpm.getheader(pkg, 'description')
-            key_lines = description.split('\n')[3:-3]
+            # Extract Radix-64-encoded PGP key. Without armor headers and
+            # a checksum.
+            key_lines = []
+            in_headers = True
+            for line in description.split('\n')[0:-3]:
+                if in_headers:
+                    if re.match(r'\A\s*\Z', line, re.NOFLAG):
+                        in_headers = False
+                else:
+                    key_lines.append(line)
             key_str = ''.join(key_lines)
             return_list += [KeyInfo(email, key_str.encode('ascii'))]
 

--- a/dnf/dnssec.py
+++ b/dnf/dnssec.py
@@ -150,7 +150,7 @@ class DNSSECKeyVerification:
         if key_union == input_key_string:
             logger.debug("Cache hit, valid key")
             return Validity.VALID
-        elif key_union is NoKey:
+        elif isinstance(key_union, NoKey):
             logger.debug("Cache hit, proven non-existence")
             return Validity.PROVEN_NONEXISTENCE
         else:


### PR DESCRIPTION
Fedora 39 slightly changed an armor format of PGP keys and as a result if gpgkey_dns_verification=true, DNF warned that Fedora 39 key is revoked. See <https://bugzilla.redhat.com/show_bug.cgi?id=2249380>. That's fixed with the first commit.

When I tried to reproduce it, I actually got a crash because an old Fedora 13 I still has imported had no e-mail address. The crash is addressed in the second commit.