### PR TITLE
rhel-10.1: Add deprecation warning to modularity commands/docs

### DIFF
--- a/dnf/cli/commands/module.py
+++ b/dnf/cli/commands/module.py
@@ -349,7 +349,7 @@ class ModuleCommand(commands.Command):
     SUBCMDS_NOT_REQUIRED_ARG = {ListSubCommand}
 
     aliases = ("module",)
-    summary = _("Interact with Modules.")
+    summary = _("Interact with Modules. WARNING: modularity is deprecated, and functionality will be removed in a future release of DNF5.")
 
     def __init__(self, cli):
         super(ModuleCommand, self).__init__(cli)
@@ -389,6 +389,7 @@ class ModuleCommand(commands.Command):
                             help=_("Module specification"))
 
     def configure(self):
+        logger.warning(_("WARNING: modularity is deprecated, and functionality will be removed in a future release of DNF5."))
         try:
             self.subcmd = self._subcmd_name2obj[self.opts.subcmd[0]]
         except (CliError, KeyError):

--- a/doc/api_module.rst
+++ b/doc/api_module.rst
@@ -19,6 +19,8 @@
  Modularity Interface
 =====================
 
+.. warning:: Modularity is deprecated, and functionality will be removed in a future release of DNF5.
+
 .. module:: dnf.module.module_base
 
 

--- a/doc/command_ref.rst
+++ b/doc/command_ref.rst
@@ -1025,6 +1025,8 @@ Module Command
 
 | Command: ``module``
 
+.. warning:: Modularity is deprecated, and functionality will be removed in a future release of DNF5.
+
 Modularity overview is available at :ref:`man page dnf.modularity(7) <modularity-label>`.
 Module subcommands take :ref:`\<module-spec>\ <specifying_modules-label>`... arguments that specify modules or profiles.
 

--- a/doc/modularity.rst
+++ b/doc/modularity.rst
@@ -21,9 +21,10 @@
  Modularity
 ############
 
+.. warning:: Modularity is deprecated, and functionality will be removed in a future release of DNF5.
+
 Modularity is new way of building, organizing and delivering packages.
 For more details see: https://docs.pagure.org/modularity/
-
 
 =============
  Definitions


### PR DESCRIPTION
For https://issues.redhat.com/browse/RHEL-89940.

Backport of https://github.com/rpm-software-management/dnf/pull/2256 to rhel-10.0 for RHEL 10.0.z.