### PR TITLE
rhel-9.5: automatic: Use add_security_filters, not _update_security_filters

### DIFF
--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -375,8 +375,7 @@ def main(args):
 
 def upgrade(base, upgrade_type):
     if upgrade_type == 'security':
-        base._update_security_filters.append(base.sack.query().upgrades().filterm(
-            advisory_type='security'))
+        base.add_security_filters("gte", ("security",))
         base.upgrade_all()
     elif upgrade_type == 'default':
         base.upgrade_all()


### PR DESCRIPTION
Upstream commit: 0b4b8cc8940a4073b33f1bb772651ae27e55f299
Resolves: https://issues.redhat.com/browse/RHEL-21874

@evan-goode, could you please review this rhel-9.5 backport of your commit?