### PR TITLE
Fix: No traceback when Python interpreter is running with `-P`, allow `-P` in shebang lines

### DIFF
--- a/bin/dnf-automatic.in
+++ b/bin/dnf-automatic.in
@@ -27,10 +27,6 @@ if here == '/usr/bin':
     # we never import Python modules from /usr/bin
     # removing this lowers the risk of accidental imports of weird files
     del sys.path[0]
-else:
-    # git checkout
-    dnf_toplevel = os.path.dirname(here)
-    sys.path[0] = dnf_toplevel
 
 import dnf.automatic.main
 sys.exit(dnf.automatic.main.main(sys.argv[1:]))

--- a/bin/dnf.in
+++ b/bin/dnf.in
@@ -52,11 +52,6 @@ if here == '/usr/bin':
     # we never import Python modules from /usr/bin
     # removing this lowers the risk of accidental imports of weird files
     del sys.path[0]
-else:
-    # git checkout
-    import os
-    dnf_toplevel = os.path.dirname(here)
-    sys.path[0] = dnf_toplevel
 
 from dnf.cli import main
 main.user_main(sys.argv[1:], exit_code=True)

--- a/dnf.spec
+++ b/dnf.spec
@@ -257,10 +257,6 @@ rm %{buildroot}%{_mandir}/man5/%{name}.conf.5*
 %endif
 
 %if 0%{?fedora} >= 41 || 0%{?rhel} >= 10
-# Don't add -P to Python shebangs
-# The executable Python scripts import each other
-%undefine _py3_shebang_P
-
 %py3_shebang_fix %{buildroot}%{_bindir}/dnf-3
 %py3_shebang_fix %{buildroot}%{_bindir}/dnf-automatic
 %py3_shebang_fix %{buildroot}%{python3_sitelib}/%{name}/cli/completion_helper.py


### PR DESCRIPTION
Closes #2078 