### PR TITLE
doc: use FIND_PROGRAM for sphinx binary instead of hardcoding for Python3

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -4,7 +4,7 @@
 if (${PYTHON_VERSION_MAJOR} STREQUAL "2")
     SET(SPHINX_BUILD_NAME "sphinx-build")
 else()
-    SET(SPHINX_BUILD_NAME "sphinx-build-3")
+    FIND_PROGRAM(SPHINX_BUILD_NAME "sphinx-build-3" "sphinx-build" REQUIRED)
 endif()
 
 


### PR DESCRIPTION
In Ubuntu et al. there is no sphinx-build-3 even with Python3, as Python2 has been removed.
Use CMake's FIND_PROGRAM instead of harcoding the name, so that the correct one can be found dynamically and work everywhere.