### PR TITLE
doc: Example send_error_messages in /etc/dnf/automatic.conf

### DIFF
--- a/etc/dnf/automatic.conf
+++ b/etc/dnf/automatic.conf
@@ -47,6 +47,8 @@ reboot_command = "shutdown -r +5 'Rebooting after applying package updates'"
 # If emit_via is None or left blank, no messages will be sent.
 emit_via = stdio
 
+# If an error occurs, send the error message via the configured emitter.
+send_error_messages = no
 
 [email]
 # The address to send email messages from.


### PR DESCRIPTION
The option was documented in a manual page, but it wasn't mentioned in the default configuration file.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2318136