### PR TITLE
Add required `.readthedocs.yaml`, `conf.py` and set `sphinx_rtd_theme`

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+  jobs:
+    pre_build:
+      - cp doc/conf.py.in doc/conf.py
+
+sphinx:
+  configuration: doc/conf.py
+
+python:
+   install:
+   - requirements: doc/requirements.txt

--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -94,7 +94,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,1 @@
+sphinx_rtd_theme


### PR DESCRIPTION
RTD no longer automatically generates config files.

The `.readthedocs.yaml` is now required: https://blog.readthedocs.com/migrate-configuration-v2/

The `conf.py` for Sphinx is also required: https://blog.readthedocs.com/doctool-without-configuration-file/
- The previously automatically generated `conf.py` contained `sphinx_rtd_theme` -> in order to keep it we have to set it and add it as a requirement.
- The version field in `conf.py.in` remains uncofigured but I don't think it is a problem because it doesn't shows up in the html docs.

This fixes the currently failing dnf doc building.