### PR TITLE
rhel-9.7 backports for RHEL-84499, RHEL-84512

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,18 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: dnf.spec
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    targets:
+      - centos-stream-9-x86_64
+  - job: tests
+    trigger: pull_request
+    identifier: "dnf-tests"
+    targets:
+      - centos-stream-9-x86_64
+    fmf_url: https://github.com/evan-goode/ci-dnf-stack.git
+    fmf_ref: evan-goode/bootc
+    tmt_plan: "^/plans/integration/bootc-behave-dnf$"

--- a/.tito/tito.props
+++ b/.tito/tito.props
@@ -3,3 +3,4 @@ builder = tito.builder.Builder
 tagger = tito.tagger.VersionTagger
 changelog_do_not_remove_cherrypick = 0
 changelog_format = %s (%ae)
+test_version_suffix = .test

--- a/dnf.spec
+++ b/dnf.spec
@@ -301,6 +301,7 @@ popd
 %dir %{confdir}/modules.defaults.d
 %dir %{pluginconfpath}
 %dir %{confdir}/protected.d
+%dir %{confdir}/usr-drift-protected-paths.d
 %dir %{confdir}/vars
 %dir %{confdir}/aliases.d
 %exclude %{confdir}/aliases.d/zypper.conf

--- a/dnf.spec
+++ b/dnf.spec
@@ -2,7 +2,7 @@
 %define __cmake_in_source_build 1
 
 # default dependencies
-%global hawkey_version 0.74.0
+%global hawkey_version 0.75.0
 %global libcomps_version 0.1.8
 %global libmodulemd_version 2.9.3
 %global rpm_version 4.14.0

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -118,6 +118,7 @@ class Base(object):
         self._update_security_options = {}
         self._allow_erasing = False
         self._repo_set_imported_gpg_keys = set()
+        self._persistence = libdnf.transaction.TransactionPersistence_UNKNOWN
         self.output = None
 
     def __enter__(self):
@@ -964,7 +965,7 @@ class Base(object):
                 else:
                     rpmdb_version = old.end_rpmdb_version
 
-                self.history.beg(rpmdb_version, [], [], cmdline)
+                self.history.beg(rpmdb_version, [], [], cmdline=cmdline, persistence=self._persistence)
                 self.history.end(rpmdb_version)
             self._plugins.run_pre_transaction()
             self._plugins.run_transaction()
@@ -1115,7 +1116,8 @@ class Base(object):
                 cmdline = ' '.join(self.cmds)
 
             comment = self.conf.comment if self.conf.comment else ""
-            tid = self.history.beg(rpmdbv, using_pkgs, [], cmdline, comment)
+            tid = self.history.beg(rpmdbv, using_pkgs, [], cmdline=cmdline,
+                                   comment=comment, persistence=self._persistence)
 
         if self.conf.reset_nice:
             onice = os.nice(0)

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -244,10 +244,13 @@ class BaseCli(dnf.Base):
                         logger.info(_("A transient overlay will be created on /usr that will be discarded on reboot. "
                                       "Keep in mind that changes to /etc and /var will still persist, and packages "
                                       "commonly modify these directories."))
+                self._persistence = libdnf.transaction.TransactionPersistence_TRANSIENT
             else:
                 # Not a bootc transaction.
                 if self.conf.persistence == "transient":
                     raise CliError(_("Transient transactions are only supported on bootc systems."))
+
+                self._persistence = libdnf.transaction.TransactionPersistence_PERSIST
 
             if self._promptWanted():
                 if self.conf.assumeno or not self.output.userconfirm():

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -262,7 +262,7 @@ class BaseCli(dnf.Base):
                         logger.info(nevra)
                         for protected_path in protected_paths:
                             logger.info("  %s" % protected_path)
-                    raise CliError(_("Operation aborted."))
+                    raise CliError(_("Operation aborted. Pass --setopt=usr_drift_protected_paths= to disable this check and proceed anyway."))
 
             else:
                 # Not a bootc transaction.

--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -31,6 +31,7 @@ except ImportError:
     from collections import Sequence
 from collections import defaultdict
 import datetime
+from fnmatch import fnmatch
 import logging
 import operator
 import os
@@ -251,8 +252,8 @@ class BaseCli(dnf.Base):
                 transaction_protected_paths = defaultdict(list)
                 for pkg in trans:
                     for pkg_file_path in sorted(pkg.files):
-                        for protected_path in self.conf.usr_drift_protected_paths:
-                            if pkg_file_path.startswith("%s/" % protected_path) or pkg_file_path == protected_path:
+                        for protected_pattern in self.conf.usr_drift_protected_paths:
+                            if fnmatch(pkg_file_path, protected_pattern):
                                 transaction_protected_paths[pkg.nevra].append(pkg_file_path)
                 if transaction_protected_paths:
                     logger.info(_('This operation would modify the following paths, possibly introducing '

--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -1772,6 +1772,14 @@ Transaction Summary
             else:
                 print(_("Command Line   :"), old.cmdline)
 
+        if old.persistence == libdnf.transaction.TransactionPersistence_PERSIST:
+            persistence_str = "Persist"
+        elif old.persistence == libdnf.transaction.TransactionPersistence_TRANSIENT:
+            persistence_str = "Transient"
+        else:
+            persistence_str = "Unknown"
+        print(_("Persistence    :"), persistence_str)
+
         if old.comment is not None:
             if isinstance(old.comment, (list, tuple)):
                 for comment in old.comment:

--- a/dnf/cli/output.py
+++ b/dnf/cli/output.py
@@ -1772,13 +1772,19 @@ Transaction Summary
             else:
                 print(_("Command Line   :"), old.cmdline)
 
-        if old.persistence == libdnf.transaction.TransactionPersistence_PERSIST:
-            persistence_str = "Persist"
-        elif old.persistence == libdnf.transaction.TransactionPersistence_TRANSIENT:
-            persistence_str = "Transient"
+        def print_persistence(persistence):
+            if old.persistence == libdnf.transaction.TransactionPersistence_PERSIST:
+                persistence_str = "Persist"
+            elif old.persistence == libdnf.transaction.TransactionPersistence_TRANSIENT:
+                persistence_str = "Transient"
+            else:
+                persistence_str = "Unknown"
+            print(_("Persistence    :"), persistence_str)
+        if isinstance(old.persistence, (list, tuple)):
+            for persistence in old.persistence:
+                print_persistence(persistence)
         else:
-            persistence_str = "Unknown"
-        print(_("Persistence    :"), persistence_str)
+            print_persistence(old.persistence)
 
         if old.comment is not None:
             if isinstance(old.comment, (list, tuple)):

--- a/dnf/db/history.py
+++ b/dnf/db/history.py
@@ -270,6 +270,10 @@ class MergedTransactionWrapper(TransactionWrapper):
         return self._trans.listCmdlines()
 
     @property
+    def persistence(self):
+        return self._trans.listPersistences()
+
+    @property
     def releasever(self):
         return self._trans.listReleasevers()
 

--- a/dnf/db/history.py
+++ b/dnf/db/history.py
@@ -222,6 +222,10 @@ class TransactionWrapper(object):
     def comment(self):
         return self._trans.getComment()
 
+    @property
+    def persistence(self):
+        return self._trans.getPersistence()
+
     def tids(self):
         return [self._trans.getId()]
 
@@ -418,7 +422,8 @@ class SwdbInterface(object):
 #        return result
 
     # TODO: rename to begin_transaction?
-    def beg(self, rpmdb_version, using_pkgs, tsis, cmdline=None, comment=""):
+    def beg(self, rpmdb_version, using_pkgs, tsis, cmdline=None, comment="",
+            persistence=libdnf.transaction.TransactionPersistence_UNKNOWN):
         try:
             self.swdb.initTransaction()
         except:
@@ -431,6 +436,7 @@ class SwdbInterface(object):
             int(misc.getloginuid()),
             comment)
         self.swdb.setReleasever(self.releasever)
+        self.swdb.setPersistence(persistence)
         self._tid = tid
 
         return tid

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -549,6 +549,15 @@ configuration file by your distribution to override the DNF defaults.
 
     Set this to False to disable the automatic running of ``group upgrade`` when running the ``upgrade`` command. Default is ``True`` (perform the operation).
 
+.. _usr_drift_protected_paths-label:
+
+``usr_drift_protected_paths``
+    :ref:`list <list-label>`
+
+    List of paths that are likely to cause problems when their contents drift with respect to ``/usr``, e.g. ``/etc/pam.d/*``. If a transient transaction would modify these paths, DNF aborts the operation and prints an error. Supports globs. Defaults to ``glob:/etc/dnf/usr-drift-protected-paths.d/*.conf``. So a list of paths can be protected by creating a ``.conf`` file in ``/etc/dnf/usr-drift-protected-paths.d/`` containing one path (or glob pattern) per line.
+
+    When using ``persistence=transient`` on bootc systems, a transient overlay is created on ``/usr``, and any changes DNF makes to ``/usr`` will be discarded on reboot. However, other paths such as ``/etc`` and ``/var`` are (often) not backed by a transient overlay, so changes to them will persist across reboots. Usually, this "filesystem drift" is fine, but it can cause problems in certain situations. For example, a configuration file in ``/etc`` that's shared by multiple packages might reference a ``.so`` file under ``/usr/lib64`` that no longer exists.
+
 .. _varsdir_options-label:
 
 ``varsdir``

--- a/etc/dnf/CMakeLists.txt
+++ b/etc/dnf/CMakeLists.txt
@@ -1,3 +1,4 @@
 INSTALL (FILES "dnf-strict.conf" "dnf.conf" "automatic.conf" DESTINATION ${SYSCONFDIR}/dnf)
 ADD_SUBDIRECTORY (aliases.d)
 ADD_SUBDIRECTORY (protected.d)
+ADD_SUBDIRECTORY (usr-drift-protected-paths.d)

--- a/etc/dnf/usr-drift-protected-paths.d/CMakeLists.txt
+++ b/etc/dnf/usr-drift-protected-paths.d/CMakeLists.txt
@@ -1,0 +1,1 @@
+INSTALL(DIRECTORY DESTINATION ${SYSCONFDIR}/dnf/usr-drift-protected-paths.d)


### PR DESCRIPTION
This backports the following PRs to rhel-9.7:

- https://github.com/rpm-software-management/dnf/pull/2240
  For https://issues.redhat.com/browse/RHEL-84512
- https://github.com/rpm-software-management/dnf/pull/2244
  For https://issues.redhat.com/browse/RHEL-84499

Also includes a Tito configuration change to make testing builds easier.

Both ci-dnf-stack and TMT bootc tests are passing locally.