### PR TITLE
Fix /var/cache/dnf and /etc/yum packaging

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -334,13 +334,13 @@ popd
 %{_tmpfilesdir}/%{name}.conf
 
 %files -n %{yum_subpackage_name}
-%if "%{yum_compat_level}" == "full"
 %{_bindir}/yum
+%{_mandir}/man8/yum.8*
+%if "%{yum_compat_level}" == "full"
 %{_sysconfdir}/yum.conf
 %{_sysconfdir}/yum/pluginconf.d
 %{_sysconfdir}/yum/protected.d
 %{_sysconfdir}/yum/vars
-%{_mandir}/man8/yum.8*
 %{_mandir}/man5/yum.conf.5.*
 %{_mandir}/man8/yum-shell.8*
 %{_mandir}/man1/yum-aliases.1*
@@ -363,11 +363,6 @@ popd
 %exclude %{_mandir}/man5/yum.conf.5.*
 %exclude %{_mandir}/man8/yum-shell.8*
 %exclude %{_mandir}/man1/yum-aliases.1*
-%endif
-
-%if "%{yum_compat_level}" == "minimal"
-%{_bindir}/yum
-%{_mandir}/man8/yum.8*
 %endif
 
 %files -n python3-%{name}

--- a/dnf.spec
+++ b/dnf.spec
@@ -337,10 +337,8 @@ popd
 %{_bindir}/yum
 %{_mandir}/man8/yum.8*
 %if "%{yum_compat_level}" == "full"
+%{_sysconfdir}/yum
 %{_sysconfdir}/yum.conf
-%{_sysconfdir}/yum/pluginconf.d
-%{_sysconfdir}/yum/protected.d
-%{_sysconfdir}/yum/vars
 %{_mandir}/man5/yum.conf.5.*
 %{_mandir}/man8/yum-shell.8*
 %{_mandir}/man1/yum-aliases.1*
@@ -356,9 +354,6 @@ popd
 %endif
 %else
 %exclude %{_sysconfdir}/yum.conf
-%exclude %{_sysconfdir}/yum/pluginconf.d
-%exclude %{_sysconfdir}/yum/protected.d
-%exclude %{_sysconfdir}/yum/vars
 %exclude %{confdir}/protected.d/yum.conf
 %exclude %{_mandir}/man5/yum.conf.5.*
 %exclude %{_mandir}/man8/yum-shell.8*

--- a/dnf.spec
+++ b/dnf.spec
@@ -301,7 +301,6 @@ popd
 %{_mandir}/man5/dnf-transaction-json.5*
 %{_unitdir}/%{name}-makecache.service
 %{_unitdir}/%{name}-makecache.timer
-%{_var}/cache/%{name}/
 
 %files data
 %license COPYING PACKAGE-LICENSING
@@ -394,6 +393,7 @@ popd
 %{python3_sitelib}/%{name}/
 %dir %{py3pluginpath}
 %dir %{py3pluginpath}/__pycache__
+%{_var}/cache/%{name}/
 
 %files automatic
 %{_bindir}/%{name}-automatic

--- a/dnf.spec
+++ b/dnf.spec
@@ -34,7 +34,6 @@
 # level=full    -> deploy all compat symlinks (conflicts with yum < 4)
 # level=minimal -> deploy a subset of compat symlinks only
 #                  (no conflict with yum >= 3.4.3-505)*
-# level=preview -> minimal level with altered paths (no conflict with yum < 4)
 # *release 505 renamed /usr/bin/yum to /usr/bin/yum-deprecated
 %global yum_compat_level full
 %global yum_subpackage_name yum
@@ -48,7 +47,6 @@
     %endif
 %endif
 %if 0%{?rhel} && 0%{?rhel} <= 7
-    %global yum_compat_level preview
     %global yum_subpackage_name nextgen-yum4
 %endif
 
@@ -370,12 +368,6 @@ popd
 %if "%{yum_compat_level}" == "minimal"
 %{_bindir}/yum
 %{_mandir}/man8/yum.8*
-%endif
-
-%if "%{yum_compat_level}" == "preview"
-%{_bindir}/yum4
-%{_mandir}/man8/yum4.8*
-%exclude %{_mandir}/man8/yum.8*
 %endif
 
 %files -n python3-%{name}


### PR DESCRIPTION
This patch set improves packaging:

* Moves /var/cache/dnf from dnf package to python3-dnf
* Removes long broken preview yum_compat_level
* Simplifies %files dnf section for both yum_compat_levels
* Fixes ownership of /etc/yum tree

I tested it on Fedora 41 and Fedora 40. The only externally visible change on binary packages is the move of /var/cache/dnf directory to python3-dnf.