### PR TITLE
rhel-9.6: Fixes for RHEL-49670 (bootc error message)

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -214,13 +214,12 @@ class BaseCli(dnf.Base):
             elif 'test' in self.conf.tsflags:
                 logger.info(_("{prog} will only download packages, install gpg keys, and check the "
                               "transaction.").format(prog=dnf.util.MAIN_PROG_UPPER))
-            if dnf.util.is_container():
-                _container_msg = _("""
-*** This system is managed with ostree.  Changes to the system
-*** made with dnf will be lost with the next ostree-based update.
-*** If you do not want to lose these changes, use 'rpm-ostree'.
+            if dnf.util._is_bootc_host():
+                _bootc_host_msg = _("""
+*** Error: system is configured to be read-only; for more
+*** information run `bootc status` or `ostree admin status`.
 """)
-                logger.info(_container_msg)
+                logger.info(_bootc_host_msg)
                 raise CliError(_("Operation aborted."))
 
             if self._promptWanted():

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -214,6 +214,15 @@ class BaseCli(dnf.Base):
             elif 'test' in self.conf.tsflags:
                 logger.info(_("{prog} will only download packages, install gpg keys, and check the "
                               "transaction.").format(prog=dnf.util.MAIN_PROG_UPPER))
+            if dnf.util.is_container():
+                _container_msg = _("""
+*** This system is managed with ostree.  Changes to the system
+*** made with dnf will be lost with the next ostree-based update.
+*** If you do not want to lose these changes, use 'rpm-ostree'.
+""")
+                logger.info(_container_msg)
+                raise CliError(_("Operation aborted."))
+
             if self._promptWanted():
                 if self.conf.assumeno or not self.output.userconfirm():
                     raise CliError(_("Operation aborted."))

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -214,7 +214,8 @@ class BaseCli(dnf.Base):
             elif 'test' in self.conf.tsflags:
                 logger.info(_("{prog} will only download packages, install gpg keys, and check the "
                               "transaction.").format(prog=dnf.util.MAIN_PROG_UPPER))
-            if dnf.util._is_bootc_host():
+            if dnf.util._is_bootc_host() and \
+                    os.path.realpath(self.conf.installroot) == "/":
                 _bootc_host_msg = _("""
 *** Error: system is configured to be read-only; for more
 *** information run `bootc --help`.

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -217,7 +217,7 @@ class BaseCli(dnf.Base):
             if dnf.util._is_bootc_host():
                 _bootc_host_msg = _("""
 *** Error: system is configured to be read-only; for more
-*** information run `bootc status` or `ostree admin status`.
+*** information run `bootc --help`.
 """)
                 logger.info(_bootc_host_msg)
                 raise CliError(_("Operation aborted."))

--- a/dnf/util.py
+++ b/dnf/util.py
@@ -33,11 +33,13 @@ import errno
 import functools
 import hawkey
 import itertools
+import json
 import locale
 import logging
 import os
 import pwd
 import shutil
+import subprocess
 import sys
 import tempfile
 import time
@@ -631,3 +633,32 @@ def _post_transaction_output(base, transaction, action_callback):
 def _name_unset_wrapper(input_name):
     # returns <name-unset> for everything that evaluates to False (None, empty..)
     return input_name if input_name else _("<name-unset>")
+
+
+def is_container():
+    """Returns true is the system is managed as an immutable container,
+       false otherwise.  If msg is True, a warning message is displayed
+       for the user.
+    """
+
+    bootc = '/usr/bin/bootc'
+    ostree = '/sysroot/ostree'
+
+    if os.path.isfile(bootc) and os.access(bootc, os.X_OK):
+        p = subprocess.Popen([bootc, "status", "--json"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        (out, err) = p.communicate()
+
+        if p.returncode == 0:
+            # check the output of 'bootc status'
+            j = json.loads(out)
+
+            # XXX: the API from bootc status is evolving
+            status = j.get("status", "")
+            kind = j.get("kind", "")
+
+            if kind.lower() == "bootchost" and bool(status.get("isContainer", None)):
+                return True
+    elif os.path.isdir(ostree):
+        return True
+
+    return False

--- a/dnf/util.py
+++ b/dnf/util.py
@@ -33,13 +33,11 @@ import errno
 import functools
 import hawkey
 import itertools
-import json
 import locale
 import logging
 import os
 import pwd
 import shutil
-import subprocess
 import sys
 import tempfile
 import time
@@ -635,30 +633,15 @@ def _name_unset_wrapper(input_name):
     return input_name if input_name else _("<name-unset>")
 
 
-def is_container():
+def _is_bootc_host():
     """Returns true is the system is managed as an immutable container,
        false otherwise.  If msg is True, a warning message is displayed
        for the user.
     """
-
-    bootc = '/usr/bin/bootc'
-    ostree = '/sysroot/ostree'
-
-    if os.path.isfile(bootc) and os.access(bootc, os.X_OK):
-        p = subprocess.Popen([bootc, "status", "--json"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        (out, err) = p.communicate()
-
-        if p.returncode == 0:
-            # check the output of 'bootc status'
-            j = json.loads(out)
-
-            # XXX: the API from bootc status is evolving
-            status = j.get("status", "")
-            kind = j.get("kind", "")
-
-            if kind.lower() == "bootchost" and bool(status.get("isContainer", None)):
-                return True
-    elif os.path.isdir(ostree):
-        return True
-
-    return False
+    ostree_booted = '/run/ostree-booted'
+    usr = '/usr/'
+    # Check if usr is writtable and we are in a running ostree system.
+    # We want this code to return true only when the system is in locked state. If someone ran
+    # bootc overlay or ostree admin unlock we would want normal DNF path to be ran as it will be
+    # temporary changes (until reboot).
+    return os.path.isfile(ostree_booted) and not os.access(usr, os.W_OK)


### PR DESCRIPTION
This patch set is a backport of the following upstream commits for rhel-9.6 branch:

Upstream commit: 5c050ba2324c5fb95bf0e0501c7925f38f6a09dc
Upstream commit: 6120fe52511775b60b6031d4169988c025610ab5
Upstream commit: e2535589ce16bc36b96b37369502a3c312f6056a
Upstream commit: a1aa8d0e048751859a2bec1b2fb12fcca93c6e83
Resolves: https://issues.redhat.com/browse/RHEL-49670