### PR TITLE
Drop dnf obsoletion temporarily

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -12,7 +12,7 @@
 %global conflicts_dnf_plugins_extras_version 4.0.4
 %global conflicts_dnfdaemon_version 0.3.19
 
-%bcond dnf5_obsoletes_dnf %[0%{?fedora} > 40 || 0%{?rhel} > 10]
+%bcond dnf5_obsoletes_dnf %[0%{?fedora} > 41 || 0%{?rhel} > 10]
 
 # override dependencies for rhel 7
 %if 0%{?rhel} == 7


### PR DESCRIPTION
To allow us and others to prepare for switching dnf5 as the default in Rawhide.