### PR TITLE
build: Adapt to changes in Fedora packaging of bash-completion

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -79,7 +79,11 @@ BuildRequires:  cmake
 BuildRequires:  gettext
 # Documentation
 BuildRequires:  systemd
+%if 0%{?fedora} > 40 || 0%{?rhel} > 10
+BuildRequires:  bash-completion-devel
+%else
 BuildRequires:  bash-completion
+%endif
 BuildRequires:  %{_bindir}/sphinx-build-3
 Requires:       python3-%{name} = %{version}-%{release}
 %if 0%{?rhel} && 0%{?rhel} <= 7


### PR DESCRIPTION
Based on: https://github.com/rpm-software-management/dnf5/pull/1254.
See also: https://github.com/rpm-software-management/dnf5/issues/1252.