### PR TITLE
Dont prepend installroot to cachedir when set from commandline

### DIFF
--- a/dnf/conf/config.py
+++ b/dnf/conf/config.py
@@ -328,6 +328,9 @@ class MainConf(BaseConfig):
     def prepend_installroot(self, optname):
         # :api
         prio = self._get_priority(optname)
+        # don't modify paths specified on commandline
+        if prio >= PRIO_COMMANDLINE:
+            return
         new_path = self._prepend_installroot_path(self._get_value(optname))
         self._set_value(optname, new_path, prio)
 


### PR DESCRIPTION
## Summary
- Fix prepend_installroot to skip options set at commandline priority (PRIO_COMMANDLINE)
- When --setopt=cachedir=... is used, the user-specified path is no longer modified by prepending installroot
- Matches existing behavior of _search_inside_installroot which already respects commandline priority

Fixes #2011