### PR TITLE
automatic: Use add_security_filters, not _update_security_filters

### DIFF
--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -380,8 +380,7 @@ def main(args):
 
 def upgrade(base, upgrade_type):
     if upgrade_type == 'security':
-        base._update_security_filters.append(base.sack.query().upgrades().filterm(
-            advisory_type='security'))
+        base.add_security_filters("gte", ("security",))
         base.upgrade_all()
     elif upgrade_type == 'default':
         base.upgrade_all()


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/RHEL-21874

It seems that selecting security updates with 

```
base._update_security_filters.append(base.sack.query().upgrades().filterm(
    advisory_type='security'))
```

sometimes results in a bad transaction. The regular `dnf update` command uses `base.add_security_filters` to select security updates, so dnf-automatic should do the same.