### PR TITLE
Allow --downloadonly on read-only bootc system

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -215,7 +215,8 @@ class BaseCli(dnf.Base):
                 logger.info(_("{prog} will only download packages, install gpg keys, and check the "
                               "transaction.").format(prog=dnf.util.MAIN_PROG_UPPER))
             if dnf.util._is_bootc_host() and \
-                    os.path.realpath(self.conf.installroot) == "/":
+                    os.path.realpath(self.conf.installroot) == "/" and \
+                    not self.conf.downloadonly:
                 _bootc_host_msg = _("""
 *** Error: system is configured to be read-only; for more
 *** information run `bootc --help`.


### PR DESCRIPTION
"dnf install --downloadonly" failed on read-only bootc system despite not running the transaction. The downloaded packages are stored under writable /var or to a directory explicitly choosen by a user.

This patch suppresses the bootc read-only bailout if --downloadonly option is used.

https://issues.redhat.com/browse/RHEL-61745