### PR TITLE
Do not add user site-packages directory to sys.path (RHEL-26646)

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -250,6 +250,16 @@ ln -sr  %{buildroot}%{confdir}/vars %{buildroot}%{_sysconfdir}/yum/vars
 rm %{buildroot}%{confdir}/%{name}.conf
 %endif
 
+%if 0%{?fedora} >= 41 || 0%{?rhel} >= 10
+# Don't add -P to Python shebangs
+# The executable Python scripts import each other
+%undefine _py3_shebang_P
+
+%py3_shebang_fix %{buildroot}%{_bindir}/dnf-3
+%py3_shebang_fix %{buildroot}%{_bindir}/dnf-automatic
+%py3_shebang_fix %{buildroot}%{python3_sitelib}/%{name}/cli/completion_helper.py
+%endif
+
 %check
 
 pushd build-py3


### PR DESCRIPTION
Adds `-s` to shebang lines.
The `-s` flag ensures that the user’s Python packages (e.g. installed by `pip install --user`) don’t interfere with the RPM installed software.
According to Fedora Python Packaging Guidelines, the flag is added using `%py3_shebang_fix` macro.

Note:
DNF supports plugins. There is a risk that the change will break a custom plugins that require something from PIP.
Therefore, the change is only in the .spec file and is only allowed for Fedora >= 41 and RHEL >= 10.