### PR TITLE
Mark transient transactions in DNF history

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -11,12 +11,12 @@ jobs:
   - job: copr_build
     trigger: pull_request
     targets:
-      - fedora-all
+      - centos-stream-9-x86_64
   - job: tests
     trigger: pull_request
     identifier: "dnf-tests"
     targets:
-      - fedora-all
-    fmf_url: https://github.com/rpm-software-management/ci-dnf-stack.git
-    fmf_ref: enable-tmt-dnf-4-stack
-    tmt_plan: "^/plans/integration/behave-dnf$"
+      - centos-stream-9-x86_64
+    fmf_url: https://github.com/evan-goode/ci-dnf-stack.git
+    fmf_ref: evan-goode/bootc
+    tmt_plan: "^/plans/integration/bootc-behave-dnf$"

--- a/dnf.spec
+++ b/dnf.spec
@@ -2,7 +2,7 @@
 %define __cmake_in_source_build 1
 
 # default dependencies
-%global hawkey_version 0.74.0
+%global hawkey_version 0.75.0
 %global libcomps_version 0.1.8
 %global libmodulemd_version 2.9.3
 %global rpm_version 4.14.0

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -118,6 +118,7 @@ class Base(object):
         self._update_security_options = {}
         self._allow_erasing = False
         self._repo_set_imported_gpg_keys = set()
+        self._persistence = libdnf.transaction.TransactionPersistence_UNKNOWN
         self.output = None
 
     def __enter__(self):
@@ -973,7 +974,7 @@ class Base(object):
                 else:
                     rpmdb_version = old.end_rpmdb_version
 
-                self.history.beg(rpmdb_version, [], [], cmdline)
+                self.history.beg(rpmdb_version, [], [], cmdline=cmdline, persistence=self._persistence)
                 self.history.end(rpmdb_version)
             self._plugins.run_pre_transaction()
             self._plugins.run_transaction()
@@ -1124,7 +1125,8 @@ class Base(object):
                 cmdline = ' '.join(self.cmds)
 
             comment = self.conf.comment if self.conf.comment else ""
-            tid = self.history.beg(rpmdbv, using_pkgs, [], cmdline, comment)
+            tid = self.history.beg(rpmdbv, using_pkgs, [], cmdline=cmdline,
+                                   comment=comment, persistence=self._persistence)
 
         if self.conf.reset_nice:
             onice = os.nice(0)

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -244,10 +244,13 @@ class BaseCli(dnf.Base):
                         logger.info(_("A transient overlay will be created on /usr that will be discarded on reboot. "
                                       "Keep in mind that changes to /etc and /var will still persist, and packages "
                                       "commonly modify these directories."))
+                self._persistence = libdnf.transaction.TransactionPersistence_TRANSIENT
             else:
                 # Not a bootc transaction.
                 if self.conf.persistence == "transient":
                     raise CliError(_("Transient transactions are only supported on bootc systems."))
+
+                self._persistence = libdnf.transaction.TransactionPersistence_PERSIST
 
             if self._promptWanted():
                 if self.conf.assumeno or not self.output.userconfirm():
@@ -952,6 +955,7 @@ class Cli(object):
                       "dnf.conf(5) for how to squelch this message)"
                       )
                 )
+
 
     def _read_conf_file(self, releasever=None, releasever_major=None, releasever_minor=None):
         timer = dnf.logging.Timer('config')

--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -1777,6 +1777,14 @@ Transaction Summary
             else:
                 print(_("Command Line   :"), old.cmdline)
 
+        if old.persistence == libdnf.transaction.TransactionPersistence_PERSIST:
+            persistence_str = "Persist"
+        elif old.persistence == libdnf.transaction.TransactionPersistence_TRANSIENT:
+            persistence_str = "Transient"
+        else:
+            persistence_str = "Unknown"
+        print(_("Persistence    :"), persistence_str)
+
         if old.comment is not None:
             if isinstance(old.comment, (list, tuple)):
                 for comment in old.comment:

--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -1777,13 +1777,19 @@ Transaction Summary
             else:
                 print(_("Command Line   :"), old.cmdline)
 
-        if old.persistence == libdnf.transaction.TransactionPersistence_PERSIST:
-            persistence_str = "Persist"
-        elif old.persistence == libdnf.transaction.TransactionPersistence_TRANSIENT:
-            persistence_str = "Transient"
+        def print_persistence(persistence):
+            if old.persistence == libdnf.transaction.TransactionPersistence_PERSIST:
+                persistence_str = "Persist"
+            elif old.persistence == libdnf.transaction.TransactionPersistence_TRANSIENT:
+                persistence_str = "Transient"
+            else:
+                persistence_str = "Unknown"
+            print(_("Persistence    :"), persistence_str)
+        if isinstance(old.persistence, (list, tuple)):
+            for persistence in old.persistence:
+                print_persistence(persistence)
         else:
-            persistence_str = "Unknown"
-        print(_("Persistence    :"), persistence_str)
+            print_persistence(old.persistence)
 
         if old.comment is not None:
             if isinstance(old.comment, (list, tuple)):

--- a/dnf/db/history.py
+++ b/dnf/db/history.py
@@ -270,6 +270,10 @@ class MergedTransactionWrapper(TransactionWrapper):
         return self._trans.listCmdlines()
 
     @property
+    def persistence(self):
+        return self._trans.listPersistences()
+
+    @property
     def releasever(self):
         return self._trans.listReleasevers()
 

--- a/dnf/db/history.py
+++ b/dnf/db/history.py
@@ -222,6 +222,10 @@ class TransactionWrapper(object):
     def comment(self):
         return self._trans.getComment()
 
+    @property
+    def persistence(self):
+        return self._trans.getPersistence()
+
     def tids(self):
         return [self._trans.getId()]
 
@@ -418,7 +422,8 @@ class SwdbInterface(object):
 #        return result
 
     # TODO: rename to begin_transaction?
-    def beg(self, rpmdb_version, using_pkgs, tsis, cmdline=None, comment=""):
+    def beg(self, rpmdb_version, using_pkgs, tsis, cmdline=None, comment="",
+            persistence=libdnf.transaction.TransactionPersistence_UNKNOWN):
         try:
             self.swdb.initTransaction()
         except:
@@ -431,6 +436,7 @@ class SwdbInterface(object):
             int(misc.getloginuid()),
             comment)
         self.swdb.setReleasever(self.releasever)
+        self.swdb.setPersistence(persistence)
         self._tid = tid
 
         return tid


### PR DESCRIPTION
For all transactions, store whether the transaction was persistent or transient in the history DB. On bootc systems (or all systems?), display which transactions were transient in `dnf4 history info` and (probably?) `dnf4 history list`.

Requires https://github.com/rpm-software-management/libdnf/pull/1706.

For https://github.com/rpm-software-management/dnf/issues/2196.