### PR TITLE
package: remote_location() takes basedir into account

### DIFF
--- a/dnf/package.py
+++ b/dnf/package.py
@@ -300,6 +300,8 @@ class Package(hawkey.Package):
         """
         if self._from_system or self._from_cmdline:
             return None
+        if self.baseurl:
+            return os.path.join(self.baseurl, self.location.lstrip("/"))
         return self.repo.remote_location(self.location, schemes)
 
     def _is_local_pkg(self):


### PR DESCRIPTION
If the package location in the repodata contains basedir, it needs to be
taken into account when calculating the package's remote_location.

Resolves: https://github.com/rpm-software-management/dnf/issues/2130
Test: https://github.com/rpm-software-management/dnf/pull/2131

= changelog =
msg:           Fix package location if baseurl is present in the metadata
type:          bugfix
resolves:      https://github.com/rpm-software-management/dnf/issues/2130