### PR TITLE
Remove --duplicates and --oldinstallonly exit with 0 when nothing to remove (RHEL-6424)

### DIFF
--- a/dnf/cli/commands/remove.py
+++ b/dnf/cli/commands/remove.py
@@ -124,8 +124,7 @@ class RemoveCommand(commands.Command):
                 for pkg in instonly:
                     self.base.package_remove(pkg)
             else:
-                raise dnf.exceptions.Error(
-                    _('No old installonly packages found for removal.'))
+                logger.info(_('No old installonly packages found for removal.'))
             return
 
         # Remove groups.

--- a/dnf/cli/commands/remove.py
+++ b/dnf/cli/commands/remove.py
@@ -92,7 +92,8 @@ class RemoveCommand(commands.Command):
             instonly = self.base._get_installonly_query(q.installed())
             dups = q.duplicated().difference(instonly)
             if not dups:
-                raise dnf.exceptions.Error(_('No duplicated packages found for removal.'))
+                logger.info(_('No duplicated packages found for removal.'))
+                return
 
             for (name, arch), pkgs_list in dups._na_dict().items():
                 if len(pkgs_list) < 2:


### PR DESCRIPTION
If no duplicates or no old installonly packages are present, then the command successfully removed all duplicates and should exit with 0 and write the message to stdout instead of stderr.

Resolves: https://issues.redhat.com/browse/RHEL-6424

Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1481