### PR TITLE
spec: Add dnf-bootc subpackage

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -189,6 +189,14 @@ Requires:       python3-%{name} = %{version}-%{release}
 %description automatic
 Systemd units that can periodically download package upgrades and apply them.
 
+%package bootc
+Summary:        %{pkg_summary} - additional bootc dependencies
+Requires:       ostree-libs
+Requires:       python3-gobject-base
+
+%description bootc
+Additional dependencies needed to perform transactions on booted bootc (bootable containers) systems.
+
 
 %prep
 %autosetup
@@ -418,6 +426,9 @@ popd
 %{_unitdir}/%{name}-automatic-install.timer
 %{python3_sitelib}/%{name}/automatic/
 %endif
+
+%files bootc
+# bootc subpackage does not include any files
 
 %changelog
 * Wed Aug 14 2024 Evan Goode <mail@evangoo.de> - 4.21.1-1


### PR DESCRIPTION
dnf-bootc's only job is to Require python3-gobject-base and ostree-libs, which are needed to check the unlock status on bootc systems. We don't want to add these dependencies on `python3-dnf` because we don't want them on non-bootc systems, so we use a subpackage.