### PR TITLE
Allow --installroot on read-only bootc system

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -214,7 +214,8 @@ class BaseCli(dnf.Base):
             elif 'test' in self.conf.tsflags:
                 logger.info(_("{prog} will only download packages, install gpg keys, and check the "
                               "transaction.").format(prog=dnf.util.MAIN_PROG_UPPER))
-            if dnf.util._is_bootc_host():
+            if dnf.util._is_bootc_host() and \
+                    os.path.realpath(self.conf.installroot) == "/":
                 _bootc_host_msg = _("""
 *** Error: system is configured to be read-only; for more
 *** information run `bootc --help`.


### PR DESCRIPTION
Some people use --installroot on a read-only bootc system to install a system into a chroot subtree. However, current bootc check did not take into account --installroot and rejected the operation.

This patch augments the check for a writable installroot being different from /.

The comparison for / is there to deal with bootc systems with a writeable /. Currently it's uncerain whether systems like that exist.

Resolves: #2108