### PR TITLE
SideCI seems to have shut down in 2023

### DIFF
--- a/sideci.yml
+++ b/sideci.yml
@@ -1,3 +1,0 @@
-linter:
-  flake8:
-    version: 3


### PR DESCRIPTION
Making its config file less-than-useless.

(Specifically, it seems they changed their name/domain from https://sideci.com/ to https://sider.review/ in 2018, then got bought out in 2019, then faded away to complete obscurity to the point where, though https://sider.review/ is now _also_ offline, its demise isn't even recorded in [the "Sider (Automated Code Review)" Wikipedia article](https://en.wikipedia.org/wiki/Sider_(Automated_Code_Review)).

Searching Google et al. for info about the now-defunct Sider.review is made extremely difficult by the fact that since then, a(n unrelated?) new service named Sider.AI has sprung up and taken over all of the search hits for "sider". But it's dead, Jim.