### PR TITLE
Add kernel-core to reboot_needed list

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -103,3 +103,5 @@ DNF CONTRIBUTORS
     Will Woods <wwoods@redhat.com>
     Furkan Karcıoğlu <krc440002@gmail.com>
     Gary Leydon <gary.leydon@yale.edu>
+    Woomymy <woomy@woomy.be>
+

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -2837,7 +2837,7 @@ class Base(object):
             return False
 
         # List taken from DNF needs-restarting
-        need_reboot = frozenset(('kernel', 'kernel-rt', 'glibc',
+        need_reboot = frozenset(('kernel', 'kernel-rt', 'kernel-core', 'glibc',
                                 'linux-firmware', 'systemd', 'dbus',
                                 'dbus-broker', 'dbus-daemon'))
         changed_pkgs = self.transaction.install_set | self.transaction.remove_set


### PR DESCRIPTION
Some variants like Fedora Cloud ship only kernel-core without
kernel-modules and the kernel metapackage, this fixes reboot when the kernel-core package alone is updated