### PR TITLE
doc: Document repo_gpgcheck_auto_import_keys option

### DIFF
--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -1143,6 +1143,29 @@ configuration.
     already imported for package signature verification and this option is turned on, it may be needed
     to import it again for the repository.
 
+.. _repo_gpgcheck_auto_import_keys-label:
+
+``repo_gpgcheck_auto_import_keys``
+    :ref:`boolean <boolean-label>`
+
+    Whether to automatically import the metadata signing key configured via :ref:`gpgkey
+    <repo_gpgkey-label>` into the repository's metadata keyring, instead of asking for
+    interactive confirmation. Only applies when :ref:`repo_gpgcheck <repo_gpgcheck-label>`
+    is enabled. The default is False.
+
+    The keys used to verify repository metadata are stored in a separate keyring for each
+    repository, and that keyring is bound to the repository's resolved URL. As a result the
+    interactive ``Is this ok [y/N]:`` prompt to import the metadata key reappears whenever the
+    repository serves content at a new URL (for example after a ``$releasever`` change), and in
+    unattended runs the prompt defaults to No and the repository is dropped. Enabling this option
+    trusts the key configured in ``gpgkey`` directly from the repository configuration, so the
+    metadata key import succeeds without a prompt. This is the same behavior the dnf Python API uses
+    by default.
+
+    The imported key is logged so the import is not silent. Only enable this for repositories whose
+    ``gpgkey`` you control and trust, and that are retrieved over a trusted channel, because doing so
+    removes the manual confirmation step for that repository's metadata key.
+
 .. _retries-label:
 
 ``retries``

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -1162,11 +1162,16 @@ configuration.
     metadata key import succeeds without a prompt. This is the same behavior the dnf Python API uses
     by default.
 
-    The imported key is logged so the import is not silent. The ``assumeno`` option (or
-    ``--assumeno``) takes precedence: the key details are shown and the import is declined, as if
-    this option were not set. Only enable this for repositories whose ``gpgkey`` you control and
-    trust, and that are retrieved over a trusted channel, because doing so removes the manual
-    confirmation step for that repository's metadata key.
+    The automatic import only applies to keys configured with a local ``file://`` URL, such as keys
+    shipped in the system image under ``/etc/pki/rpm-gpg/``. Keys fetched over the network (for
+    example an ``https://`` ``gpgkey`` URL) always go through the interactive confirmation so the
+    key fingerprint can be verified before it is trusted.
+
+    The imported key and its fingerprint are logged so the import is not silent. The ``assumeno``
+    option (or ``--assumeno``) takes precedence: the key details are shown and the import is
+    declined, as if this option were not set. Only enable this for repositories whose ``gpgkey``
+    you control and trust, because doing so removes the manual confirmation step for that
+    repository's metadata key.
 
 .. _retries-label:
 

--- a/doc/conf_ref.rst
+++ b/doc/conf_ref.rst
@@ -1162,9 +1162,11 @@ configuration.
     metadata key import succeeds without a prompt. This is the same behavior the dnf Python API uses
     by default.
 
-    The imported key is logged so the import is not silent. Only enable this for repositories whose
-    ``gpgkey`` you control and trust, and that are retrieved over a trusted channel, because doing so
-    removes the manual confirmation step for that repository's metadata key.
+    The imported key is logged so the import is not silent. The ``assumeno`` option (or
+    ``--assumeno``) takes precedence: the key details are shown and the import is declined, as if
+    this option were not set. Only enable this for repositories whose ``gpgkey`` you control and
+    trust, and that are retrieved over a trusted channel, because doing so removes the manual
+    confirmation step for that repository's metadata key.
 
 .. _retries-label:
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -135,6 +135,25 @@ class ConfTest(tests.support.TestCase):
         self.assertEqual(conf.minrate, 2000)
         self.assertEqual(repo.minrate, 4096)
 
+    def test_repo_gpgcheck_auto_import_keys(self):
+        conf = Conf()
+        repo = RepoConf(conf)
+
+        # opt-in: must default to False so dnf keeps prompting before
+        # importing a repository metadata signing key
+        self.assertFalse(conf.repo_gpgcheck_auto_import_keys)
+        self.assertFalse(repo.repo_gpgcheck_auto_import_keys)
+
+        # the repo option is a child of the main option and inherits its value
+        conf.repo_gpgcheck_auto_import_keys = True
+        self.assertTrue(conf.repo_gpgcheck_auto_import_keys)
+        self.assertTrue(repo.repo_gpgcheck_auto_import_keys)
+
+        # a per-repo value overrides the inherited main value
+        repo.repo_gpgcheck_auto_import_keys = False
+        self.assertTrue(conf.repo_gpgcheck_auto_import_keys)
+        self.assertFalse(repo.repo_gpgcheck_auto_import_keys)
+
     def test_prepend_installroot(self):
         conf = Conf()
         conf.installroot = '/mnt/root'


### PR DESCRIPTION
### Summary

Document the `repo_gpgcheck_auto_import_keys` repo option and add a config test. The option itself is implemented in libdnf (companion PR); this change adds the `conf_ref.rst` entry and a `test_config.py` case for its default and inheritance.

Companion libdnf PR: rpm-software-management/libdnf#1778. Ref: rpm-software-management/dnf#2333.

### Motivation

`repo_gpgcheck_auto_import_keys` (default `false`) lets a repository import its configured `gpgkey` for `repo_gpgcheck` metadata verification without the interactive `Is this ok [y/N]:` prompt. It addresses direction 2 of dnf#2333: the per-repo pubring is bound to the resolved repository URL, so the import prompt recurs whenever the repo serves new content at a new URL, and non-interactive runs decline it and drop the repo. The option is registered in libdnf and is exposed through dnf's config, so it needs a user-facing entry in the configuration reference.

### Implementation

`conf_ref.rst`: a new entry under "Options for both [main] and Repo", next to `repo_gpgcheck`, describing the option, its default, and the trust implication (it trusts the configured `gpgkey` without a prompt). No dnf code change — dnf reads the option from libdnf via the existing config layer, so `.repo` files, `[main]`, and `--setopt` work once libdnf provides it.

`tests/test_config.py`: a case asserting the option defaults to `false` and that a `RepoConf` inherits the `[main]` value while a per-repo setting overrides it.

### Testing

`python3 -m pytest tests/test_config.py -k repo_gpgcheck_auto_import_keys` passes against a libdnf built with the companion PR. Docs build with the rest of `conf_ref.rst`.

### Notes for reviewers

Depends on the libdnf PR landing first (the option must exist in libdnf for the config test to pass and for the documented behavior to apply). I am open to a different option name if maintainers prefer one; it should match whatever is chosen in libdnf.