### PR TITLE
Update docs due to dropping filelists metadata by default

### DIFF
--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -433,10 +433,7 @@ configuration file by your distribution to override the DNF defaults.
 
     Note that the list can be extended by individual commands to explicitly request loading specific metadata type.
 
-    Currently only ``filelists`` value is supported. Default is ``filelists``.
-
-..
-    # TODO(jkolarik): Change the default to an empty list when dropping the filelists for Fedora 40
+    Currently only ``filelists`` value is supported. Default is an empty list.
 
 .. _persistdir-label:
 

--- a/doc/user_faq.rst
+++ b/doc/user_faq.rst
@@ -144,3 +144,10 @@ Then, when you want to include the packages from the rawhide repo, execute a DNF
 .. note::
 
     Installing rawhide packages onto a stable Fedora release system is generally discouraged as it leads to less tested combinations of installed packages. Please consider this step carefully.
+
+Starting with Fedora 40, I noticed repository metadata is synchronized much faster. What happened?
+===================================================================================================
+
+This is because filelists metadata is no longer downloaded by default. This change is associated with the Fedora system-wide `change <https://fedoraproject.org/wiki/Changes/DNFConditionalFilelists>`_, and the related `change <https://pagure.io/packaging-committee/pull-request/1321>`_ in the Fedora packaging guidelines policy, which specifies that packages must not rely on filepath dependencies requiring filelists metadata.
+
+All Fedora packages have been adjusted to align with this updated behavior, and users don't need to take any additional action. If you encounter any issues, such as non-compliance from a third-party package or if you prefer filelists metadata to be consistently downloaded, you can configure it using the :ref:`optional_metadata_types <optional_metadata_types-label>` configuration option.


### PR DESCRIPTION
Documentation updates:
- Change optional metadata types configuration default to an empty list
- Add a FAQ entry about the new filelists behavior

Based on the https://fedoraproject.org/wiki/Changes/DNFConditionalFilelists.

Requires: https://github.com/rpm-software-management/libdnf/pull/1642.
Targetted for: https://issues.redhat.com/browse/RHEL-12355.