### PR TITLE
rhel-9.5: man: Improve upgrade-minimal command docs (RHEL-6417)

### DIFF
--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -1761,11 +1761,11 @@ Upgrade-Minimal Command
 | Deprecated aliases: ``update-minimal``
 
 ``dnf [options] upgrade-minimal``
-    Updates each package to the latest available version that provides a bugfix, enhancement
-    or a fix for a security issue (security).
+    Updates each package to the nearest available version that provides
+    a bugfix, enhancement or a fix for a security issue (security).
 
 ``dnf [options] upgrade-minimal <package-spec>...``
-    Updates each specified package to the latest available version that provides
+    Updates each specified package to the nearest available version that provides
     a bugfix, enhancement or a fix for security issue (security). Updates
     dependencies as necessary.
 


### PR DESCRIPTION
Upstream commit: 4a2b425d3f0b7ea95f9584834e86a15ad3c447ab
Resolves: https://issues.redhat.com/browse/RHEL-6417

@jan-kolarik, could you please review this RHEL 9.5 backport of your commit which addresses RHEL-6417?