### PR TITLE
spec: Package release notes

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -311,7 +311,7 @@ fi
 
 %files data
 %license COPYING PACKAGE-LICENSING
-%doc AUTHORS README.rst
+%doc AUTHORS README.rst doc/release_notes.rst
 %dir %{confdir}
 %dir %{confdir}/modules.d
 %dir %{confdir}/modules.defaults.d


### PR DESCRIPTION
It's good when users can read what has changed after installing an update.

Putting it to dnf-data (last package that left?) might be strange, but it is where we already have had README. It's better to have all the documentation alongside. If somebody knows a better place, we can move all the documentation files elsewhere.