### PR TITLE
spec: Fix executing ctest on RHEL < 10

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -282,7 +282,13 @@ rm %{buildroot}%{_unitdir}/%{name}-makecache.timer
 %endif
 
 %check
+%if 0%{?rhel} && 0%{?rhel} < 10
+pushd %{__cmake_builddir}
+ctest -VV
+popd
+%else
 %ctest -VV
+%endif
 
 
 %if %{without dnf5_obsoletes_dnf}


### PR DESCRIPTION
Commit ab1a0d54d25880b431dcad71eb5eaf0410a8b0fc (spec: Allow to build with ninja) broke spec parsing on RHEL 9 because %ctest macro is does not recongize any arguments there:

$ rpm --eval '%ctest -VV'
error: Unknown option V in ctest(:-:)

This patch falls back to a manual ctest invocation on RHEL < 10.