### PR TITLE
`--disableexcludes` and `--disableexcludepkgs` values are not optional (man page)

### DIFF
--- a/dnf/cli/option_parser.py
+++ b/dnf/cli/option_parser.py
@@ -182,7 +182,7 @@ class OptionParser(argparse.ArgumentParser):
                                  help=_("show {prog} version and exit").format(
                                      prog=dnf.util.MAIN_PROG_UPPER))
         general_grp.add_argument("--installroot", help=_("set install root"),
-                                 metavar='PATH]')
+                                 metavar='PATH')
         general_grp.add_argument("--nodocs", action="store_const", const=['nodocs'], dest='tsflags',
                                  help=_("do not install documentations"))
         general_grp.add_argument("--noplugins", action="store_false",
@@ -191,11 +191,11 @@ class OptionParser(argparse.ArgumentParser):
         general_grp.add_argument("--enableplugin", dest="enableplugin",
                                  default=[], action=self._SplitCallback,
                                  help=_("enable plugins by name"),
-                                 metavar='PLUGIN]')
+                                 metavar='PLUGIN')
         general_grp.add_argument("--disableplugin", dest="disableplugin",
                                  default=[], action=self._SplitCallback,
                                  help=_("disable plugins by name"),
-                                 metavar='PLUGIN]')
+                                 metavar='PLUGIN')
         general_grp.add_argument("--releasever", default=None,
                                  help=_("override the value of $releasever"
                                         " in config and repo files"))

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -164,7 +164,7 @@ Options
 
 .. _disableexcludes-label:
 
-``--disableexcludes=[all|main|<repoid>], --disableexcludepkgs=[all|main|<repoid>]``
+``--disableexcludes={all|main|<repoid>}, --disableexcludepkgs={all|main|<repoid>}``
     Disable ``excludepkgs`` and ``includepkgs`` configuration options. Takes one of the following three options:
 
     * ``all``, disables all ``excludepkgs`` and ``includepkgs`` configurations


### PR DESCRIPTION
This is a follow up for https://github.com/rpm-software-management/dnf/pull/2218 I forgot to fix the man page plus I introduced several typos.