### PR TITLE
automatic: Expand email_to in command_email emitter to individual arguments

### DIFF
--- a/dnf/automatic/emitter.py
+++ b/dnf/automatic/emitter.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 from dnf.i18n import _
+import libdnf
 import logging
 import dnf.pycomp
 import smtplib
@@ -132,6 +133,20 @@ class EmailEmitter(Emitter):
             logger.error(msg)
 
 
+class ShellQuotedLists(dict):
+    """
+    Dictionary which returns values quoted with dnf.pycomp.shlex_quote().
+    If a looked-up value is a list or libdnf.module.VectorString, it will
+    quote the list members and then concatenate them with a space and return
+    the resulting string.
+    """
+    def __getitem__(self, key):
+        value = super(ShellQuotedLists, self).__getitem__(key)
+        if isinstance(value, (list, libdnf.module.VectorString)):
+            return ' '.join(dnf.pycomp.shlex_quote(item) for item in value)
+        else:
+            return dnf.pycomp.shlex_quote(value)
+
 class CommandEmitterMixIn(object):
     """
     Executes a desired command, and pushes data into its stdin.
@@ -147,9 +162,7 @@ class CommandEmitterMixIn(object):
         msg = self._prepare_msg()
         # all strings passed to shell should be quoted to avoid accidental code
         # execution
-        quoted_msg = dict((key, dnf.pycomp.shlex_quote(val))
-                          for key, val in msg.items())
-        command = command_fmt.format(**quoted_msg)
+        command = command_fmt.format_map(ShellQuotedLists(msg))
         stdin_feed = stdin_fmt.format(**msg).encode('utf-8')
 
         # Execute the command
@@ -177,7 +190,7 @@ class CommandEmailEmitter(CommandEmitterMixIn, EmailEmitter):
         return {'subject': subject,
                 'body': body,
                 'email_from': self._conf.email_from,
-                'email_to': ' '.join(self._conf.email_to)}
+                'email_to': self._conf.email_to}
 
 
 class StdIoEmitter(Emitter):


### PR DESCRIPTION
If /etc/dnf/automatic.conf has:

    [emitters]
    emit_via = command_email
    [command_email]
    email_to = root,test

a command incompatible with s-nail-14.9.25, a "mail" command implementation, was executed:

    execve("/usr/bin/mail", ["mail", "-Ssendwait", "-s", "Updates available on 'fedora-43'.", "-r", "root", "root test"], ...) = 0

The cause was that s-nail does not support multiple recipients in a single argument.

This patch changes how "{email_to}" expands in command_format formatting string. Now it expands into multiple, space separated arguments. The new syntax is also accepted by mailx tool.

Implementation detail: A list of email_to recipients passed in CommandEmitterMixIn does not inherit from "list" Python class or any other iterator. It's libdnf.module.VectorString class generated by Swig without. There the custom ShellQuotedLists formatting dictionary needs to refer to libdnf.module.VectorString type and include "libdnf" Python module explicitly.

Test: https://github.com/rpm-software-management/ci-dnf-stack/pull/1691

Resolve: #2241