### PR TITLE
rhel-10.0: Override releasever_{major,minor} with system-release provides

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -157,8 +157,14 @@ class Base(object):
         conf = dnf.conf.Conf()
         subst = conf.substitutions
         if 'releasever' not in subst:
-            subst['releasever'] = \
-                dnf.rpm.detect_releasever(conf.installroot)
+            releasever, major, minor = \
+                dnf.rpm.detect_releasevers(conf.installroot)
+            subst['releasever'] = releasever
+            if major is not None:
+                subst['releasever_major'] = major
+            if minor is not None:
+                subst['releasever_minor'] = minor
+
         return conf
 
     def _setup_modular_excludes(self):

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -971,13 +971,20 @@ class Cli(object):
             from_root = "/"
         subst = conf.substitutions
         subst.update_from_etc(from_root, varsdir=conf._get_value('varsdir'))
+
         # cachedir, logs, releasever, and gpgkey are taken from or stored in installroot
+        major = None
+        minor = None
         if releasever is None and conf.releasever is None:
-            releasever = dnf.rpm.detect_releasever(conf.installroot)
+            releasever, major, minor = dnf.rpm.detect_releasevers(conf.installroot)
         elif releasever == '/':
-            releasever = dnf.rpm.detect_releasever(releasever)
+            releasever, major, minor = dnf.rpm.detect_releasevers(releasever)
         if releasever is not None:
             conf.releasever = releasever
+            if major is not None:
+                conf.releasever_major = major
+            if minor is not None:
+                conf.releasever_minor = minor
         if conf.releasever is None:
             logger.warning(_("Unable to detect release version (use '--releasever' to specify "
                              "release version)"))

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -836,7 +836,7 @@ class Cli(object):
                                           dnf.conf.PRIO_DEFAULT)
                 self.demands.cacheonly = True
             self.base.conf._configure_from_options(opts)
-            self._read_conf_file(opts.releasever)
+            self._read_conf_file(opts.releasever, opts.releasever_major, opts.releasever_minor)
             if 'arch' in opts:
                 self.base.conf.arch = opts.arch
             self.base.conf._adjust_conf_options()
@@ -945,7 +945,7 @@ class Cli(object):
                       )
                 )
 
-    def _read_conf_file(self, releasever=None):
+    def _read_conf_file(self, releasever=None, releasever_major=None, releasever_minor=None):
         timer = dnf.logging.Timer('config')
         conf = self.base.conf
 
@@ -973,18 +973,23 @@ class Cli(object):
         subst.update_from_etc(from_root, varsdir=conf._get_value('varsdir'))
 
         # cachedir, logs, releasever, and gpgkey are taken from or stored in installroot
-        major = None
-        minor = None
+
+        det_major = None
+        det_minor = None
         if releasever is None and conf.releasever is None:
-            releasever, major, minor = dnf.rpm.detect_releasevers(conf.installroot)
+            releasever, det_major, det_minor = dnf.rpm.detect_releasevers(conf.installroot)
         elif releasever == '/':
-            releasever, major, minor = dnf.rpm.detect_releasevers(releasever)
-        if releasever is not None:
-            conf.releasever = releasever
-            if major is not None:
-                conf.releasever_major = major
-            if minor is not None:
-                conf.releasever_minor = minor
+            releasever, det_major, det_minor = dnf.rpm.detect_releasevers(releasever)
+
+        def or_else(*args):
+            for arg in args:
+                if arg is not None:
+                    return arg
+            return None
+        conf.releasever = or_else(releasever, conf.releasever)
+        conf.releasever_major = or_else(releasever_major, det_major, conf.releasever_major)
+        conf.releasever_minor = or_else(releasever_minor, det_minor, conf.releasever_minor)
+
         if conf.releasever is None:
             logger.warning(_("Unable to detect release version (use '--releasever' to specify "
                              "release version)"))

--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -199,6 +199,12 @@ class OptionParser(argparse.ArgumentParser):
         general_grp.add_argument("--releasever", default=None,
                                  help=_("override the value of $releasever"
                                         " in config and repo files"))
+        general_grp.add_argument("--releasever-major", default=None,
+                                 help=_("override the value of $releasever_major"
+                                        " in config and repo files"))
+        general_grp.add_argument("--releasever-minor", default=None,
+                                 help=_("override the value of $releasever_minor"
+                                        " in config and repo files"))
         general_grp.add_argument("--setopt", dest="setopts", default=[],
                                  action=self._SetoptsCallback,
                                  help=_("set arbitrary config and repo options"))

--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -425,6 +425,12 @@ class MainConf(BaseConfig):
     @releasever.setter
     def releasever(self, val):
         # :api
+        """
+        Sets the releasever variable and sets releasever_major and
+        releasever_minor accordingly. releasever_major is set to the part of
+        $releasever before the first ".". releasever_minor is set to the part
+        after the first ".".
+        """
         if val is None:
             self.substitutions.pop('releasever', None)
             return
@@ -438,6 +444,11 @@ class MainConf(BaseConfig):
     @releasever_major.setter
     def releasever_major(self, val):
         # :api
+        """
+        Override the releasever_major variable, which is usually derived from
+        the releasever variable. This setter does not update the value of
+        $releasever.
+        """
         if val is None:
             self.substitutions.pop('releasever_major', None)
             return
@@ -446,6 +457,11 @@ class MainConf(BaseConfig):
     @property
     def releasever_minor(self):
         # :api
+        """
+        Override the releasever_minor variable, which is usually derived from
+        the releasever variable. This setter does not update the value of
+        $releasever.
+        """
         return self.substitutions.get('releasever_minor')
 
     @releasever_minor.setter

--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -431,6 +431,32 @@ class MainConf(BaseConfig):
         self.substitutions['releasever'] = str(val)
 
     @property
+    def releasever_major(self):
+        # :api
+        return self.substitutions.get('releasever_major')
+
+    @releasever_major.setter
+    def releasever_major(self, val):
+        # :api
+        if val is None:
+            self.substitutions.pop('releasever_major', None)
+            return
+        self.substitutions['releasever_major'] = str(val)
+
+    @property
+    def releasever_minor(self):
+        # :api
+        return self.substitutions.get('releasever_minor')
+
+    @releasever_minor.setter
+    def releasever_minor(self, val):
+        # :api
+        if val is None:
+            self.substitutions.pop('releasever_minor', None)
+            return
+        self.substitutions['releasever_minor'] = str(val)
+
+    @property
     def arch(self):
         # :api
         return self.substitutions.get('arch')

--- a/dnf/conf/substitutions.py
+++ b/dnf/conf/substitutions.py
@@ -22,11 +22,12 @@ import logging
 import os
 import re
 
+from libdnf.conf import ConfigParser
 from dnf.i18n import _
 from dnf.exceptions import ReadOnlyVariableError
 
 ENVIRONMENT_VARS_RE = re.compile(r'^DNF_VAR_[A-Za-z0-9_]+$')
-READ_ONLY_VARIABLES = frozenset(("releasever_major", "releasever_minor"))
+READ_ONLY_VARIABLES = frozenset()
 logger = logging.getLogger('dnf')
 
 
@@ -45,18 +46,6 @@ class Substitutions(dict):
             elif key in numericvars:
                 self[key] = val
 
-    @staticmethod
-    def _split_releasever(releasever):
-        # type: (str) -> tuple[str, str]
-        pos = releasever.find(".")
-        if pos == -1:
-            releasever_major = releasever
-            releasever_minor = ""
-        else:
-            releasever_major = releasever[:pos]
-            releasever_minor = releasever[pos + 1:]
-        return releasever_major, releasever_minor
-
     def __setitem__(self, key, value):
         if Substitutions.is_read_only(key):
             raise ReadOnlyVariableError(f"Variable \"{key}\" is read-only", variable_name=key)
@@ -65,7 +54,7 @@ class Substitutions(dict):
         setitem(key, value)
 
         if key == "releasever" and value:
-            releasever_major, releasever_minor = Substitutions._split_releasever(value)
+            releasever_major, releasever_minor = ConfigParser.splitReleasever(value)
             setitem("releasever_major", releasever_major)
             setitem("releasever_minor", releasever_minor)
 

--- a/dnf/const.py.in
+++ b/dnf/const.py.in
@@ -25,6 +25,8 @@ CONF_AUTOMATIC_FILENAME='/etc/dnf/automatic.conf'
 DISTROVERPKG=('system-release(releasever)', 'system-release',
               'distribution-release(releasever)', 'distribution-release',
               'redhat-release', 'suse-release')
+DISTROVER_MAJOR_PKG='system-release(releasever_major)'
+DISTROVER_MINOR_PKG='system-release(releasever_minor)'
 GROUP_PACKAGE_TYPES = ('mandatory', 'default', 'conditional') # :api
 INSTALLONLYPKGS=['kernel', 'kernel-PAE',
                  'installonlypkg(kernel)',

--- a/doc/api_rpm.rst
+++ b/doc/api_rpm.rst
@@ -27,6 +27,14 @@
 
   Returns ``None`` if the information can not be determined (perhaps because the tree has no RPMDB).
 
+.. function:: detect_releasevers(installroot)
+
+  Returns a tuple of the release name, overridden major release, and overridden minor release of the distribution of the tree rooted at `installroot`. The function uses information from RPMDB found under the tree. The major and minor release versions are usually derived from the release version by splitting it on the first ``.``, but distributions can override the derived major and minor versions. It's preferred to use ``detect_releasevers`` over ``detect_releasever``; if you use the latter, you will not be aware of distribution overrides for the major and minor release versions.
+
+  Returns ``(None, None, None)`` if the information can not be determined (perhaps because the tree has no RPMDB).
+
+  If the distribution does not override the release major version, then the second item of the returned tuple will be ``None``. Likewise, if the release minor version is not overridden, the third return value will be ``None``.
+
 .. function:: basearch(arch)
 
   Return base architecture of the processor based on `arch` type given. E.g. when `arch` i686 is given then the returned value will be i386.

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -337,10 +337,12 @@ Options
 ``--releasever_major=<major version>``
     Override the releasever_major variable, which is usually automatically
     detected or taken from the part of ``$releasever`` before the first ``.``.
+    This option does not affect the ``$releasever`` variable.
 
 ``--releasever_minor=<minor version>``
     Override the releasever_minor variable, which is usually automatically
     detected or taken from the part of ``$releasever`` after the first ``.``.
+    This option does not affect the ``$releasever`` variable.
 
 .. _repofrompath_options-label:
 

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -334,6 +334,14 @@ Options
     Configure DNF as if the distribution release was ``<release>``. This can
     affect cache paths, values in configuration files and mirrorlist URLs.
 
+``--releasever_major=<major version>``
+    Override the releasever_major variable, which is usually automatically
+    detected or taken from the part of ``$releasever`` before the first ``.``.
+
+``--releasever_minor=<minor version>``
+    Override the releasever_minor variable, which is usually automatically
+    detected or taken from the part of ``$releasever`` after the first ``.``.
+
 .. _repofrompath_options-label:
 
 

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -503,6 +503,8 @@ configuration file by your distribution to override the DNF defaults.
 
     The ``$releasever_major`` and ``$releasever_minor`` variables will be automatically derived from ``$releasever`` by splitting it on the first ``.``. For example, if ``$releasever`` is set to ``1.23``, then ``$releasever_major`` will be ``1`` and ``$releasever_minor`` will be ``23``.
 
+    ``$releasever_major`` and ``$releasever_minor`` can also be set by the distribution.
+
     See also :ref:`repo variables <repo-variables-label>`.
 
 .. _reposdir-label:

--- a/doc/examples/install_extension.py
+++ b/doc/examples/install_extension.py
@@ -32,8 +32,12 @@ if __name__ == '__main__':
 
     with dnf.Base() as base:
         # Substitutions are needed for correct interpretation of repo files.
-        RELEASEVER = dnf.rpm.detect_releasever(base.conf.installroot)
+        RELEASEVER, MAJOR, MINOR = dnf.rpm.detect_releasever(base.conf.installroot)
         base.conf.substitutions['releasever'] = RELEASEVER
+        if MAJOR is not None:
+            base.conf.substitutions['releasever_major'] = MAJOR
+        if MINOR is not None:
+            base.conf.substitutions['releasever_minor'] = MINOR
         # Repositories are needed if we want to install anything.
         base.read_all_repos()
         # A sack is required by marking methods and dependency resolving.

--- a/tests/api/test_dnf_rpm.py
+++ b/tests/api/test_dnf_rpm.py
@@ -14,6 +14,10 @@ class DnfRpmApiTest(TestCase):
         # dnf.rpm.detect_releasever
         self.assertHasAttr(dnf.rpm, "detect_releasever")
 
+    def test_detect_releasevers(self):
+        # dnf.rpm.detect_releasevers
+        self.assertHasAttr(dnf.rpm, "detect_releasevers")
+
     def test_basearch(self):
         # dnf.rpm.basearch
         self.assertHasAttr(dnf.rpm, "basearch")

--- a/tests/cli/commands/test_clean.py
+++ b/tests/cli/commands/test_clean.py
@@ -31,7 +31,7 @@ from tests.support import mock
 '''
 def _run(cli, args):
     with mock.patch('sys.stdout', new_callable=StringIO), \
-            mock.patch('dnf.rpm.detect_releasever', return_value=69):
+            mock.patch('dnf.rpm.detect_releasevers', return_value=(69, None, None)):
         cli.configure(['clean', '--config', '/dev/null'] + args)
         cli.run()
 

--- a/tests/conf/test_substitutions.py
+++ b/tests/conf/test_substitutions.py
@@ -56,16 +56,6 @@ class SubstitutionsFromEnvironmentTest(tests.support.TestCase):
         self.assertEqual('opera', conf.substitutions['GENRE'])
 
 
-class SubstitutionsReadOnlyTest(tests.support.TestCase):
-    def test_set_readonly(self):
-        conf = dnf.conf.Conf()
-        variable_name = "releasever_major"
-        self.assertTrue(Substitutions.is_read_only(variable_name))
-        with self.assertRaises(ReadOnlyVariableError) as cm:
-            conf.substitutions["releasever_major"] = "1"
-        self.assertEqual(cm.exception.variable_name, "releasever_major")
-
-
 class SubstitutionsReleaseverTest(tests.support.TestCase):
     def test_releasever_simple(self):
         conf = dnf.conf.Conf()
@@ -84,3 +74,12 @@ class SubstitutionsReleaseverTest(tests.support.TestCase):
         conf.substitutions["releasever"] = "1.23.45"
         self.assertEqual(conf.substitutions["releasever_major"], "1")
         self.assertEqual(conf.substitutions["releasever_minor"], "23.45")
+
+    def test_releasever_major_minor_overrides(self):
+        conf = dnf.conf.Conf()
+        conf.substitutions["releasever"] = "1.23"
+        conf.substitutions["releasever_major"] = "45"
+        conf.substitutions["releasever_minor"] = "67"
+        self.assertEqual(conf.substitutions["releasever"], "1.23")
+        self.assertEqual(conf.substitutions["releasever_major"], "45")
+        self.assertEqual(conf.substitutions["releasever_minor"], "67")

--- a/tests/support.py
+++ b/tests/support.py
@@ -177,7 +177,7 @@ def command_run(cmd, args):
 
 class Base(dnf.Base):
     def __init__(self, *args, **kwargs):
-        with mock.patch('dnf.rpm.detect_releasever', return_value=69):
+        with mock.patch('dnf.rpm.detect_releasevers', return_value=(69, None, None)):
             super(Base, self).__init__(*args, **kwargs)
 
 # mock objects

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -57,7 +57,7 @@ class BaseTest(tests.support.TestCase):
         self.assertIsNotNone(base)
         base.close()
 
-    @mock.patch('dnf.rpm.detect_releasever', lambda x: 'x')
+    @mock.patch('dnf.rpm.detect_releasevers', lambda x: ('x', None, None))
     @mock.patch('dnf.util.am_i_root', lambda: True)
     def test_default_config_root(self):
         base = dnf.Base()
@@ -67,7 +67,7 @@ class BaseTest(tests.support.TestCase):
         self.assertIsNotNone(reg.match(base.conf.cachedir))
         base.close()
 
-    @mock.patch('dnf.rpm.detect_releasever', lambda x: 'x')
+    @mock.patch('dnf.rpm.detect_releasevers', lambda x: ('x', None, None))
     @mock.patch('dnf.util.am_i_root', lambda: False)
     def test_default_config_user(self):
         base = dnf.Base()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -191,7 +191,7 @@ class ConfigureTest(tests.support.DnfBaseTestCase):
         # call setUp() once again *after* am_i_root() is mocked so the cachedir is set as expected
         self.setUp()
         self.base._conf.installroot = self._installroot
-        with mock.patch('dnf.rpm.detect_releasever', return_value=69):
+        with mock.patch('dnf.rpm.detect_releasevers', return_value=(69, None, None)):
             self.cli.configure(['update', '-c', self.conffile])
         reg = re.compile('^' + self._installroot + '/var/tmp/dnf-[.a-zA-Z0-9_-]+$')
         self.assertIsNotNone(reg.match(self.base.conf.cachedir))
@@ -203,7 +203,7 @@ class ConfigureTest(tests.support.DnfBaseTestCase):
     def test_configure_root(self):
         """ Test Cli.configure as root."""
         self.base._conf = dnf.conf.Conf()
-        with mock.patch('dnf.rpm.detect_releasever', return_value=69):
+        with mock.patch('dnf.rpm.detect_releasevers', return_value=(69, None, None)):
             self.cli.configure(['update', '--nogpgcheck', '-c', self.conffile])
         reg = re.compile('^/var/cache/dnf$')
         self.assertIsNotNone(reg.match(self.base.conf.system_cachedir))
@@ -213,7 +213,7 @@ class ConfigureTest(tests.support.DnfBaseTestCase):
 
     def test_configure_verbose(self):
         self.base._conf.installroot = self._installroot
-        with mock.patch('dnf.rpm.detect_releasever', return_value=69):
+        with mock.patch('dnf.rpm.detect_releasevers', return_value=(69, None, None)):
             self.cli.configure(['-v', 'update', '-c', self.conffile])
         parser = argparse.ArgumentParser()
         expected = "%s -v update -c %s " % (parser.prog, self.conffile)
@@ -225,7 +225,7 @@ class ConfigureTest(tests.support.DnfBaseTestCase):
     @mock.patch('os.path.exists', return_value=True)
     def test_conf_exists_in_installroot(self, ospathexists):
         with mock.patch('logging.Logger.warning'), \
-                mock.patch('dnf.rpm.detect_releasever', return_value=69):
+                mock.patch('dnf.rpm.detect_releasevers', return_value=(69, None, None)):
             self.cli.configure(['--installroot', '/roots/dnf', 'update'])
         self.assertEqual(self.base.conf.config_file_path, '/roots/dnf/etc/dnf/dnf.conf')
         self.assertEqual(self.base.conf.installroot, '/roots/dnf')
@@ -233,7 +233,7 @@ class ConfigureTest(tests.support.DnfBaseTestCase):
     @mock.patch('dnf.cli.cli.Cli._parse_commands', new=mock.MagicMock)
     @mock.patch('os.path.exists', return_value=False)
     def test_conf_notexists_in_installroot(self, ospathexists):
-        with mock.patch('dnf.rpm.detect_releasever', return_value=69):
+        with mock.patch('dnf.rpm.detect_releasevers', return_value=(69, None, None)):
             self.cli.configure(['--installroot', '/roots/dnf', 'update'])
         self.assertEqual(self.base.conf.config_file_path, '/etc/dnf/dnf.conf')
         self.assertEqual(self.base.conf.installroot, '/roots/dnf')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -145,3 +145,19 @@ class ConfTest(tests.support.TestCase):
         conf = Conf()
         with self.assertRaises(dnf.exceptions.ConfigError):
             conf.debuglevel = '11'
+
+    def test_releasever_major_minor(self):
+        conf = Conf()
+        conf.releasever = '1.2'
+        self.assertEqual(conf.releasever_major, '1')
+        self.assertEqual(conf.releasever_minor, '2')
+
+        # override releasever_major
+        conf.releasever_major = '3'
+        self.assertEqual(conf.releasever_major, '3')
+        self.assertEqual(conf.releasever_minor, '2')
+
+        # override releasever_minor
+        conf.releasever_minor = '4'
+        self.assertEqual(conf.releasever_major, '3')
+        self.assertEqual(conf.releasever_minor, '4')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -149,15 +149,18 @@ class ConfTest(tests.support.TestCase):
     def test_releasever_major_minor(self):
         conf = Conf()
         conf.releasever = '1.2'
+        self.assertEqual(conf.releasever, '1.2')
         self.assertEqual(conf.releasever_major, '1')
         self.assertEqual(conf.releasever_minor, '2')
 
         # override releasever_major
         conf.releasever_major = '3'
+        self.assertEqual(conf.releasever, '1.2')
         self.assertEqual(conf.releasever_major, '3')
         self.assertEqual(conf.releasever_minor, '2')
 
         # override releasever_minor
         conf.releasever_minor = '4'
+        self.assertEqual(conf.releasever, '1.2')
         self.assertEqual(conf.releasever_major, '3')
         self.assertEqual(conf.releasever_minor, '4')


### PR DESCRIPTION
This is a backport of #2198 to RHEL 10.  This patchset requires https://github.com/rpm-software-management/libdnf/pull/1697.

Resolves: https://issues.redhat.com/browse/RHEL-68034