### PR TITLE
autoremove: warn and skip dangling protected dependencies

### DIFF
--- a/dnf.spec
+++ b/dnf.spec
@@ -1,5 +1,5 @@
 # default dependencies
-%global hawkey_version 0.75.0
+%global hawkey_version 0.76.0
 %global libcomps_version 0.1.8
 %global libmodulemd_version 2.9.3
 %global rpm_version 4.14.0

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -2313,9 +2313,23 @@ class Base(object):
                 logger.warning(_('No packages marked for removal.'))
 
         else:
-            pkgs = self.sack.query()._unneeded(self.history.swdb,
+            unneeded_pkgs = self.sack.query()._unneeded(self.history.swdb,
                                                debug_solver=self.conf.debug_solver)
-            for pkg in pkgs:
+
+            protected = self.sack.query().installed().filterm(name=self.conf.protected_packages)
+            protected_found = False
+            for pkg in protected:
+                if pkg in unneeded_pkgs:
+                    msg = _('Unneeded protected package: %s (and its dependencies) cannot be removed, '
+                            'either mark it as user-installed or change protected_packages configuration option.')
+                    logger.warning(msg, pkg)
+                    protected_found = True
+
+            if protected_found:
+                unneeded_pkgs = self.sack.query()._unneeded_extra_userinstalled(self.history.swdb, protected,
+                                                   debug_solver=self.conf.debug_solver)
+
+            for pkg in unneeded_pkgs:
                 self.package_remove(pkg)
 
     def remove(self, pkg_spec, reponame=None, forms=None):


### PR DESCRIPTION
Requires new libdnf 0.76.0 API.

Requires: https://github.com/rpm-software-management/libdnf/pull/1740

The intent is to match the autoremove behavior introduced in dnf5: https://github.com/rpm-software-management/dnf5/pull/2563

Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1810