### PR TITLE
Add exit code change of some history subcommands

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -67,6 +67,7 @@ DNF CONTRIBUTORS
     Baurzhan Muftakhidinov <baurthefirst@gmail.com>
     Christopher Meng <cickumqt@gmail.com>
     Daniel Mach <dmach@redhat.com>
+    Dane H Lim <slimdane@amazon.com>
     Dave Johansen <davejohansen@gmail.com>
     Derick Diaz <derickdiaz123@outlook.com>
     Dominik Mierzejewski <dominik@greysector.net>

--- a/doc/cli_vs_yum.rst
+++ b/doc/cli_vs_yum.rst
@@ -314,6 +314,15 @@ Following sub-commands were removed:
 * langlist
 * langinfo
 
+======================================================================================
+``dnf history`` subcommands ``list`` and ``info`` return 0 when transactions not found
+======================================================================================
+DNF ``dnf history list`` and ``dnf history info`` return a zero exit status when they
+fail to find transactions for a specified package.
+
+This is different from corresponding YUM ``yum history package-list`` and
+``yum history list``, which both return a non-zero exit status when they fail to find
+ transactions for a specified package.
 
 ###############################################
  Changes in DNF plugins compared to YUM plugins


### PR DESCRIPTION
[`dnf history`](https://dnf.readthedocs.io/en/latest/command_ref.html#history-command) subcommands `list` and `info` do not return non-zero exit status when they fail to find transactions for a specified package/[`<package-name-spec>`](https://dnf.readthedocs.io/en/latest/command_ref.html#specifying-packages). This is an undocumented behavior change relative to the corresponding `yum history package-list` and `yum history list`, and this pull request addresses that.

Closes #2213 
