### PR TITLE
history: Keep reinstall action when reverting merged transaction items

### DIFF
--- a/dnf/cli/commands/history.py
+++ b/dnf/cli/commands/history.py
@@ -220,7 +220,7 @@ class HistoryCommand(commands.Command):
             "Downgrade": "Upgraded",
             "Downgraded": "Upgrade",
             "Reinstalled": "Reinstall",
-            "Reinstall": "Reinstalled",
+            "Reinstall": "Reinstall",
             "Obsoleted": "Install",
             "Obsolete": "Obsoleted",
             "Reason Change": "Reason Change",


### PR DESCRIPTION
When we have a sequence of transactions involving the reinstallation, upgrading, or downgrading of a package, which ultimately results in the package remaining at the same version, the expected behavior, when reverting the entire merged transaction, is that the package is reinstalled. This differs from the previous behavior, where the package would be removed from the system.

Resolves: https://issues.redhat.com/browse/RHEL-17494
Closes: https://github.com/rpm-software-management/dnf/issues/2031