### PR TITLE
Add detection for ostree-based systems and warn users about losing changes

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -214,6 +214,15 @@ class BaseCli(dnf.Base):
             elif 'test' in self.conf.tsflags:
                 logger.info(_("{prog} will only download packages, install gpg keys, and check the "
                               "transaction.").format(prog=dnf.util.MAIN_PROG_UPPER))
+            if dnf.util.is_container():
+                _container_msg = _("""
+*** This system is managed with ostree.  Changes to the system
+*** made with dnf will be lost with the next ostree-based update.
+*** If you do not want to lose these changes, use 'rpm-ostree'.
+""")
+                logger.info(_container_msg)
+                raise CliError(_("Operation aborted."))
+
             if self._promptWanted():
                 if self.conf.assumeno or not self.output.userconfirm():
                     raise CliError(_("Operation aborted."))


### PR DESCRIPTION
On ostree-based systems, users can use dnf to customize the environment but those changes will be lost at the next ostree-based image update.  If you want to retain changes between ostree-updates you need to make use of rpm-ostree right now.

All this patch does is add a function to detect systems managed this way and present warnings before dnf operations that modify the system.  I display the warning at the beginning of the output, but maybe that should be after any other output is on the display.