### PR TITLE
Prepare man pages for switch to dnf5 as the default package manager

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -8,7 +8,7 @@
 %global rpm_version 4.14.0
 
 # conflicts
-%global conflicts_dnf_plugins_core_version 4.0.26
+%global conflicts_dnf_plugins_core_version 4.7.0
 %global conflicts_dnf_plugins_extras_version 4.0.4
 %global conflicts_dnfdaemon_version 0.3.19
 
@@ -226,6 +226,11 @@ ln -sr %{buildroot}%{_bindir}/dnf-3 %{buildroot}%{_bindir}/dnf
 ln -sr %{buildroot}%{_bindir}/dnf-3 %{buildroot}%{_bindir}/dnf4
 ln -sr %{buildroot}%{_datadir}/bash-completion/completions/dnf-3 %{buildroot}%{_datadir}/bash-completion/completions/dnf4
 ln -sr %{buildroot}%{_datadir}/bash-completion/completions/dnf-3 %{buildroot}%{_datadir}/bash-completion/completions/dnf
+for file in %{buildroot}%{_mandir}/man[578]/dnf4[-.]*; do
+    dir=$(dirname $file)
+    filename=$(basename $file)
+    ln -sr $file $dir/${filename/dnf4/dnf}
+done
 mv %{buildroot}%{_bindir}/dnf-automatic-3 %{buildroot}%{_bindir}/dnf-automatic
 rm -vf %{buildroot}%{_bindir}/dnf-automatic-*
 
@@ -248,6 +253,7 @@ ln -sr  %{buildroot}%{confdir}/vars %{buildroot}%{_sysconfdir}/yum/vars
 
 %if %{with dnf5_obsoletes_dnf}
 rm %{buildroot}%{confdir}/%{name}.conf
+rm %{buildroot}%{_mandir}/man5/%{name}.conf.5*
 %endif
 
 %check
@@ -319,7 +325,10 @@ popd
 %ghost %attr(644,-,-) %{_sharedstatedir}/%{name}/groups.json
 %ghost %attr(755,-,-) %dir %{_sharedstatedir}/%{name}/yumdb
 %ghost %attr(755,-,-) %dir %{_sharedstatedir}/%{name}/history
+%{_mandir}/man5/%{name}4.conf.5*
+%if %{without dnf5_obsoletes_dnf}
 %{_mandir}/man5/%{name}.conf.5*
+%endif
 %{_tmpfilesdir}/%{name}.conf
 %{_sysconfdir}/libreport/events.d/collect_dnf.conf
 
@@ -373,6 +382,9 @@ popd
 %dir %{_datadir}/bash-completion/completions
 %{_datadir}/bash-completion/completions/%{name}-3
 %{_datadir}/bash-completion/completions/%{name}4
+%{_mandir}/man8/%{name}4.8*
+%{_mandir}/man7/dnf4.modularity.7*
+%{_mandir}/man5/dnf4-transaction-json.5*
 %exclude %{python3_sitelib}/%{name}/automatic
 %{python3_sitelib}/%{name}-*.dist-info
 %{python3_sitelib}/%{name}/

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -20,18 +20,18 @@ ADD_CUSTOM_TARGET (doc)
 ADD_DEPENDENCIES (doc doc-html doc-man)
 
 if (NOT WITH_MAN EQUAL 0)
-    INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/dnf.8
+    INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/dnf4.8
               ${CMAKE_CURRENT_BINARY_DIR}/dnf-automatic.8
               ${CMAKE_CURRENT_BINARY_DIR}/yum2dnf.8
               ${CMAKE_CURRENT_BINARY_DIR}/yum.8
               ${CMAKE_CURRENT_BINARY_DIR}/yum-shell.8
               DESTINATION share/man/man8)
-    INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/dnf.conf.5
+    INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/dnf4.conf.5
               ${CMAKE_CURRENT_BINARY_DIR}/yum.conf.5
-              ${CMAKE_CURRENT_BINARY_DIR}/dnf-transaction-json.5
+              ${CMAKE_CURRENT_BINARY_DIR}/dnf4-transaction-json.5
               DESTINATION share/man/man5)
     INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/yum-aliases.1
               DESTINATION share/man/man1)
-    INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/dnf.modularity.7
+    INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/dnf4.modularity.7
               DESTINATION share/man/man7)
 endif()

--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -218,13 +218,13 @@ latex_documents = [
 man_pages = [
     ('automatic', 'dnf-automatic', u'DNF Automatic',
      AUTHORS, 8),
-    ('command_ref', 'dnf', u'DNF Command Reference',
+    ('command_ref', 'dnf4', u'DNF Command Reference',
      AUTHORS, 8),
-    ('conf_ref', 'dnf.conf', u'DNF Configuration Reference',
+    ('conf_ref', 'dnf4.conf', u'DNF Configuration Reference',
      AUTHORS, 5),
     ('conf_ref', 'yum.conf', u'redirecting to DNF Configuration Reference',
      AUTHORS, 5),
-    ('transaction_json', 'dnf-transaction-json', u'DNF Stored Transaction JSON',
+    ('transaction_json', 'dnf4-transaction-json', u'DNF Stored Transaction JSON',
      AUTHORS, 5),
     ('cli_vs_yum', 'yum2dnf', u'Changes in DNF compared to YUM',
      AUTHORS, 8),
@@ -234,7 +234,7 @@ man_pages = [
      AUTHORS, 8),
     ('command_ref', 'yum-aliases', u'redirecting to DNF Command Reference',
      AUTHORS, 1),
-    ('modularity', 'dnf.modularity', u'Modularity in DNF',
+    ('modularity', 'dnf4.modularity', u'Modularity in DNF',
      AUTHORS, 7),
 ]
 


### PR DESCRIPTION
For: https://bugzilla.redhat.com/show_bug.cgi?id=2216850.

Requires:
- https://github.com/rpm-software-management/dnf5/pull/1366
- https://github.com/rpm-software-management/dnf-plugins-core/pull/529

Related:
- https://github.com/rpm-software-management/dnf5/issues/1057

Closes:
- https://github.com/rpm-software-management/dnf/issues/1965