### PR TITLE
rhel-10.3: Preserve ACL when rotating logs

### DIFF
--- a/dnf/logging.py
+++ b/dnf/logging.py
@@ -125,10 +125,19 @@ class MultiprocessRotatingFileHandler(logging.handlers.RotatingFileHandler):
             try:
                 if self.shouldRollover(record):
                     with self.rotate_lock:
-                        # Do rollover while preserving the mode of the new log file
+                        # Do rollover while preserving the mode and ACL of the new log file
                         mode = os.stat(self.baseFilename).st_mode
+                        acl = None
+                        try:
+                            acl = os.getxattr(self.baseFilename, "system.posix_acl_access")
+                        except:
+                            # The extended attribute does not exist or the
+                            # file system does not support them.
+                            pass
                         self.doRollover()
                         os.chmod(self.baseFilename, mode)
+                        if acl is not None:
+                            os.setxattr(self.baseFilename, "system.posix_acl_access", acl)
                 logging.FileHandler.emit(self, record)
                 return
             except (dnf.exceptions.ProcessLockError, dnf.exceptions.ThreadLockError):


### PR DESCRIPTION
This is a rhel-10.3 backport of #2284.

Upstream commit: 4324b297da2fd6a15670241398a31e7f462e44e4

When DNF rotated /var/log/dnf.log, it preserved a file mode, but it lost an access control list:

    # getfacl -c /var/log/dnf.log
    getfacl: Removing leading '/' from absolute path names
    user::rw-
    user:root:r--
    group::r--
    mask::r--
    other::r--

    # dnf4 --setopt log_rotate=4 --setopt log_size=1 upgrade --assumeno

    # getfacl -c /var/log/dnf.log
    getfacl: Removing leading '/' from absolute path names
    user::rw-
    group::r--
    other::r--

This patch fixes it by copying an extended attribute which stores the access control list. (Python does not have an interface for handling the access control lists.)

Resolve: #2279
Resolve: https://redhat.atlassian.net/browse/RHEL-123670
Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1853