### PR TITLE
Allow local downloads to same `downloaddir`

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1320,7 +1320,10 @@ class Base(object):
                                             pkg.location.lstrip("/"))
                 else:
                     location = os.path.join(pkg.repo.pkgdir, pkg.location.lstrip("/"))
-                shutil.copy(location, self.conf.destdir)
+                try:
+                    shutil.copy(location, self.conf.destdir)
+                except shutil.SameFileError:
+                    pass
 
     def add_remote_rpms(self, path_list, strict=True, progress=None):
         # :api


### PR DESCRIPTION
Currently when `dnf download --downloaddir <dir> <package>` sources`<package>` from `<dir>` it triggers a `shutil.SameFileError` exception and aborts the entire download process with a `'<package>.rpm' and '<package>.rpm' are the same file` error.

This goes against the current flow which marks locally present RPMs that match a remote RPM as `[SKIPPED] <package>.rpm: Already downloaded`.

This change allows downloads of locally sourced packages to the same file, treating it as a no-op.