### PR TITLE
Fix delta RPM wasted percentage calculation to use expected full size as base

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1299,7 +1299,7 @@ class Base(object):
             elif real > full:
                 msg = _("Failed Delta RPMs increased %.1f MB of updates to %.1f MB "
                         "(%.1f%% wasted)")
-                percent = 100 - full / real * 100
+                percent = real / full * 100 - 100
             logger.info(msg, full / 1024 ** 2, real / 1024 ** 2, percent)
 
     def download_packages(self, pkglist, progress=None, callback_total=None):


### PR DESCRIPTION
When failed delta RPMs increase the download size, the wasted percentage was calculated relative to the actual downloaded size (real) instead of the expected full size (full). This makes it inconsistent with the saved percentage calculation which already uses full as the base.

Example: full=148.9 MB, real=189.0 MB
- Old: (1 - 148.9/189.0) * 100 = 21.2% (relative to real)
- New: (189.0/148.9 - 1) * 100 = 26.9% (relative to full, matching the saved case)

Fixes #1900