### PR TITLE
Require one transaction ID for history list + info

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -67,6 +67,7 @@ DNF CONTRIBUTORS
     Baurzhan Muftakhidinov <baurthefirst@gmail.com>
     Christopher Meng <cickumqt@gmail.com>
     Daniel Mach <dmach@redhat.com>
+    Dane H Lim <slimdane@amazon.com>
     Dave Johansen <davejohansen@gmail.com>
     Derick Diaz <derickdiaz123@outlook.com>
     Dominik Mierzejewski <dominik@greysector.net>

--- a/dnf/cli/commands/history.py
+++ b/dnf/cli/commands/history.py
@@ -116,7 +116,7 @@ class HistoryCommand(commands.Command):
             self.base.conf.install_weak_deps = False
 
             dnf.cli.commands._checkGPGKey(self.base, self.cli)
-        elif self.opts.transactions_action == 'store':
+        elif self.opts.transactions_action in ['store', 'list', 'info']:
             self._require_one_transaction_id = True
             if not self.opts.transactions:
                 raise dnf.cli.CliError(_('No transaction ID or package name given.'))


### PR DESCRIPTION
### Summary
<!-- What does this pull request do? -->
Require one transaction ID for `dnf history` command actions `list` and `info`. This is a bugfix that resolves https://github.com/rpm-software-management/dnf/issues/2213.

Currently, `dnf history` command actions `list` and `info` are missing from the set of actions which should require one transaction ID.

### Implementation details
<!-- How are the changes implemented? -->
Set `self._require_one_transaction_id = True` for `dnf history` command actions `list` and `info`.

### Testing
<!-- How was this tested? -->
Using a Fedora 41 instance  with `containerd` not installed, I ran `dnf history list containerd` and `dnf history info containerd` with and without the changes from this pull request. 

I verified that without these changes, the commands return a zero exit status and do not write a message to `stderr`.
<details>

<summary>Click here to expand for full output of commands without changes from this pull request</summary>

```
$ dnf --version
4.22.0
  Installed: rpm-0:4.20.0-1.fc41.x86_64 at Fri 06 Dec 2024 07:18:57 AM GMT
  Built    : Fedora Project at Tue 08 Oct 2024 03:18:49 PM GMT

$ sudo dnf history list containerd 2>&1 1>/dev/null ; echo $?
0

$ sudo dnf history list containerd ; echo $?
No transaction which manipulates package 'containerd' was found.
0

$ sudo dnf history info containerd 2>&1 1>/dev/null ; echo $?
0

$ sudo dnf history info  containerd ; echo $?
No transaction which manipulates package 'containerd' was found.
0
```

</details>

I also built from source with these pull request's changes included (by following [these instructions](https://github.com/rpm-software-management/dnf?tab=readme-ov-file#building-from-source)) and then verified using the built `dnf` that the commands return a non-zero exit status and write an error message to `stderr`.

<details>

<summary>Click here to expand for full output of commands with changes from this pull request</summary>

```
$ PYTHONPATH=`readlink -f .` bin/dnf-3 --version
4.22.0
  Installed: rpm-0:4.20.0-1.fc41.x86_64 at Fri 06 Dec 2024 07:18:57 AM GMT
  Built    : Fedora Project at Tue 08 Oct 2024 03:18:49 PM GMT

$ PYTHONPATH=`readlink -f .` bin/dnf-3 history list containerd 2>&1 1>/dev/null ; echo $?
No transaction which manipulates package 'containerd' was found.
1

$ PYTHONPATH=`readlink -f .` bin/dnf-3 history list containerd ; echo $?
No transaction which manipulates package 'containerd' was found.
1

$ PYTHONPATH=`readlink -f .` bin/dnf-3 history info containerd 2>&1 1>/dev/null ; echo $?
No transaction which manipulates package 'containerd' was found.
1

$ PYTHONPATH=`readlink -f .` bin/dnf-3 history info containerd ; echo $?
No transaction which manipulates package 'containerd' was found.
1
```

</details>

