### PR TITLE
Update need_reboot for dnf-automatic

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -2837,9 +2837,9 @@ class Base(object):
             return False
 
         # List taken from DNF needs-restarting
-        need_reboot = frozenset(('kernel', 'kernel-rt', 'kernel-core', 'glibc',
-                                'linux-firmware', 'systemd', 'dbus',
-                                'dbus-broker', 'dbus-daemon'))
+        need_reboot = frozenset(('kernel', 'kernel-core', 'kernel-rt', 'glibc',
+                                 'linux-firmware', 'systemd', 'dbus',
+                                 'dbus-broker', 'dbus-daemon', 'microcode_ctl'))
         changed_pkgs = self.transaction.install_set | self.transaction.remove_set
         return any(pkg.name in need_reboot for pkg in changed_pkgs)
 


### PR DESCRIPTION
Hi,
the need_reboot from dnf does no longer match dnf-automatic. We noticed it will not reboot on microcode_ctl updates. I also added kernel-core because it was missing.
It now matches 
https://github.com/rpm-software-management/dnf-plugins-core/blob/master/plugins/needs_restarting.py#L42-L44



Greetings
Klaas