### PR TITLE
Relaxed check for root user

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -727,9 +727,8 @@ class Cli(object):
 
         if demands.root_user:
             if not dnf.util.am_i_root():
-                raise dnf.exceptions.Error(
-                    _('This command has to be run with superuser privileges '
-                        '(under the root user on most systems).'))
+                logger.warning('In most cases, this command has to be run with superuser privileges '
+                               '(usually under the root user)')                
 
         if demands.changelogs:
             for repo in repos.iter_enabled():


### PR DESCRIPTION
In case the user running DNF is not root, the current behavior is to raise an Exception (because is a demand) and exit. To work around the fact that DNF does not provide a mechanism for relocate packages (see #2105), a way to work around this limitation is to execute dnf from within a container, binding the required folders from the host in the expected locations in the container. However, for certain runtimes (e.g., singularity) than run under the user permissions (and not root), this is not enough: besides the binding of the folders, the check for root must not be enforced.

This PR relaxes the check for root, so that instead of raising an Exception, a warning log message gets emitted. This should not pose a problem because, even in the case the user is not allowed to perform certain actions (e.g., write to /var/cache), DNF will be running anyway as the unprivileged user and will not harm the system.