### PR TITLE
rhel-9.7: Add dnf4 provides and symlink /usr/bin/dnf4 -> /usr/bin/dnf-3

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -226,6 +226,7 @@ mkdir -p %{buildroot}%{_localstatedir}/log/
 mkdir -p %{buildroot}%{_var}/cache/dnf/
 touch %{buildroot}%{_localstatedir}/log/%{name}.log
 ln -sr %{buildroot}%{_bindir}/dnf-3 %{buildroot}%{_bindir}/dnf
+ln -sr %{buildroot}%{_bindir}/dnf-3 %{buildroot}%{_bindir}/dnf4
 mv %{buildroot}%{_bindir}/dnf-automatic-3 %{buildroot}%{_bindir}/dnf-automatic
 rm -vf %{buildroot}%{_bindir}/dnf-automatic-*
 
@@ -354,6 +355,7 @@ popd
 
 %files -n python3-%{name}
 %{_bindir}/%{name}-3
+%{_bindir}/%{name}4
 %exclude %{python3_sitelib}/%{name}/automatic
 %{python3_sitelib}/%{name}/
 %dir %{py3pluginpath}

--- a/dnf.spec
+++ b/dnf.spec
@@ -171,6 +171,7 @@ Requires:       rpm-plugin-systemd-inhibit
 %else
 Recommends:     (rpm-plugin-systemd-inhibit if systemd)
 %endif
+Provides:       dnf4 = %{version}-%{release}
 
 %description -n python3-%{name}
 Python 3 interface to DNF.


### PR DESCRIPTION
Backport of https://github.com/rpm-software-management/dnf/pull/1964 and https://github.com/rpm-software-management/dnf/pull/2190 to rhel-9.7.

Resolves https://issues.redhat.com/browse/RHEL-82310.