### PR TITLE
doc: `--disableexcludepkgs=all` doesn't affect just file configuration

### DIFF
--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -165,11 +165,13 @@ Options
 .. _disableexcludes-label:
 
 ``--disableexcludes=[all|main|<repoid>], --disableexcludepkgs=[all|main|<repoid>]``
-    Disable the configuration file excludes. Takes one of the following three options:
+    Disable ``excludepkgs`` and ``includepkgs`` configuration options. Takes one of the following three options:
 
-    * ``all``, disables all configuration file excludes
-    * ``main``, disables excludes defined in the ``[main]`` section
-    * ``repoid``, disables excludes defined for the given repository
+    * ``all``, disables all ``excludepkgs`` and ``includepkgs`` configurations
+    * ``main``, disables ``excludepkgs`` and ``includepkgs`` defined in the ``[main]`` section
+    * ``repoid``, disables ``excludepkgs`` and ``includepkgs`` defined for the given repository
+
+    Note that the \-\ :ref:`-exclude <exclude_option-label>` option appends to the ``[main]`` ``excludepkgs`` configuration and therefore is disabled when ``main`` or ``all`` is specified.
 
 ``--disable, --set-disabled``
     Disable specified repositories (automatically saves). The option has to be used together with the


### PR DESCRIPTION
The option `--disableexcludepkgs=all` disables all configuration includes and excludes including packages specified on the commandline via `--exclude=`, `-x=`, the deprecated `--excludepkgs=` and file configuration via `--excludepkgs=`, `--includepkgs=`.

https://issues.redhat.com/browse/RHEL-28779 (Once merged I will also backport to the 9.6 branch).