### PR TITLE
Add '--noplugins' tsflag config value

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -639,6 +639,9 @@ class Base(object):
     if hasattr(rpm, 'RPMTRANS_FLAG_NOCAPS'):
         # Introduced in rpm-4.14
         _TS_FLAGS_TO_RPM['nocaps'] = rpm.RPMTRANS_FLAG_NOCAPS
+    if hasattr(rpm, 'RPMTRANS_FLAG_NOPLUGINS'):
+        # Introduced in rpm-4.12
+        _TS_FLAGS_TO_RPM['noplugins'] = rpm.RPMTRANS_FLAG_NOPLUGINS
 
     _TS_VSFLAGS_TO_RPM = {'nocrypto': rpm._RPMVSF_NOSIGNATURES |
                           rpm._RPMVSF_NODIGESTS}

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -549,6 +549,7 @@ configuration file by your distribution to override the DNF defaults.
     nocaps        RPMTRANS_FLAG_NOCAPS
     nocrypto      RPMTRANS_FLAG_NOFILEDIGEST
     deploops      RPMTRANS_FLAG_DEPLOOPS
+    noplugins     RPMTRANS_FLAG_NOPLUGINS
     ============  ===========================
 
     The ``nocrypto`` option will also set the ``_RPMVSF_NOSIGNATURES`` and
@@ -558,6 +559,8 @@ configuration file by your distribution to override the DNF defaults.
     file conflicts.
     The ``nocaps`` is supported with rpm-4.14 or later. When ``nocaps`` is used but rpm
     doesn't support it, DNF only reports it as an invalid tsflag.
+    The ``noplugins`` option is supported with rpm-4.12 or later to disable use of rpm plugins.
+    Similarly, this will be reported as an invalid tsflag if rpm doesn't support it.
 
 .. _upgrade_group_objects_upgrade-label:
 


### PR DESCRIPTION
I don't know how much appetite there is for exposing this option, but it helps me upgrade a build to a newer dnf version where I'm installing some packages into a chroot inside the build environment which is docker container where it doesn't have sufficient permission to run the `unshare` RPM plugin that was relatively recently added.

With this change I can now run `dnf --setopt=tsflags=noplugins` and install packages (*) as before.

(* In this case - known, trusted packages pulled from a local RPM mirror)