### PR TITLE
rhel-9.5: Revert RHEL-49670

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -214,15 +214,6 @@ class BaseCli(dnf.Base):
             elif 'test' in self.conf.tsflags:
                 logger.info(_("{prog} will only download packages, install gpg keys, and check the "
                               "transaction.").format(prog=dnf.util.MAIN_PROG_UPPER))
-            if dnf.util.is_container():
-                _container_msg = _("""
-*** This system is managed with ostree.  Changes to the system
-*** made with dnf will be lost with the next ostree-based update.
-*** If you do not want to lose these changes, use 'rpm-ostree'.
-""")
-                logger.info(_container_msg)
-                raise CliError(_("Operation aborted."))
-
             if self._promptWanted():
                 if self.conf.assumeno or not self.output.userconfirm():
                     raise CliError(_("Operation aborted."))

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -214,12 +214,13 @@ class BaseCli(dnf.Base):
             elif 'test' in self.conf.tsflags:
                 logger.info(_("{prog} will only download packages, install gpg keys, and check the "
                               "transaction.").format(prog=dnf.util.MAIN_PROG_UPPER))
-            if dnf.util._is_bootc_host():
-                _bootc_host_msg = _("""
-*** Error: system is configured to be read-only; for more
-*** information run `bootc status` or `ostree admin status`.
+            if dnf.util.is_container():
+                _container_msg = _("""
+*** This system is managed with ostree.  Changes to the system
+*** made with dnf will be lost with the next ostree-based update.
+*** If you do not want to lose these changes, use 'rpm-ostree'.
 """)
-                logger.info(_bootc_host_msg)
+                logger.info(_container_msg)
                 raise CliError(_("Operation aborted."))
 
             if self._promptWanted():

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -217,7 +217,7 @@ class BaseCli(dnf.Base):
             if dnf.util._is_bootc_host():
                 _bootc_host_msg = _("""
 *** Error: system is configured to be read-only; for more
-*** information run `bootc --help`.
+*** information run `bootc status` or `ostree admin status`.
 """)
                 logger.info(_bootc_host_msg)
                 raise CliError(_("Operation aborted."))

--- a/dnf/util.py
+++ b/dnf/util.py
@@ -33,13 +33,11 @@ import errno
 import functools
 import hawkey
 import itertools
-import json
 import locale
 import logging
 import os
 import pwd
 import shutil
-import subprocess
 import sys
 import tempfile
 import time
@@ -633,32 +631,3 @@ def _post_transaction_output(base, transaction, action_callback):
 def _name_unset_wrapper(input_name):
     # returns <name-unset> for everything that evaluates to False (None, empty..)
     return input_name if input_name else _("<name-unset>")
-
-
-def is_container():
-    """Returns true is the system is managed as an immutable container,
-       false otherwise.  If msg is True, a warning message is displayed
-       for the user.
-    """
-
-    bootc = '/usr/bin/bootc'
-    ostree = '/sysroot/ostree'
-
-    if os.path.isfile(bootc) and os.access(bootc, os.X_OK):
-        p = subprocess.Popen([bootc, "status", "--json"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        (out, err) = p.communicate()
-
-        if p.returncode == 0:
-            # check the output of 'bootc status'
-            j = json.loads(out)
-
-            # XXX: the API from bootc status is evolving
-            status = j.get("status", "")
-            kind = j.get("kind", "")
-
-            if kind.lower() == "bootchost" and bool(status.get("isContainer", None)):
-                return True
-    elif os.path.isdir(ostree):
-        return True
-
-    return False


### PR DESCRIPTION
This patchset reverts #2114 because it broke "dnf --installroot" in a locked OSTree system.
Related: https://issues.redhat.com/browse/RHEL-49670