### PR TITLE
Print rpm unpack errors to the user (RhBug:2312906)

### DIFF
--- a/dnf/yum/rpmtrans.py
+++ b/dnf/yum/rpmtrans.py
@@ -397,6 +397,8 @@ class RPMTransaction(object):
             display.error(msg)
 
     def _unpackError(self, key):
+        self._scriptout()
+
         transaction_list = self._extract_cbkey(key)
         msg = "Error unpacking rpm package %s" % transaction_list[0].pkg
         for display in self.displays:


### PR DESCRIPTION
DNF currently prints RPM errors that occur during scriptlet execution or
during package installation/removal.
This patch adds error handling for issues that arise during RPM package
unpacking as well.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2312906