### PR TITLE
Add a hint for user on transaction file dependency failure

### DIFF
--- a/dnf/cli/main.py
+++ b/dnf/cli/main.py
@@ -149,6 +149,13 @@ def cli_run(cli, base):
                     else:
                         msg += _(" or '{}' to use not only best candidate packages").format(
                             "--nobest")
+            if base._goal.file_dep_problem_present() and 'filelists' not in cli.base.conf.optional_metadata_types:
+                if not msg:
+                    msg += _("try to add '{}' to load additional filelists metadata").format(
+                        "--setopt=optional_metadata_types=filelists")
+                else:
+                    msg += _(" or '{}' to load additional filelists metadata").format(
+                        "--setopt=optional_metadata_types=filelists")
             if msg:
                 logger.info("({})".format(msg))
             raise


### PR DESCRIPTION
Print a hint when resolving a transaction results in an error due to a file dependency and filelists were not loaded for all enabled repositories.

Requires: 
- https://github.com/rpm-software-management/libdnf/pull/1635
- https://github.com/rpm-software-management/libdnf/pull/1637
- https://github.com/rpm-software-management/dnf/pull/2012

Targetted for: https://issues.redhat.com/browse/RHEL-12355.