### PR TITLE
rhel-10.0: automatic: Fix detecting releasever_minor

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -986,9 +986,13 @@ class Cli(object):
                 if arg is not None:
                     return arg
             return None
+        # Setting conf.releasever rewrites conf.releasever_major and
+        # conf.releasever_minor. Copy them for later use.
+        old_releasever_major = conf.releasever_major
+        old_releasever_minor = conf.releasever_minor
         conf.releasever = or_else(releasever, conf.releasever)
-        conf.releasever_major = or_else(releasever_major, det_major, conf.releasever_major)
-        conf.releasever_minor = or_else(releasever_minor, det_minor, conf.releasever_minor)
+        conf.releasever_major = or_else(releasever_major, det_major, old_releasever_major)
+        conf.releasever_minor = or_else(releasever_minor, det_minor, old_releasever_minor)
 
         if conf.releasever is None:
             logger.warning(_("Unable to detect release version (use '--releasever' to specify "

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,6 +21,7 @@ from __future__ import unicode_literals
 
 import argparse
 
+import dnf
 import dnf.conf
 import dnf.conf.read
 import dnf.exceptions
@@ -164,3 +165,14 @@ class ConfTest(tests.support.TestCase):
         self.assertEqual(conf.releasever, '1.2')
         self.assertEqual(conf.releasever_major, '3')
         self.assertEqual(conf.releasever_minor, '4')
+
+    def test__read_conf_file_preserves_autodetected_releasever_major_minor(self):
+        base = dnf.Base()
+        base.conf.releasever = '1'  # Do not set to '1.2', autodetection pretends '1'
+        base.conf.releasever_major = '1'
+        base.conf.releasever_minor = '2'
+        cli = dnf.cli.Cli(base)
+        cli._read_conf_file()
+        self.assertEqual(base.conf.releasever, '1')
+        self.assertEqual(base.conf.releasever_major, '1')
+        self.assertEqual(base.conf.releasever_minor, '2')


### PR DESCRIPTION
Upstream commit: b7eb2e399c42d10444f7d045689fd50f91cf72db

When running dnf-automatic in RHEL 10.0 where releasever_minor should default to "0", releasever_minor variable was incorrectly detected as undefined. That led to expanding a metalink for an EPEL repository to a wrong URL.

The cause was a bad logic in updating the release, releasever_major, and releasever_minor triplet in dnf.cli.cli.Cli._read_conf_file(): Setting release invalidates releasever_major and releasever_minor. At the same time for backward compatibilty detected release only contains the major number.

This bug did not manifest in "dnf upgrade" command because "dnf" program does not explicitly construct dnf.Base() before calling _read_conf_file(). That is dnf-automtic first detected releasever=10 and releasever_minor=0 when calling _setup_default_conf() via dnf.Base(). But then _read_conf_file() called by dnf-automatic set releasever again to 10, that rewrote releasever_minor to None and then _read_conf_file() set releasever_minor to releasever_minor, i.e to None.

This patch does not change the code flow to minimize regressions. Instead it saves the original releasever_minor value to be able to default to it again.

Resolve: #2259
Resolve: https://issues.redhat.com/browse/RHEL-108617