### PR TITLE
Fixes for RHEL-15902

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -815,9 +815,11 @@ class Base(object):
         if erasures:
             remaining_installed_query = self.sack.query(flags=hawkey.IGNORE_EXCLUDES).installed()
             remaining_installed_query.filterm(pkg__neq=erasures)
+            remaining_installed_query.apply()
             for pkg in erasures:
-                if remaining_installed_query.filter(name=pkg.name):
-                    remaining = remaining_installed_query[0]
+                tmp_remaining_installed_query = remaining_installed_query.filter(name=pkg.name, arch=pkg.arch)
+                if tmp_remaining_installed_query:
+                    remaining = tmp_remaining_installed_query[0]
                     ts.get_reason(remaining)
                     self.history.set_reason(remaining, ts.get_reason(remaining))
                 self._ds_callback.pkg_added(pkg, 'e')

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -795,8 +795,8 @@ transactions and act according to this information (assuming the
     the current state of RPMDB, it will not undo the transaction.
 
 ``dnf history userinstalled``
-    Show all installonly packages, packages installed outside of DNF and packages not
-    installed as dependency. I.e. it lists packages that will stay on the system when
+    Show all packages installed by user, installed from a group or a module profile, and packages
+    installed outside of DNF. I.e. it lists packages that will stay on the system when
     :ref:`\autoremove_command-label` or :ref:`\remove_command-label` along with
     `clean_requirements_on_remove` configuration option set to True is executed. Note the same
     results can be accomplished with ``dnf repoquery --userinstalled``, and the repoquery

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -501,9 +501,6 @@ Autoremove Command
 
     Removes all "leaf" packages from the system that were originally installed as dependencies of user-installed packages, but which are no longer required by any such package.
 
-Packages listed in :ref:`installonlypkgs <installonlypkgs-label>` are never automatically removed by
-this command.
-
 ``dnf [options] autoremove <spec>...``
 
     This is an alias for the :ref:`\remove_command-label` command with clean_requirements_on_remove set to

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -499,7 +499,7 @@ Autoremove Command
 
 ``dnf [options] autoremove``
 
-    Removes all "leaf" packages from the system that were originally installed as dependencies of user-installed packages, but which are no longer required by any such package.
+    Removes all packages from the system that were originally installed as dependencies of user-installed packages, but which are no longer required by any such package.
 
 ``dnf [options] autoremove <spec>...``
 


### PR DESCRIPTION
Upstream commit: a4d815e4df87f5afbae9d37c7faf6a9871d50b53
Upstream commit: 824a95e1786b460102d9bf4a2cec0ce7973f882e
Upstream commit: a6d4cd745ce27c09d6cdb4302177b2bfed600549
Upstream commit: 929d9133971b53eabfd65d989ded0de8f72f95ea
Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1496
Resolves: https://issues.redhat.com/browse/RHEL-15902

@j-mracek, please review this rhel-9.5 backport of your commits resolving RHEL-15902.