### PR TITLE
rhel-10.1: spec: Provide dnf4 by python3-dnf

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -159,6 +159,7 @@ Requires:       rpm-plugin-systemd-inhibit
 %else
 Recommends:     (rpm-plugin-systemd-inhibit if systemd)
 %endif
+Provides:       dnf4 = %{version}-%{release}
 Provides:       dnf-command(alias)
 Provides:       dnf-command(autoremove)
 Provides:       dnf-command(check-update)


### PR DESCRIPTION
Backport of https://github.com/rpm-software-management/dnf/pull/2190 to rhel-10.1.

Resolves: https://issues.redhat.com/browse/RHEL-82311