### PR TITLE
man: Improve upgrade-minimal command docs (RHEL-6417)

### DIFF
--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -1759,11 +1759,11 @@ Upgrade-Minimal Command
 | Deprecated aliases: ``update-minimal``
 
 ``dnf [options] upgrade-minimal``
-    Updates each package to the latest available version that provides a bugfix, enhancement
-    or a fix for a security issue (security).
+    Updates each package to the nearest available version that provides
+    a bugfix, enhancement or a fix for a security issue (security).
 
 ``dnf [options] upgrade-minimal <package-spec>...``
-    Updates each specified package to the latest available version that provides
+    Updates each specified package to the nearest available version that provides
     a bugfix, enhancement or a fix for security issue (security). Updates
     dependencies as necessary.
 


### PR DESCRIPTION
Making the man pages for the `upgrade-minimal` command clearer about how packages with advisories are upgraded.

Resolves: https://issues.redhat.com/browse/RHEL-6417