### PR TITLE
spec: Wrap overlong dnf-bootc description

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -177,7 +177,8 @@ Requires:       python3-gobject-base
 Requires:       util-linux-core
 
 %description bootc
-Additional dependencies needed to perform transactions on booted bootc (bootable containers) systems.
+Additional dependencies needed to perform transactions on booted bootc
+(bootable containers) systems.
 
 
 %prep


### PR DESCRIPTION
Reported by rpmlint:

    dnf-bootc.noarch: E: description-line-too-long Additional dependencies needed to perform transactions on booted bootc (bootable containers) systems.