### PR TITLE
[dnf-automatic] Add in options for includepkgs and excludepkgs

### DIFF
--- a/tests/automatic/test_main.py
+++ b/tests/automatic/test_main.py
@@ -39,6 +39,11 @@ class TestConfig(tests.support.TestCase):
         self.assertEqual(conf.commands.random_sleep, 300)
         self.assertEqual(conf.email.email_from, 'staring@crowd.net')
 
+        # test includepkg and excludepkgs
+        conf = dnf.automatic.main.AutomaticConfig(FILE)
+        self.assertEqual(list(conf.commands.includepkgs), ["dnf","dnf-automatic"])
+        self.assertEqual(list(conf.commands.excludepkgs), ["gtk3","gtk3-immodule-xim"])
+
         # test overriding installupdates
         conf = dnf.automatic.main.AutomaticConfig(FILE, installupdates=False)
         # as per above, download is set false in config

--- a/tests/etc/automatic.conf
+++ b/tests/etc/automatic.conf
@@ -2,6 +2,8 @@
 update_cmd = default
 download_updates = no
 apply_updates = yes
+includepkgs = dnf,dnf-automatic
+excludepkgs = gtk3,gtk3-immodule-xim
 
 [email]
 email_from = staring@crowd.net


### PR DESCRIPTION
This option adds in includepks and excludepkgs so we can specify a list we wanted updated or explicitly excluded from automatic updates. This bring automatic more inline with some of dnf-conf's options without having to tamper with it 