### PR TITLE
smtplib: catch OSError, not SMTPException

### DIFF
--- a/dnf/automatic/emitter.py
+++ b/dnf/automatic/emitter.py
@@ -106,7 +106,7 @@ class EmailEmitter(Emitter):
             smtp = smtplib.SMTP(self._conf.email_host, timeout=300)
             smtp.sendmail(email_from, email_to, message.as_string())
             smtp.close()
-        except smtplib.SMTPException as exc:
+        except OSError as exc:
             msg = _("Failed to send an email via '%s': %s") % (
                 self._conf.email_host, exc)
             logger.error(msg)


### PR DESCRIPTION
A backport of a upstream patch for RHEL 9.6.

Upstream commit: https://github.com/rpm-software-management/dnf/commit/aab7defca4fd827ede02336e5a0cf95e8691fb74

Resolves: https://issues.redhat.com/browse/RHEL-49743