### PR TITLE
bootc: unlock only if /usr is read-only

### DIFF
--- a/dnf/cli/cli.py
+++ b/dnf/cli/cli.py
@@ -224,6 +224,7 @@ class BaseCli(dnf.Base):
             # Handle bootc transactions. `--transient` must be specified if
             # /usr is not already writeable.
             bootc_system = None
+            bootc_system_needs_unlock = False
             if is_bootc_transaction:
                 if self.conf.persistence == "persist":
                     logger.info(_("Persistent transactions aren't supported on bootc systems."))
@@ -245,6 +246,7 @@ class BaseCli(dnf.Base):
                         logger.info(_("A transient overlay will be created on /usr that will be discarded on reboot. "
                                       "Keep in mind that changes to /etc and /var will still persist, and packages "
                                       "commonly modify these directories."))
+                        bootc_system_needs_unlock = True
                 self._persistence = libdnf.transaction.TransactionPersistence_TRANSIENT
 
                 # Check whether the transaction modifies usr_drift_protected_paths
@@ -275,7 +277,7 @@ class BaseCli(dnf.Base):
                 if self.conf.assumeno or not self.output.userconfirm():
                     raise CliError(_("Operation aborted."))
 
-            if bootc_system:
+            if bootc_system and bootc_system_needs_unlock:
                 bootc_system.make_writable()
         else:
             logger.info(_('Nothing to do.'))

--- a/dnf/util.py
+++ b/dnf/util.py
@@ -748,4 +748,4 @@ class _BootcSystem:
             # read-only. Set up a mount namespace for DNF.
             self._set_up_mountns()
 
-        assert os.access(self.usr, os.W_OK)
+        assert self.is_writable()


### PR DESCRIPTION
DNF should only run `ostree admin unlock --transient` if `/usr` is actually read-only. `/usr` may be writable via OSTree's `root.transient = true` even if the `ostree admin status` is not transient.

Resolves https://issues.redhat.com/browse/SWM-7460