### PR TITLE
Install module package IDs on `module enable`

### DIFF
--- a/dnf/module/module_base.py
+++ b/dnf/module/module_base.py
@@ -434,12 +434,12 @@ class ModuleBase(object):
                 for key in sorted(streamDict.keys()):
                     if key == stream:
                         if enable:
-                            self.base._moduleContainer.enable(moduleName, key)
+                            self.base._moduleContainer.enable(moduleName, key, streamDict[key])
                         continue
                     del streamDict[key]
             elif enable:
                 for key in streamDict.keys():
-                    self.base._moduleContainer.enable(moduleName, key)
+                    self.base._moduleContainer.enable(moduleName, key, streamDict[key])
             assert len(streamDict) == 1
         return moduleDict
 


### PR DESCRIPTION
Module packages should be explicitly specified when enabling modules.

This is the dnf companion to https://github.com/rpm-software-management/libdnf/pull/1656.

For https://issues.redhat.com/browse/RHEL-16580.

Currently a draft since tests are failing.