### PR TITLE
Fix changelog date calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,12 @@ asthelper.completions
 TAGS
 build/
 package/dnf.spec
+dnf/cli/completion_helper.py
 dnf/const.py
+doc/conf.py
+file.conf
+tests/modules/var/
+usr/
 bin/dnf*-2
 bin/dnf*-3
 bin/yum-2

--- a/AUTHORS
+++ b/AUTHORS
@@ -63,6 +63,7 @@ DNF CONTRIBUTORS
     Adam Williamson <awilliam@redhat.com>
     Albert Uchytil <auchytil@redhat.com>
     Alberto Ruiz <aruiz@redhat.com>
+    Alex Hedges <dnf@alexhedges.dev>
     Anish Bhatt <anish.bhatt@salesforce.com>
     Baurzhan Muftakhidinov <baurthefirst@gmail.com>
     Christopher Meng <cickumqt@gmail.com>

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -351,15 +351,15 @@ class BaseCli(dnf.Base):
             raise dnf.exceptions.Error(_("GPG check FAILED"))
 
     def latest_changelogs(self, package):
-        """Return list of changelogs for package newer then installed version"""
-        newest = None
-        # find the date of the newest changelog for installed version of package
+        """Return list of changelogs for package newer then newest installed version"""
+        newest_times = []
+        # find the date of the newest changelog for installed versions of package
         # stored in rpmdb
         for mi in self._rpmconn.readonly_ts.dbMatch('name', package.name):
             changelogtimes = mi[rpm.RPMTAG_CHANGELOGTIME]
             if changelogtimes:
-                newest = datetime.date.fromtimestamp(changelogtimes[0])
-                break
+                newest_times.append(datetime.date.fromtimestamp(changelogtimes[0]))
+        newest = max(newest_times) if newest_times else None
         chlogs = [chlog for chlog in package.changelogs
                   if newest is None or chlog['timestamp'] > newest]
         return chlogs

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -50,6 +50,8 @@ def drop_all_handlers():
     for logger_name in ('dnf', 'dnf.rpm'):
         logger = logging.getLogger(logger_name)
         for handler in logger.handlers[:]:
+            if isinstance(handler, logging.FileHandler):
+                handler.close()
             logger.removeHandler(handler)
 
 


### PR DESCRIPTION
The logic in `dnf.cli.cli.BaseCli.latest_changelogs()` would loop over installed packages with the target package name to find one with changelog times, take the newest date from that, and break out of the loop immediately afterwards.

This behavior was presumably implemented for efficiency, but it assumes that there is only one version of the package installed. For some packages (e.g., `kernel`), multiple versions can be installed at once. If the first version returned is not the latest, then the function would calculate the date of the newest changelog entry incorrectly.

The solution is simple: loop over all versions of the package and take the latest changelog entry from the entire set.

---

I've had this branch on my local machine since 2023, but I forgot to submit it. I figured I'd upstream it before I updated to a version of Fedora using DNF5.

Some of these commits were added to discover problems that I discovered setting up the development environment. I can split them out into separate PRs if you would prefer that.