### PR TITLE
Download remote rpms to temp directory

### DIFF
--- a/dnf/repo.py
+++ b/dnf/repo.py
@@ -47,6 +47,7 @@ import sys
 import time
 import traceback
 import urllib
+import tempfile
 
 _PACKAGES_RELATIVE_DIR = "packages"
 _MIRRORLIST_FILENAME = "mirrorlist"
@@ -282,17 +283,21 @@ class RPMPayload(PackagePayload):
 
 class RemoteRPMPayload(PackagePayload):
 
-    def __init__(self, remote_location, conf, progress):
+    def __init__(self, remote_location, conf, progress, temp=False):
         super(RemoteRPMPayload, self).__init__("unused_object", progress)
         self.remote_location = remote_location
         self.remote_size = 0
         self.conf = conf
-        s = (self.conf.releasever or "") + self.conf.substitutions.get('basearch')
-        digest = hashlib.sha256(s.encode('utf8')).hexdigest()[:16]
-        repodir = "commandline-" + digest
-        self.pkgdir = os.path.join(self.conf.cachedir, repodir, "packages")
-        dnf.util.ensure_dir(self.pkgdir)
-        self.local_path = os.path.join(self.pkgdir, self.__str__().lstrip("/"))
+        if temp:
+            self.pkgdir = tempfile.gettempdir()
+            self.local_path = os.path.join(self.pkgdir, self.__str__().lstrip("/"))
+        else:
+            s = (self.conf.releasever or "") + self.conf.substitutions.get('basearch')
+            digest = hashlib.sha256(s.encode('utf8')).hexdigest()[:16]
+            repodir = "commandline-" + digest
+            self.pkgdir = os.path.join(self.conf.cachedir, repodir, "packages")
+            dnf.util.ensure_dir(self.pkgdir)
+            self.local_path = os.path.join(self.pkgdir, self.__str__().lstrip("/"))
 
     def __str__(self):
         return os.path.basename(urllib.parse.unquote(self.remote_location))

--- a/dnf/util.py
+++ b/dnf/util.py
@@ -88,7 +88,7 @@ def _parse_specs(namespace, values):
 def _urlopen_progress(url, conf, progress=None):
     if progress is None:
         progress = dnf.callback.NullDownloadProgress()
-    pload = dnf.repo.RemoteRPMPayload(url, conf, progress)
+    pload = dnf.repo.RemoteRPMPayload(url, conf, progress, temp=True)
     est_remote_size = sum([pload.download_size])
     progress.start(1, est_remote_size)
     targets = [pload._librepo_target()]


### PR DESCRIPTION
Previously remote rpms were downloaded to dnf cache without any locking, this meant that concurrent `dnf clean packages` could remove downloaded packages that could still be needed.

However adding a proper lock would be awkawrd as it would need to cut across a lot of layer boundaries, it would need to be held from starting of the download in command.run all the way to do_transaction. Managing lifetime of such a lock would be complex.
Simpler solution is to download the rpms to temp space which is not managed by `dnf clean`.

For RHEL-83124