### PR TITLE
Use PackagesInUsePersistor to track which process owns which packages

### DIFF
--- a/dnf/base.py
+++ b/dnf/base.py
@@ -511,17 +511,19 @@ class Base(object):
         self._tempfile_persistor = dnf.persistor.TempfilePersistor(
             self.conf.cachedir)
 
-        if not self.conf.keepcache:
-            self._clean_packages(self._tempfiles)
-            if self._trans_success:
-                self._trans_tempfiles.update(
-                    self._tempfile_persistor.get_saved_tempfiles())
-                self._tempfile_persistor.empty()
-                if self._trans_install_set:
-                    self._clean_packages(self._trans_tempfiles)
-            else:
-                self._tempfile_persistor.tempfiles_to_add.update(
-                    self._trans_tempfiles)
+        lock = dnf.lock.build_download_lock(self.conf.cachedir, self.conf.exit_on_lock)
+        with lock:
+            if not self.conf.keepcache:
+                self._clean_packages(self._tempfiles)
+                if self._trans_success:
+                    self._trans_tempfiles.update(
+                        self._tempfile_persistor.get_saved_tempfiles())
+                    self._tempfile_persistor.empty()
+                    if self._trans_install_set:
+                        self._clean_packages(self._trans_tempfiles)
+                else:
+                    self._tempfile_persistor.tempfiles_to_add.update(
+                        self._trans_tempfiles)
 
         if self._tempfile_persistor.tempfiles_to_add:
             logger.info(_("The downloaded packages were saved in cache "

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -1349,16 +1349,19 @@ class Base(object):
             raise dnf.exceptions.Error(
                 _("Cannot add local packages, because transaction job already exists"))
         pkgs_error = []
-        for path in path_list:
-            if not os.path.exists(path) and '://' in path:
-                # download remote rpm to a tempfile
-                path = dnf.util._urlopen_progress(path, self.conf, progress)
-                self._add_tempfiles([path])
-            try:
-                pkgs.append(self.sack.add_cmdline_package(path))
-            except IOError as e:
-                logger.warning(e)
-                pkgs_error.append(path)
+        lock = dnf.lock.build_download_lock(self.conf.cachedir, self.conf.exit_on_lock)
+        with lock:
+            for path in path_list:
+                if not os.path.exists(path) and '://' in path:
+                    # download remote rpm to a tempfile
+                    path = dnf.util._urlopen_progress(path, self.conf, progress)
+                    self._add_tempfiles([path])
+                try:
+                    pkgs.append(self.sack.add_cmdline_package(path))
+                except IOError as e:
+                    logger.warning(e)
+                    pkgs_error.append(path)
+
         self._setup_excludes_includes(only_main=True)
         if pkgs_error and strict:
             raise IOError(_("Could not open: {}").format(' '.join(pkgs_error)))

--- a/dnf/base.py
+++ b/dnf/base.py
@@ -513,14 +513,18 @@ class Base(object):
 
         lock = dnf.lock.build_download_lock(self.conf.cachedir, self.conf.exit_on_lock)
         with lock:
+            in_use_abs_paths = dnf.persistor.PackagesInUsePersistor(self.conf.cachedir).remove_pid_prune_write(os.getpid())
+
             if not self.conf.keepcache:
-                self._clean_packages(self._tempfiles)
+                c = [f for f in self._tempfiles if f not in in_use_abs_paths]
+                self._clean_packages(c)
                 if self._trans_success:
                     self._trans_tempfiles.update(
                         self._tempfile_persistor.get_saved_tempfiles())
                     self._tempfile_persistor.empty()
                     if self._trans_install_set:
-                        self._clean_packages(self._trans_tempfiles)
+                        c = [f for f in self._trans_tempfiles if f not in in_use_abs_paths]
+                        self._clean_packages(c)
                 else:
                     self._tempfile_persistor.tempfiles_to_add.update(
                         self._trans_tempfiles)
@@ -1251,6 +1255,9 @@ class Base(object):
                 progress.start(len(payloads), est_remote_size)
             errors = dnf.repo._download_payloads(payloads, drpm, fail_fast)
 
+            path_list = [payload.pkg.localPkg() for payload in payloads]
+            dnf.persistor.PackagesInUsePersistor(self.conf.cachedir).append_paths_pid_write(path_list, os.getpid())
+
             if errors._irrecoverable():
                 raise dnf.exceptions.DownloadError(errors._irrecoverable())
 
@@ -1363,6 +1370,9 @@ class Base(object):
                 except IOError as e:
                     logger.warning(e)
                     pkgs_error.append(path)
+
+            path_list = [pkg.localPkg() for pkg in pkgs]
+            dnf.persistor.PackagesInUsePersistor(self.conf.cachedir).append_paths_pid_write(path_list, os.getpid())
 
         self._setup_excludes_includes(only_main=True)
         if pkgs_error and strict:

--- a/dnf/cli/commands/clean.py
+++ b/dnf/cli/commands/clean.py
@@ -27,6 +27,7 @@ import dnf.cli
 import dnf.exceptions
 import dnf.lock
 import dnf.logging
+import dnf.persistor
 import dnf.repo
 import logging
 import os
@@ -57,6 +58,12 @@ def _tree(dirpath):
 def _filter(files, patterns):
     """Yield those filenames that match any of the patterns."""
     return (f for f in files for p in patterns if re.match(p, f))
+
+
+def _filter_packages_used_by_different_processes(files, cachedir):
+    """Keep only package paths that are not reserved by a running DNF process."""
+    in_use_rel_paths = dnf.persistor.PackagesInUsePersistor(cachedir).get_in_use_rel_paths_prune_read()
+    return [f for f in files if f not in in_use_rel_paths]
 
 
 def _clean(dirpath, files):
@@ -110,7 +117,10 @@ class CleanCommand(commands.Command):
                         logger.info(_('Cache was expired'))
 
                     patterns = [dnf.repo.CACHE_FILES[t] for t in types]
-                    count = _clean(cachedir, _filter(files, patterns))
+                    to_clean = _filter(files, patterns)
+                    if 'packages' in types:
+                        to_clean = _filter_packages_used_by_different_processes(to_clean, cachedir)
+                    count = _clean(cachedir, to_clean)
                     logger.info(P_('%d file removed', '%d files removed', count) % count)
                     return
             except dnf.exceptions.LockError as e:

--- a/dnf/persistor.py
+++ b/dnf/persistor.py
@@ -137,3 +137,61 @@ class TempfilePersistor(JSONDB):
 
     def empty(self):
         self._empty = True
+
+
+class PackagesInUsePersistor(JSONDB):
+    """Track files with an associated PID.
+
+    It can be used to ensure different dnf processes don't remove each others files.
+    """
+
+    def __init__(self, cachedir):
+        self.cachedir = os.path.normpath(cachedir)
+        # Stores pairs (path, pid), this allows multiple processes to own the same file
+        self.db_path = os.path.join(self.cachedir, "packages_in_use.json")
+
+    @staticmethod
+    def _keep_alive_pids(data):
+        """Remove data paths owned by processes that are no longer running."""
+        return [(path, pid) for path, pid in data if os.access('/proc/%d/stat' % pid, os.F_OK)]
+
+    def append_paths_pid_write(self, paths, pid):
+        try:
+            self._check_json_db(self.db_path)
+            data = self._get_json_db(self.db_path)
+        except OSError as e:
+            logger.warning(_("Failed to load packages in use persistor: %s"), e)
+            return False
+        for path in paths:
+            data.append((path, pid))
+        try:
+            self._write_json_db(self.db_path, list(data))
+        except OSError as e:
+            logger.warning(_("Failed to store packages in use persistor: %s"), e)
+            return False
+        return True
+
+    def remove_pid_prune_write(self, in_pid):
+        try:
+            self._check_json_db(self.db_path)
+            data = self._get_json_db(self.db_path)
+        except OSError as e:
+            logger.warning(_("Failed to load packages in use persistor: %s"), e)
+            return []
+        data = {(path, pid) for path, pid in data if pid != in_pid}
+        data = self._keep_alive_pids(data)
+
+        try:
+            self._write_json_db(self.db_path, data)
+        except OSError as e:
+            logger.warning(_("Failed to store packages in use persistor: %s"), e)
+        return [f for f, _ in data]
+
+    def get_in_use_rel_paths_prune_read(self):
+        try:
+            self._check_json_db(self.db_path)
+            data = self._keep_alive_pids(self._get_json_db(self.db_path))
+        except OSError as e:
+            logger.warning(_("Failed to load packages in use persistor: %s"), e)
+            return []
+        return [os.path.relpath(f, self.cachedir) for f, _ in data]

--- a/tests/test_persistor.py
+++ b/tests/test_persistor.py
@@ -19,6 +19,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import os
 import tempfile
 
 import dnf.comps
@@ -47,3 +48,35 @@ class RepoPersistorTest(tests.support.TestCase):
 
         persistor = dnf.persistor.RepoPersistor(self.persistdir)
         self.assertEqual(persistor.get_expired_repos(), IDS)
+
+
+class PackagesInUsePersistorTest(tests.support.TestCase):
+    def setUp(self):
+        self.cachedir = tempfile.mkdtemp(prefix="dnf-pkg-reservation-test-")
+        self.pkg_path = os.path.join(self.cachedir, 'fedora-abc0123456789abcd', 'packages', 'foo.rpm')
+
+    def tearDown(self):
+        dnf.util.rm_rf(self.cachedir)
+
+    def test_add(self):
+        persistor = dnf.persistor.PackagesInUsePersistor(self.cachedir)
+        persistor.append_paths_pid_write([self.pkg_path], os.getpid())
+        persistor.append_paths_pid_write([self.pkg_path], 99999)
+        data = persistor.get_in_use_rel_paths_prune_read()
+        self.assertLength(data, 1)
+        self.assertIn(os.path.relpath(self.pkg_path, self.cachedir), data)
+
+    def test_add_and_remove(self):
+        persistor = dnf.persistor.PackagesInUsePersistor(self.cachedir)
+        persistor.append_paths_pid_write([self.pkg_path], os.getpid())
+        persistor.append_paths_pid_write([self.pkg_path], 99999)
+        data = persistor.remove_pid_prune_write(123123)
+        self.assertLength(data, 1)
+        self.assertIn(self.pkg_path, data)
+
+        data = persistor.get_in_use_rel_paths_prune_read()
+        self.assertLength(data, 1)
+        self.assertIn(os.path.relpath(self.pkg_path, self.cachedir), data)
+
+        data = persistor.remove_pid_prune_write(os.getpid())
+        self.assertLength(data, 0)


### PR DESCRIPTION
This is an alternative solution to https://github.com/rpm-software-management/dnf/pull/2334 that is more general and also works for packages downloaded from repos.
However it does add more overhead.

For RHEL-83124

Test update: https://github.com/rpm-software-management/ci-dnf-stack/pull/1910