### PR TITLE
spec: toggle dnf5_obsoletes_dnf for RHEL 11

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -12,7 +12,7 @@
 %global conflicts_dnf_plugins_extras_version 4.0.4
 %global conflicts_dnfdaemon_version 0.3.19
 
-%bcond dnf5_obsoletes_dnf %[0%{?fedora} > 40 || 0%{?rhel} > 11]
+%bcond dnf5_obsoletes_dnf %[0%{?fedora} > 40 || 0%{?rhel} > 10]
 
 # override dependencies for rhel 7
 %if 0%{?rhel} == 7


### PR DESCRIPTION
Fedora 41 has completed the migration to DNF5, so ELN (the future RHEL 11) is now ready to follow suit.

See also: https://github.com/rpm-software-management/dnf5/pull/1886