### PR TITLE
repoquery: Fix loading filelists when -f is used (RhBug:2276012)

### DIFF
--- a/dnf/cli/commands/repoquery.py
+++ b/dnf/cli/commands/repoquery.py
@@ -327,7 +327,7 @@ class RepoQueryCommand(commands.Command):
         if self.opts.querychangelogs:
             demands.changelogs = True
 
-        if self.opts.queryfilelist or dnf.util._is_file_pattern_present(self.opts.key):
+        if self.opts.queryfilelist or self.opts.file or dnf.util._is_file_pattern_present(self.opts.key):
             self.base.conf.optional_metadata_types += ["filelists"]
 
     def build_format_fn(self, opts, pkg):


### PR DESCRIPTION
When `-f` option is used, the argument is stored in the `opts.file` instead of the `opts.key`. We need to load filelists also in this case.

Note: this is working correctly in dnf5.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2276012
Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1488