### PR TITLE
packit: Fix bootc tests

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -13,31 +13,17 @@ jobs:
   - job: copr_build
     trigger: pull_request
     targets:
-      - centos-stream+epel-next-9-x86_64
       - fedora-all
     additional_repos:
       - "copr://rpmsoftwaremanagement/dnf-nightly"
+
   - job: tests
     trigger: pull_request
-    identifier: "dnf-bootc-tests"
-    targets:
-      - centos-stream-9-x86_64
-    fmf_url: https://github.com/evan-goode/ci-dnf-stack.git
-    fmf_ref: evan-goode/bootc
-    tmt_plan: "^/plans/integration/bootc-behave-dnf$"
-    tf_extra_params:
-      environments:
-        - artifacts:
-            - type: repository-file
-              # We use the rawhide repo file for all fedora releases, the url doesn't change and it is not rawhide specific (it contains "fedora-$releasever-$basearch")
-              id: https://copr.fedorainfracloud.org/coprs/rpmsoftwaremanagement/dnf-nightly/repo/fedora-rawhide/rpmsoftwaremanagement-dnf-nightly-fedora-rawhide.repo
-  - job: tests
-    trigger: pull_request
-    identifier: "dnf-tests"
+    identifier: "behave-dnf"
     targets:
       - fedora-all
     fmf_url: https://github.com/rpm-software-management/ci-dnf-stack.git
-    fmf_ref: enable-tmt-dnf-4-stack
+    fmf_ref: dnf-4-stack
     tmt_plan: "^/plans/integration/behave-dnf$"
     tf_extra_params:
       environments:
@@ -46,3 +32,17 @@ jobs:
               # We use the rawhide repo file for all fedora releases, the url doesn't change and it is not rawhide specific (it contains "fedora-$releasever-$basearch")
               id: https://copr.fedorainfracloud.org/coprs/rpmsoftwaremanagement/dnf-nightly/repo/fedora-rawhide/rpmsoftwaremanagement-dnf-nightly-fedora-rawhide.repo
 
+  - job: tests
+    trigger: pull_request
+    identifier: "behave-dnf-bootc"
+    targets:
+      - fedora-all
+    fmf_url: https://github.com/rpm-software-management/ci-dnf-stack.git
+    fmf_ref: dnf-4-stack
+    tmt_plan: "^/plans/integration/behave-dnf-bootc/"
+    tf_extra_params:
+      environments:
+        - artifacts:
+            - type: repository-file
+              # We use the rawhide repo file for all fedora releases, the url doesn't change and it is not rawhide specific (it contains "fedora-$releasever-$basearch")
+              id: https://copr.fedorainfracloud.org/coprs/rpmsoftwaremanagement/dnf-nightly/repo/fedora-rawhide/rpmsoftwaremanagement-dnf-nightly-fedora-rawhide.repo


### PR DESCRIPTION
- Rename "dnf-tests" to "behave-dnf" to match the behave suite name
- Rename "dnf-bootc-tests" to "behave-dnf-bootc" to match the behave suite name
- Run behave-dnf tests only on fedora-all. dnf-4-stack tests are currently not passing on c9s and c10s.
- Use dnf-4-stack branch of ci-dnf-stack, not `evan-goode/bootc` or `enable-tmt-dnf-4-stack`.

Setting as a draft to test Packit.