### PR TITLE
Fix unload plugins behavior without filelists

### DIFF
--- a/dnf/plugin.py
+++ b/dnf/plugin.py
@@ -29,6 +29,7 @@ import inspect
 import logging
 import operator
 import os
+import rpm
 import sys
 import traceback
 
@@ -193,7 +194,7 @@ class Plugins(object):
 
         # check whether removed plugin file is added at the same time (upgrade of a plugin)
         for pkg in transaction.install_set:
-            erased_plugin_files.difference_update(pkg.files)
+            erased_plugin_files.difference_update(pkg._header[rpm.RPMTAG_FILENAMES])
 
         # unload plugins that were removed in transaction
         for plugin_file in erased_plugin_files:


### PR DESCRIPTION
For packages originating outside the System repository, we don't populate the `pkg.files` when running without filelists metadata. Use RPM database as a source instead.

This fixes the CI failing scenario "Moving plugin between subpackages is not considered removal of plugin" which  broke due to changes introduced in https://github.com/rpm-software-management/libdnf/pull/1642.

Related:
- https://github.com/rpm-software-management/dnf/pull/1732