### PR TITLE
unittest: use writable installroots 

### DIFF
--- a/tests/etc/installroot.conf
+++ b/tests/etc/installroot.conf
@@ -1,2 +1,0 @@
-[main]
-installroot=/roots/dnf

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -22,6 +22,8 @@ from __future__ import unicode_literals
 import binascii
 import itertools
 import re
+import tempfile
+import shutil
 
 import hawkey
 import libdnf.transaction
@@ -60,9 +62,13 @@ class BaseTest(tests.support.TestCase):
     @mock.patch('dnf.util.am_i_root', lambda: True)
     def test_default_config_root(self):
         base = dnf.Base()
+        installroot = tempfile.mkdtemp(prefix="dnf_test_installroot_")
+        self.addCleanup(shutil.rmtree, installroot)
+        base.conf.installroot = installroot
+        base.conf.prepend_installroot("cachedir")
         self.assertIsNotNone(base.conf)
         self.assertIsNotNone(base.conf.cachedir)
-        reg = re.compile('/var/cache/dnf')
+        reg = re.compile('/tmp/dnf_test_installroot_.*/var/cache/dnf')
         self.assertIsNotNone(reg.match(base.conf.cachedir))
         base.close()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -203,11 +203,13 @@ class ConfigureTest(tests.support.DnfBaseTestCase):
         """ Test Cli.configure as root."""
         self.base._conf = dnf.conf.Conf()
         with mock.patch('dnf.rpm.detect_releasevers', return_value=(69, None, None)):
-            self.cli.configure(['update', '--nogpgcheck', '-c', self.conffile])
+            self.cli.configure(['update', '--nogpgcheck', '-c', self.conffile,
+                                '--installroot', self._installroot])
         reg = re.compile('^/var/cache/dnf$')
         self.assertIsNotNone(reg.match(self.base.conf.system_cachedir))
         parser = argparse.ArgumentParser()
-        expected = "%s update --nogpgcheck -c %s " % (parser.prog, self.conffile)
+        expected = "%s update --nogpgcheck -c %s --installroot %s " % (
+            parser.prog, self.conffile, self._installroot)
         self.assertEqual(self.cli.cmdstring, expected)
 
     def test_configure_verbose(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -225,17 +225,18 @@ class ConfigureTest(tests.support.DnfBaseTestCase):
     def test_conf_exists_in_installroot(self, ospathexists):
         with mock.patch('logging.Logger.warning'), \
                 mock.patch('dnf.rpm.detect_releasevers', return_value=(69, None, None)):
-            self.cli.configure(['--installroot', '/roots/dnf', 'update'])
-        self.assertEqual(self.base.conf.config_file_path, '/roots/dnf/etc/dnf/dnf.conf')
-        self.assertEqual(self.base.conf.installroot, '/roots/dnf')
+            self.cli.configure(['--installroot', self._installroot, 'update'])
+        self.assertEqual(self.base.conf.config_file_path,
+                         os.path.join(self._installroot, 'etc/dnf/dnf.conf'))
+        self.assertEqual(self.base.conf.installroot, self._installroot)
 
     @mock.patch('dnf.cli.cli.Cli._parse_commands', new=mock.MagicMock)
     @mock.patch('os.path.exists', return_value=False)
     def test_conf_notexists_in_installroot(self, ospathexists):
         with mock.patch('dnf.rpm.detect_releasevers', return_value=(69, None, None)):
-            self.cli.configure(['--installroot', '/roots/dnf', 'update'])
+            self.cli.configure(['--installroot', self._installroot, 'update'])
         self.assertEqual(self.base.conf.config_file_path, '/etc/dnf/dnf.conf')
-        self.assertEqual(self.base.conf.installroot, '/roots/dnf')
+        self.assertEqual(self.base.conf.installroot, self._installroot)
 
     @mock.patch('dnf.cli.cli.Cli._parse_commands', new=mock.MagicMock)
     def test_installroot_with_etc(self):
@@ -248,7 +249,8 @@ class ConfigureTest(tests.support.DnfBaseTestCase):
 
     def test_installroot_configurable(self):
         """Test that conffile is detected in a new installroot."""
-
-        conf = os.path.join(tests.support.dnf_toplevel(), "tests/etc/installroot.conf")
-        self.cli.configure(['-c', conf, '--nogpgcheck', '--releasever', '17', 'update'])
-        self.assertEqual(self.base.conf.installroot, '/roots/dnf')
+        conf_path = os.path.join(self._installroot, 'installroot.conf')
+        with open(conf_path, 'w') as conf_file:
+            conf_file.write('[main]\ninstallroot=%s\n' % self._installroot)
+        self.cli.configure(['-c', conf_path, '--nogpgcheck', '--releasever', '17', 'update'])
+        self.assertEqual(self.base.conf.installroot, self._installroot)


### PR DESCRIPTION
In a subsequent PR I would like to add a new persistent file into the `cachedir` to ensure different dnf processes don't delete each others packages.

While working on that I ran into problems with current unittests. 
These changes should also help separate hosts environment from the tests environments.