### PR TITLE
spec: Provide dnf4 by python3-dnf

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -153,6 +153,7 @@ Requires:       rpm-plugin-systemd-inhibit
 %else
 Recommends:     (rpm-plugin-systemd-inhibit if systemd)
 %endif
+Provides:       dnf4 = %{version}-%{release}
 Provides:       dnf-command(alias)
 Provides:       dnf-command(autoremove)
 Provides:       dnf-command(check-update)


### PR DESCRIPTION
To differentiate from DNF5, python3-dnf already packages /usr/bin/dnf4 symbolic link. After dnf5 obsoleting dnf, people willing to install DNF4 they had to install python3-dnf package, a package whose name is hard to remember.

This patch adds "dnf4" RPM provide to python3-dnf package.

This patch should be backported to all systems so that people can rely on this new identifier.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2328463