### PR TITLE
Add pre_transaction_test() hook

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -991,6 +991,8 @@ class Base(object):
 
             logger.info(_('Transaction check succeeded.'))
 
+            self._plugins.run_pre_transaction_test()
+
             timer = dnf.logging.Timer('transaction test')
             logger.info(_('Running transaction test'))
 

--- a/dnf/plugin.py
+++ b/dnf/plugin.py
@@ -89,6 +89,10 @@ class Plugin(object):
         # :api
         pass
 
+    def pre_transaction_test(self):
+        # :api
+        pass
+
     def transaction(self):
         # :api
         pass
@@ -160,6 +164,9 @@ class Plugins(object):
 
     def run_resolved(self):
         self._caller('resolved')
+
+    def run_pre_transaction_test(self):
+        self._caller('pre_transaction_test')
 
     def run_pre_transaction(self):
         self._caller('pre_transaction')


### PR DESCRIPTION
Hi,
in `yum` I've used the pre_transaction_hook() to be able to do the processing in the case between `yum` downloaded the packages and before it went to the transaction test itself. With `dnf` I found out I am unable to do it like that as it's missing the pre_transaction_test() hook so I have implemented it.

This is functionality that I was using in the previous version, i.e. `yum`, for the preprocessing purposes of the packages before they got installed. The use case is to either provide an encryption of the packages and decrypt before the transaction test and/or to do the verification on my on.

Please kindly review.
Thanks,
Michal