### PR TITLE
README: direct to Libera.Chat instead of Freenode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,4 +131,4 @@ The DNF package distribution contains man pages, dnf(8) and dnf.conf(8). It is a
 
 Please report discovered bugs to the `Red Hat bugzilla <https://bugzilla.redhat.com/>`_ following this `guide <https://github.com/rpm-software-management/dnf/wiki/Bug-Reporting>`_. If you planned to propose the patch in the report, consider `Contribution`_ instead.
 
-Freenode's irc channel ``#yum`` is meant for discussions related to both YUM and DNF. Questions should be asked there, issues discussed. Remember: ``#yum`` is not a support channel and prior research is expected from the questioner.
+Libera.Chat's IRC channel ``#yum`` is meant for discussions related to both YUM and DNF. Questions should be asked there, issues discussed. Remember: ``#yum`` is not a support channel, and prior research is expected from the questioner.


### PR DESCRIPTION
Freenode's `#yum` channel appears quite dead following the Freenode takeover years ago. New people should be directed to Libera.Chat's `#yum` instead.