### PR TITLE
bootc: Add support for `--transient`

### DIFF
--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -317,6 +317,9 @@ class OptionParser(argparse.ArgumentParser):
         general_grp.add_argument("--downloadonly", dest="downloadonly",
                                  action="store_true", default=False,
                                  help=_("only download packages"))
+        general_grp.add_argument("--transient", dest="persistence",
+                                 action="store_const", const="transient", default=None,
+                                 help=_("Use a transient overlay which will reset on reboot"))
         general_grp.add_argument("--comment", dest="comment", default=None,
                                  help=_("add a comment to transaction"))
         # Updateinfo options...

--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -343,7 +343,7 @@ class MainConf(BaseConfig):
                        'best', 'assumeyes', 'assumeno', 'clean_requirements_on_remove', 'gpgcheck',
                        'showdupesfromrepos', 'plugins', 'ip_resolve',
                        'rpmverbosity', 'disable_excludes', 'color',
-                       'downloadonly', 'exclude', 'excludepkgs', 'skip_broken',
+                       'downloadonly', 'persistence', 'exclude', 'excludepkgs', 'skip_broken',
                        'tsflags', 'arch', 'basearch', 'ignorearch', 'cacheonly', 'comment']
 
         for name in config_args:

--- a/dnf/util.py
+++ b/dnf/util.py
@@ -38,6 +38,7 @@ import logging
 import os
 import pwd
 import shutil
+import subprocess
 import sys
 import tempfile
 import time
@@ -642,15 +643,32 @@ def _is_file_pattern_present(specs):
 
 
 def _is_bootc_host():
-    """Returns true is the system is managed as an immutable container,
-       false otherwise.  If msg is True, a warning message is displayed
-       for the user.
-    """
-    ostree_booted = '/run/ostree-booted'
-    usr = '/usr/'
-    # Check if usr is writtable and we are in a running ostree system.
-    # We want this code to return true only when the system is in locked state. If someone ran
-    # bootc overlay or ostree admin unlock we would want normal DNF path to be ran as it will be
-    # temporary changes (until reboot).
-    return os.path.isfile(ostree_booted) and not os.access(usr, os.W_OK)
+    """Returns true is the system is managed as an immutable container, false
+    otherwise."""
+    ostree_booted = "/run/ostree-booted"
+    return os.path.isfile(ostree_booted)
 
+
+def _is_bootc_unlocked():
+    """Check whether /usr is writeable, e.g. if we are in a normal mutable
+    system or if we are in a bootc after `bootc usr-overlay` or `ostree admin
+    unlock` was run."""
+    usr = "/usr"
+    return os.access(usr, os.W_OK)
+
+
+def _bootc_unlock():
+    """Set up a writeable overlay on bootc systems."""
+
+    if _is_bootc_unlocked():
+        return
+
+    unlock_command = ["bootc", "usr-overlay"]
+
+    try:
+        completed_process = subprocess.run(unlock_command, text=True)
+        completed_process.check_returncode()
+    except FileNotFoundError:
+        raise dnf.exceptions.Error(_("bootc command not found. Is this a bootc system?"))
+    except subprocess.CalledProcessError:
+        raise dnf.exceptions.Error(_("Failed to unlock system: %s", completed_process.stderr))


### PR DESCRIPTION
**This is just a proof-of-concept.** I am not sure whether we want to implement the bootc support this way or keep the original plan of keeping things contained to a DNF plugin. But this approach has the big advantage that we get all DNF operations (builddep, install, remove, upgrade, everything) working in "transient mode" for free without reimplementing any DNF commands within the bootc plugin.

Adds support for the `--transient` option on all transactions. Passing `--transient` on a bootc system will call `bootc usr-overlay` to create a transient writeable /usr and continue the transaction.

Specifying `--transient` on a non-bootc system will throw an error; we don't want to mislead users to thinking this feature works on non-bootc systems.

If `--transient` is not specified and the bootc system is in a locked state, the operation will be aborted and a message will be printed suggesting to try again with `--transient`.