### PR TITLE
doc: minor formatting and consistency fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ If you want to build the manpages, use the option ``-DWITH_MAN=0`` with cmake.
 
 Man pages will be located in ``build/doc`` and can be read with ``man -l``, e.g::
 
-    man -l build/doc/dnf.8
+    man -l build/doc/dnf4.8
 
 =============================
  Building and installing rpm

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -165,7 +165,6 @@ Options
 .. _disableexcludes-label:
 
 ``--disableexcludes=[all|main|<repoid>], --disableexcludepkgs=[all|main|<repoid>]``
-
     Disable the configuration file excludes. Takes one of the following three options:
 
     * ``all``, disables all configuration file excludes
@@ -509,9 +508,9 @@ Autoremove Command
     package directly, or a ``@<group-spec>``, which specifies an (environment) group which contains
     it. It also removes any dependencies that are no longer needed.
 
-    There are also a few specific autoremove commands ``autoremove-n``, ``autoremove-na`` and
-    ``autoremove-nevra`` that allow the specification of an exact argument in the NEVRA
-    (name-epoch:version-release.architecture) format.
+There are also a few specific autoremove commands ``autoremove-n``, ``autoremove-na`` and
+``autoremove-nevra`` that allow the specification of an exact argument in the NEVRA
+(name-epoch:version-release.architecture) format.
 
 This command by default does not force a sync of expired metadata. See also :ref:`\metadata_synchronization-label`.
 
@@ -541,7 +540,6 @@ Check-Update Command
 
 
 ``dnf [options] check-update [--changelogs] [<package-file-spec>...]``
-
     Non-interactively checks if updates of the specified packages are available. If no ``<package-file-spec>`` is given, checks whether any updates at all are available for your system. DNF exit code will be 100 when there are updates available and a list of the updates will be printed, 0 if not and 1 if an error occurs. If ``--changelogs`` option is specified, also changelog delta of packages about to be updated is printed.
 
     Please note that having a specific newer version available for an installed package (and reported by ``check-update``) does not imply that subsequent ``dnf upgrade`` will install it. The difference is that ``dnf upgrade`` has restrictions (like package dependencies being satisfied) to take into account.
@@ -856,11 +854,11 @@ Install Command
     some older version is being obsoleted. It creates a split in the upgrade-path and both ways
     are considered correct, the resulting package is picked simply by lexicographical order.
 
-    There are also a few specific install commands ``install-n``, ``install-na`` and
-    ``install-nevra`` that allow the specification of an exact argument in the NEVRA format. As a consequence, <spec>
-    will be not matched with provides and file provides.
+There are also a few specific install commands ``install-n``, ``install-na`` and
+``install-nevra`` that allow the specification of an exact argument in the NEVRA format. As a consequence, <spec>
+will be not matched with provides and file provides.
 
-    See also :ref:`\configuration_files_replacement_policy-label`.
+See also :ref:`\configuration_files_replacement_policy-label`.
 
 .. _install_examples-label:
 
@@ -1152,7 +1150,7 @@ Provides Command
 
     4. If this last step also fails, DNF returns "Error: No Matches found".
 
-    This command by default does not force a sync of expired metadata. See also :ref:`\metadata_synchronization-label`.
+This command by default does not force a sync of expired metadata. See also :ref:`\metadata_synchronization-label`.
 
 .. _reinstall_command-label:
 
@@ -1191,9 +1189,9 @@ Remove Command
 ``dnf [options] remove --oldinstallonly``
     Removes old installonly packages, keeping only latest versions and version of running kernel.
 
-    There are also a few specific remove commands ``remove-n``, ``remove-na`` and ``remove-nevra``
-    that allow the specification of an exact argument in the NEVRA format. As a consequence, <spec>
-    will be not matched with provides and file provides.
+There are also a few specific remove commands ``remove-n``, ``remove-na`` and ``remove-nevra``
+that allow the specification of an exact argument in the NEVRA format. As a consequence, <spec>
+will be not matched with provides and file provides.
 
 Remove Examples
 ---------------
@@ -1205,9 +1203,9 @@ Remove Examples
     Remove packages not present in any repository, but don't remove the ``tito``
     and ``acpi`` packages (they still might be removed if they depend on some of the removed packages).
 
-Remove older versions of duplicated packages (an equivalent of yum's `package-cleanup --cleandups`)::
+``dnf remove --duplicates``
+    Remove older versions of duplicated packages (an equivalent of yum's `package-cleanup --cleandups`).
 
-    dnf remove --duplicates
 
 .. _repoinfo_command-label:
 
@@ -1217,8 +1215,8 @@ Repoinfo Command
 
 | Command: ``repoinfo``
 
-    An alias for the :ref:`repolist <repolist_command-label>` command
-    that provides more detailed information like ``dnf repolist -v``.
+An alias for the :ref:`repolist <repolist_command-label>` command
+that provides more detailed information like ``dnf repolist -v``.
 
 .. _repolist_command-label:
 
@@ -1255,9 +1253,9 @@ Repoquery Command
 ``dnf [options] repoquery --querytags``
     Provides the list of tags recognized by the \-\ :ref:`-queryformat <queryformat_repoquery-label>` repoquery option.
 
-    There are also a few specific repoquery commands ``repoquery-n``, ``repoquery-na`` and ``repoquery-nevra``
-    that allow the specification of an exact argument in the NEVRA format (does not affect arguments of options like --whatprovides <arg>, ...).
-    As a consequence, <spec> will be not matched with file provides.
+There are also a few specific repoquery commands ``repoquery-n``, ``repoquery-na`` and ``repoquery-nevra``
+that allow the specification of an exact argument in the NEVRA format (does not affect arguments of options like --whatprovides <arg>, ...).
+As a consequence, <spec> will be not matched with file provides.
 
 Select Options
 --------------
@@ -1476,52 +1474,41 @@ are displayed in the standard NEVRA notation.
     resolve capabilities to originating package(s).
 
 
-Examples
---------
+Repoquery Examples
+------------------
 
-Display NEVRAs of all available packages matching ``light*``::
+``dnf repoquery 'light*'``
+    Display NEVRAs of all available packages matching ``light*``
 
-    dnf repoquery 'light*'
+``dnf repoquery-na 'light*.noarch'``
+    Display NEVRAs of all available packages matching name ``light*`` and architecture ``noarch`` (accepts only arguments in the "<name>.<arch>" format)
 
-Display NEVRAs of all available packages matching name ``light*`` and architecture ``noarch`` (accepts only arguments in the "<name>.<arch>" format)::
+``dnf repoquery --requires lighttpd``
+    Display requires of all lighttpd packages
 
-    dnf repoquery-na 'light*.noarch'
+``dnf repoquery --requires python --resolve``
+    Display packages providing the requires of python packages
 
-Display requires of all lighttpd packages::
+``dnf repoquery --source lighttpd``
+    Display source rpm of lighttpd package
 
-    dnf repoquery --requires lighttpd
+``dnf repoquery --file /etc/lighttpd/lighttpd.conf``
+    Display package name that owns the given file
 
-Display packages providing the requires of python packages::
+``dnf repoquery --queryformat '%{name}.%{arch} : %{reponame}' lighttpd``
+    Display name, architecture and the containing repository of all lighttpd packages
 
-    dnf repoquery --requires python --resolve
+``dnf repoquery --whatprovides webserver``
+    Display all available packages providing "webserver"
 
-Display source rpm of ligttpd package::
+``dnf repoquery --whatprovides webserver --arch i686``
+    Display all available packages providing "webserver" but only for "i686" architecture
 
-    dnf repoquery --source lighttpd
+``dnf repoquery --duplicates``
+    Display duplicate packages
 
-Display package name that owns the given file::
-
-    dnf repoquery --file /etc/lighttpd/lighttpd.conf
-
-Display name, architecture and the containing repository of all lighttpd packages::
-
-    dnf repoquery --queryformat '%{name}.%{arch} : %{reponame}' lighttpd
-
-Display all available packages providing "webserver"::
-
-    dnf repoquery --whatprovides webserver
-
-Display all available packages providing "webserver" but only for "i686" architecture::
-
-    dnf repoquery --whatprovides webserver --arch i686
-
-Display duplicate packages::
-
-    dnf repoquery --duplicates
-
-Display source packages that require a <provide> for a build::
-
-    dnf repoquery --disablerepo="*" --enablerepo="*-source" --arch=src --whatrequires <provide>
+``dnf repoquery --disablerepo="*" --enablerepo="*-source" --arch=src --whatrequires <provide>``
+    Display source packages that require a <provide> for a build
 
 .. _repository_packages_command-label:
 
@@ -1669,7 +1656,7 @@ Swap Command
 
 ``dnf [options] swap <remove-spec> <install-spec>``
 
-    Remove spec and install spec in one transaction. Each ``<spec>`` can be either a
+    Remove ``remove-spec`` and install ``install-spec`` in one transaction. Each ``<spec>`` can be either a
     :ref:`<package-spec> <specifying_packages-label>`, which specifies a package directly, or a
     ``@<group-spec>``, which specifies an (environment) group which contains it. Automatic
     conflict solving is provided in DNF by the --allowerasing option that provides the functionality of the swap


### PR DESCRIPTION
This patch includes some minor consistency fixes I noticed when reading the man page:
- A few commands had extra blank lines before starting their description which was causing extra whitespace to be added to the description.
- Some information relevant to commands was nested under example commands because of leading whitespace (mostly the information about `-nevra` commands).
- Some example commands followed their description, while most other examples have the command first and then the description. This changes all examples to the latter for consistency.
- Renamed the `Examples` header to `Repoquery Examples` similar to other example headers
- Fixed typo in repoquery examples (ligttpd -> lighttpd)
- Added parameter names to `swap` description

Also this updates the man page file name in the README (dnf.8 -> dnf4.8) as that's the actual file generated by `make`.