### PR TITLE
Backport: Check availability of dnf-automatic config file

### DIFF
--- a/dnf/automatic/main.py
+++ b/dnf/automatic/main.py
@@ -379,7 +379,7 @@ def main(args):
                (conf.commands.reboot == 'when-needed' and base.reboot_needed())):
                 exit_code = os.waitstatus_to_exitcode(os.system(conf.commands.reboot_command))
                 if exit_code != 0:
-                    raise dnf.exceptions.Error('reboot command returned nonzero exit code: %d', exit_code)
+                    raise dnf.exceptions.Error('reboot command returned nonzero exit code: %d' % exit_code)
     except dnf.exceptions.Error as exc:
         logger.error(_('Error: %s'), ucd(exc))
         if conf is not None and conf.emitters.send_error_messages and emitters is not None:


### PR DESCRIPTION
Upstream commit: 13ecc3921fb1566c2af7b80d5cb515d8fc4e5ec9

If a configuration file is explicitly specified on the command line, ensure that it exists and is readable. If the file is not found, notify the user immediately and terminate the process.

This resolves issues where users may run dnf-automatic with unrecognized positional arguments, such as `dnf-automatic install`.

The most natural approach to handle a non-existing config file would be by catching the exception thrown by the `read()` method of the `libdnf.conf.ConfigParser` class. Unfortunately, the Python bindings override the `read()` method at the SWIG level, causing it to suppress any potentially raised IOError.
For details see this section of the commit
https://github.com/rpm-software-management/libdnf/commit/8f1fedf8551b72d6bc24018f5980714b3a103aeb

def ConfigParser__newRead(self, filenames):
    parsedFNames = []
    try:
        if isinstance(filenames, str) or isinstance(filenames, unicode):
            filenames = [filenames]
    except NameError:
        pass
    for fname in filenames:
        try:
            self.readFileName(fname)
            parsedFNames.append(fname)
        except IOError:
            pass
        except Exception as e:
            raise RuntimeError("Parsing file '%s' failed: %s" % (fname, str(e)))
    return parsedFNames
ConfigParser.read = ConfigParser__newRead

Resolves: https://issues.redhat.com/browse/RHEL-68979