### PR TITLE
Fix pattern to remove temp metadata files during cleanup

### DIFF
--- a/dnf/repo.py
+++ b/dnf/repo.py
@@ -63,7 +63,7 @@ CACHE_FILES = {
     'metadata': r'^%s\/.*((xml|yaml)(\.gz|\.xz|\.bz2|\.zck|\.zst)?|asc|cachecookie|%s)$' %
                 (_CACHEDIR_RE, _MIRRORLIST_FILENAME),
     'packages': r'^%s\/%s\/.+rpm$' % (_CACHEDIR_RE, _PACKAGES_RELATIVE_DIR),
-    'dbcache': r'^.+(solv|solvx)$',
+    'dbcache': r'^.+\.(solv|solvx)(\.[A-Za-z0-9]+)?$',
 }
 
 logger = logging.getLogger("dnf")

--- a/tests/cli/commands/test_clean.py
+++ b/tests/cli/commands/test_clean.py
@@ -52,7 +52,7 @@ class CleanTest(tests.support.TestCase):
             (
                 repo.basecachedir,
                 [os.path.basename(repo._cachedir)],
-                [repo.id + '.solv'],
+                [repo.id + '.solv'], [repo.id + '.solvx'], [repo.id + '.solvx.XXXXX'],
             ),
             (repo._cachedir, ['repodata', 'packages'], ['metalink.xml']),
             (repo._cachedir + '/repodata', [], ['foo.xml', 'bar.xml.bz2']),
@@ -76,7 +76,7 @@ class CleanTest(tests.support.TestCase):
                 _run(self.cli, args)
 
         calls = [call[0] for call in _clean.call_args_list]
-        counts = (5, 4, 5, 5, 1, 0)
+        counts = (7, 6, 7, 7, 3, 0)
         for call, count in zip(calls, counts):
             files = list(call[1])
             assert len(files) == count


### PR DESCRIPTION
Seems there are times when caching operations fail and the temp file remains. Running `clean all` with and without privileges doesn't fix this and it can build up.

Source issue: https://github.com/amazonlinux/amazon-linux-2023/issues/955

This should hopefully address it.