### PR TITLE
Do not disable dnf-automatic.timer when upgrading to dnf5-plugin-automatic

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -314,7 +314,10 @@ popd
 %systemd_post dnf-automatic.timer dnf-automatic-notifyonly.timer dnf-automatic-download.timer dnf-automatic-install.timer
 
 %preun automatic
-%systemd_preun dnf-automatic.timer dnf-automatic-notifyonly.timer dnf-automatic-download.timer dnf-automatic-install.timer
+if [ ! -e %{_unitdir}/dnf5-automatic.timer ]; then
+    %systemd_preun dnf-automatic.timer
+fi
+%systemd_preun dnf-automatic-notifyonly.timer dnf-automatic-download.timer dnf-automatic-install.timer
 
 %postun automatic
 %systemd_postun_with_restart dnf-automatic.timer dnf-automatic-notifyonly.timer dnf-automatic-download.timer dnf-automatic-install.timer


### PR DESCRIPTION
Both dnf-automatic and dnf5-plugin-automatic packages deliver dnf-automatic.timer. When upgrading from dnf to dnf5, dnf-automatic's preun script saw that dnf-automatic package was being uninstalled and hence disabled dnf-automatic.timer. As a result upgrading people found the upgraded system without automatically applied updates.

It is supposed that people who have enabled dnf-automatic.timer want to keep it enabled even after migrating to DNF5.

This patch stops disabling dnf-automatic.timer when dnf-automatic package is uinstalled and there is dnf5-automatic.timer. Existence of dnf5-automatic.timer means that dnf5-plugin-automatic is installed. The new dnf-automatic.timer is a symbolic link to
dnf5-automatic.timer and both names can be used interchangably by systemd.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2358865