### PR TITLE
Fix remote packages not copied to destdir in download_packages

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1324,6 +1324,11 @@ class Base(object):
             self._download_remote_payloads(payloads, drpm, progress, callback_total)
 
         if self.conf.destdir:
+            for pkg in remote_pkgs:
+                try:
+                    shutil.copy(pkg.localPkg(), self.conf.destdir)
+                except shutil.SameFileError:
+                    pass
             for pkg in local_pkgs:
                 if pkg.baseurl:
                     location = os.path.join(pkg.get_local_baseurl(),


### PR DESCRIPTION
The `download_packages()` method in `Base` class only copies local packages to `self.conf.destdir`, but ignores remote packages after they have been downloaded. This makes the API behavior inconsistent with the CLI, where remote packages are correctly copied to `destdir`.

## Changes
- Added a loop to copy downloaded remote packages to `destdir` using `pkg.localPkg()` to locate the cached RPM file
- The fix is placed after `_download_remote_payloads()` completes, so `pkg.localPkg()` correctly points to the cached download

Fixes #2035