### PR TITLE
automatic: Fix incorrect Error class instantiation

### DIFF
--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -379,7 +379,7 @@ def main(args):
                (conf.commands.reboot == 'when-needed' and base.reboot_needed())):
                 exit_code = os.waitstatus_to_exitcode(os.system(conf.commands.reboot_command))
                 if exit_code != 0:
-                    raise dnf.exceptions.Error('reboot command returned nonzero exit code: %d', exit_code)
+                    raise dnf.exceptions.Error('reboot command returned nonzero exit code: %d' % exit_code)
     except Exception as exc:
         logger.error(_('Error: %s'), ucd(exc))
         if conf is not None and conf.emitters.send_error_messages and emitters is not None:


### PR DESCRIPTION
dnf.exceptions.Error class constructor accepts only one argument - error message.

The error somehow slipped through a gap our CI and the reason is that related tests are not part of the master branch, they are only in RHEL branch.