### PR TITLE
Add dedicated lock for clean command

### DIFF
--- a/dnf/cli/commands/__init__.py
+++ b/dnf/cli/commands/__init__.py
@@ -23,6 +23,7 @@ Classes for subcommands of the yum command line interface.
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from dnf.cli.demand import CleanCommandLock
 from dnf.cli.option_parser import OptionParser
 from dnf.i18n import _
 
@@ -342,6 +343,7 @@ class RepoPkgsCommand(Command):
             demands.sack_activation = True
             demands.resolving = True
             demands.root_user = True
+            demands.clean_command_lock = CleanCommandLock.READ
 
         def run_on_repo(self):
             self.cli._populate_update_security_filter(self.opts)
@@ -394,6 +396,7 @@ class RepoPkgsCommand(Command):
             demands.available_repos = True
             demands.resolving = True
             demands.root_user = True
+            demands.clean_command_lock = CleanCommandLock.READ
 
         def run_on_repo(self):
             """Execute the command with respect to given arguments *cli_args*."""
@@ -449,6 +452,7 @@ class RepoPkgsCommand(Command):
             demands.available_repos = True
             demands.resolving = True
             demands.root_user = True
+            demands.clean_command_lock = CleanCommandLock.READ
 
         def run_on_repo(self):
             """Execute the command with respect to given arguments *cli_args*."""
@@ -537,6 +541,7 @@ class RepoPkgsCommand(Command):
             demands.sack_activation = True
             demands.resolving = True
             demands.root_user = True
+            demands.clean_command_lock = CleanCommandLock.READ
 
         def _replace(self, pkg_spec, reponame):
             """Synchronize a package with another repository or remove it."""
@@ -599,6 +604,7 @@ class RepoPkgsCommand(Command):
             demands.available_repos = True
             demands.resolving = True
             demands.root_user = True
+            demands.clean_command_lock = CleanCommandLock.READ
 
         def run_on_repo(self):
             """Execute the command with respect to given arguments *cli_args*."""
@@ -688,6 +694,7 @@ class RepoPkgsCommand(Command):
             demands.available_repos = True
             demands.resolving = True
             demands.root_user = True
+            demands.clean_command_lock = CleanCommandLock.READ
 
         def run_on_repo(self):
             """Execute the command with respect to given arguments *cli_args*."""

--- a/dnf/cli/commands/clean.py
+++ b/dnf/cli/commands/clean.py
@@ -20,6 +20,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from dnf.cli import commands
+from dnf.cli.demand import CleanCommandLock
 from dnf.i18n import _, P_
 from dnf.yum import misc
 
@@ -90,6 +91,9 @@ class CleanCommand(commands.Command):
         parser.add_argument('type', nargs='+',
                            choices=_CACHE_TYPES.keys(),
                            help=_('Metadata type to clean'))
+
+    def configure(self):
+        self.cli.demands.clean_command_lock = CleanCommandLock.WRITE
 
     def run(self):
         cachedir = self.base.conf.cachedir

--- a/dnf/cli/commands/distrosync.py
+++ b/dnf/cli/commands/distrosync.py
@@ -19,6 +19,7 @@
 
 from __future__ import absolute_import
 from dnf.cli import commands
+from dnf.cli.demand import CleanCommandLock
 from dnf.i18n import _
 
 
@@ -40,6 +41,7 @@ class DistroSyncCommand(commands.Command):
         demands.available_repos = True
         demands.resolving = True
         demands.root_user = True
+        demands.clean_command_lock = CleanCommandLock.READ
         commands._checkGPGKey(self.base, self.cli)
         commands._checkEnabledRepo(self.base, self.opts.package)
 

--- a/dnf/cli/commands/downgrade.py
+++ b/dnf/cli/commands/downgrade.py
@@ -20,6 +20,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from dnf.cli import commands
+from dnf.cli.demand import CleanCommandLock
 from dnf.cli.option_parser import OptionParser
 from dnf.i18n import _
 
@@ -43,6 +44,7 @@ class DowngradeCommand(commands.Command):
         demands.available_repos = True
         demands.resolving = True
         demands.root_user = True
+        demands.clean_command_lock = CleanCommandLock.READ
 
         commands._checkGPGKey(self.base, self.cli)
         if not self.opts.filenames:

--- a/dnf/cli/commands/group.py
+++ b/dnf/cli/commands/group.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from dnf.comps import CompsQuery
 from dnf.cli import commands
+from dnf.cli.demand import CleanCommandLock
 from dnf.i18n import _, ucd
 
 import libdnf.transaction
@@ -362,6 +363,7 @@ class GroupCommand(commands.Command):
 
         if cmd in ('install', 'upgrade'):
             commands._checkGPGKey(self.base, self.cli)
+            demands.clean_command_lock = CleanCommandLock.READ
 
     def run(self):
         cmd = self.opts.subcmd

--- a/dnf/cli/commands/history.py
+++ b/dnf/cli/commands/history.py
@@ -24,6 +24,7 @@ import hawkey
 from dnf.i18n import _, ucd
 from dnf.cli import commands
 from dnf.transaction_sr import TransactionReplay, serialize_transaction
+from dnf.cli.demand import CleanCommandLock
 
 import dnf.cli
 import dnf.exceptions
@@ -109,6 +110,7 @@ class HistoryCommand(commands.Command):
             demands.available_repos = True
             demands.resolving = True
             demands.root_user = True
+            demands.clean_command_lock = CleanCommandLock.READ
 
             # Override configuration options that affect how the transaction is resolved
             self.base.conf.clean_requirements_on_remove = False
@@ -123,6 +125,7 @@ class HistoryCommand(commands.Command):
             demands.available_repos = True
             demands.resolving = True
             demands.root_user = True
+            demands.clean_command_lock = CleanCommandLock.READ
 
             self._require_one_transaction_id = True
             if not self.opts.transactions:

--- a/dnf/cli/commands/install.py
+++ b/dnf/cli/commands/install.py
@@ -28,6 +28,7 @@ import hawkey
 import dnf.exceptions
 import dnf.util
 from dnf.cli import commands
+from dnf.cli.demand import CleanCommandLock
 from dnf.cli.option_parser import OptionParser
 from dnf.i18n import _
 
@@ -62,6 +63,7 @@ class InstallCommand(commands.Command):
         demands.available_repos = True
         demands.resolving = True
         demands.root_user = True
+        demands.clean_command_lock = CleanCommandLock.READ
 
         if dnf.util._is_file_pattern_present(self.opts.pkg_specs):
             self.base.conf.optional_metadata_types += ["filelists"]

--- a/dnf/cli/commands/module.py
+++ b/dnf/cli/commands/module.py
@@ -19,6 +19,7 @@
 from __future__ import print_function
 
 from dnf.cli import commands, CliError
+from dnf.cli.demand import CleanCommandLock
 from dnf.i18n import _
 from dnf.module.exceptions import NoModuleException
 from dnf.util import logger
@@ -209,6 +210,7 @@ class ModuleCommand(commands.Command):
             demands.sack_activation = True
             demands.resolving = True
             demands.root_user = True
+            demands.clean_command_lock = CleanCommandLock.READ
 
         def run_on_module(self):
             try:
@@ -230,6 +232,7 @@ class ModuleCommand(commands.Command):
             demands.sack_activation = True
             demands.resolving = True
             demands.root_user = True
+            demands.clean_command_lock = CleanCommandLock.READ
 
         def run_on_module(self):
             module_specs = self.module_base.upgrade(self.opts.module_spec)
@@ -284,6 +287,7 @@ class ModuleCommand(commands.Command):
             demands.sack_activation = True
             demands.resolving = True
             demands.root_user = True
+            demands.clean_command_lock = CleanCommandLock.READ
             self.base.conf.module_stream_switch = True
 
         def run_on_module(self):

--- a/dnf/cli/commands/reinstall.py
+++ b/dnf/cli/commands/reinstall.py
@@ -20,6 +20,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from dnf.cli import commands
+from dnf.cli.demand import CleanCommandLock
 from dnf.cli.option_parser import OptionParser
 from dnf.i18n import _
 
@@ -53,6 +54,7 @@ class ReinstallCommand(commands.Command):
         demands.available_repos = True
         demands.resolving = True
         demands.root_user = True
+        demands.clean_command_lock = CleanCommandLock.READ
         commands._checkGPGKey(self.base, self.cli)
         if not self.opts.filenames:
             commands._checkEnabledRepo(self.base)

--- a/dnf/cli/commands/shell.py
+++ b/dnf/cli/commands/shell.py
@@ -18,6 +18,7 @@
 #
 
 from dnf.cli import commands
+from dnf.cli.demand import CleanCommandLock
 from dnf.i18n import _, ucd
 
 import dnf.util
@@ -38,6 +39,7 @@ class ShellDemandSheet(object):
     resolving = True
     root_user = True
     sack_activation = True
+    clean_command_lock = CleanCommandLock.READ
 
 
 class ShellCommand(commands.Command, cmd.Cmd):

--- a/dnf/cli/commands/swap.py
+++ b/dnf/cli/commands/swap.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from dnf.i18n import _
 from dnf.cli import commands
+from dnf.cli.demand import CleanCommandLock
 
 import dnf.util
 import logging
@@ -46,6 +47,7 @@ class SwapCommand(commands.Command):
         demands.available_repos = True
         demands.resolving = True
         demands.root_user = True
+        demands.clean_command_lock = CleanCommandLock.READ
         commands._checkGPGKey(self.base, self.cli)
         commands._checkEnabledRepo(self.base, [self.opts.install_spec])
 

--- a/dnf/cli/commands/upgrade.py
+++ b/dnf/cli/commands/upgrade.py
@@ -26,6 +26,7 @@ import dnf.exceptions
 import dnf.base
 import dnf.util
 from dnf.cli import commands
+from dnf.cli.demand import CleanCommandLock
 from dnf.cli.option_parser import OptionParser
 from dnf.i18n import _
 
@@ -56,6 +57,7 @@ class UpgradeCommand(commands.Command):
         demands.available_repos = True
         demands.resolving = True
         demands.root_user = True
+        demands.clean_command_lock = CleanCommandLock.READ
 
         if dnf.util._is_file_pattern_present(self.opts.pkg_specs):
             self.base.conf.optional_metadata_types += ["filelists"]

--- a/dnf/cli/demand.py
+++ b/dnf/cli/demand.py
@@ -19,6 +19,15 @@
 
 from __future__ import unicode_literals
 
+from enum import Enum
+
+
+class CleanCommandLock(Enum):
+    """Clean command lock modes. :api"""
+    NONE = 0
+    READ = 1
+    WRITE = 2
+
 
 class _Default(object):
     def __init__(self, default, choices=None):
@@ -69,3 +78,8 @@ class DemandSheet(object):
     # repositories packages (e.g. versionlock).
     # If it stays None, the demands.resolving is used as a fallback.
     plugin_filtering_enabled = _BoolDefault(None)
+
+    # Determines if/how to lock the clean command lock.
+    # This lock is used to ensure clean command (which uses WRITE mode) running concurrently
+    # with another dnf process doesn't delete required data (packages).
+    clean_command_lock = _Default(CleanCommandLock.NONE, tuple(CleanCommandLock))

--- a/dnf/cli/demand.py
+++ b/dnf/cli/demand.py
@@ -20,9 +20,10 @@
 from __future__ import unicode_literals
 
 
-class _BoolDefault(object):
-    def __init__(self, default):
+class _Default(object):
+    def __init__(self, default, choices=None):
         self.default = default
+        self.choices = choices
         self._storing_name = '__%s%x' % (self.__class__.__name__, id(self))
 
     def __get__(self, obj, objtype=None):
@@ -32,12 +33,18 @@ class _BoolDefault(object):
         return self.default
 
     def __set__(self, obj, val):
+        if self.choices is not None and val not in self.choices:
+            raise ValueError('Invalid demand value: %s' % val)
         objdict = obj.__dict__
         if self._storing_name in objdict:
             current_val = objdict[self._storing_name]
             if current_val != val:
                 raise AttributeError('Demand already set.')
         objdict[self._storing_name] = val
+
+
+_BoolDefault = _Default
+
 
 class DemandSheet(object):
     """Collection of demands that different CLI parts have on other parts. :api"""

--- a/dnf/cli/main.py
+++ b/dnf/cli/main.py
@@ -23,6 +23,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from dnf.conf import Conf
 from dnf.cli.cli import Cli
+from dnf.cli.demand import CleanCommandLock
 from dnf.cli.option_parser import OptionParser
 from dnf.i18n import ucd
 from dnf.cli.utils import show_lock_owner
@@ -32,6 +33,7 @@ import dnf.cli
 import dnf.cli.cli
 import dnf.cli.option_parser
 import dnf.exceptions
+import dnf.lock
 import dnf.i18n
 import dnf.logging
 import dnf.util
@@ -42,6 +44,7 @@ import logging
 import os
 import os.path
 import sys
+from contextlib import nullcontext
 
 logger = logging.getLogger("dnf")
 
@@ -117,52 +120,63 @@ def cli_run(cli, base):
     else:
         f.close()
 
-    try:
-        cli.run()
-    except dnf.exceptions.LockError:
-        raise
-    except (IOError, OSError) as e:
-        return ex_IOError(e)
+    lock = None
+    if cli.demands.clean_command_lock == CleanCommandLock.NONE:
+        lock = nullcontext()
+    elif cli.demands.clean_command_lock == CleanCommandLock.READ:
+        lock = dnf.lock.build_clean_command_lock(base.conf.cachedir, base.conf.exit_on_lock, True)
+    elif cli.demands.clean_command_lock == CleanCommandLock.WRITE:
+        lock = dnf.lock.build_clean_command_lock(base.conf.cachedir, base.conf.exit_on_lock, False)
+    else:
+        raise RuntimeError('Invalid demands.clean_command_lock: %s' % cli.demands.clean_command_lock)
 
-    if cli.demands.resolving:
+    with lock:
         try:
-            ret = resolving(cli, base)
-        except dnf.exceptions.DepsolveError as e:
-            ex_Error(e)
-            msg = ""
-            if not cli.demands.allow_erasing and base._goal.problem_conflicts(available=True):
-                msg += _("try to add '{}' to command line to replace conflicting "
-                         "packages").format("--allowerasing")
-            if cli.base.conf.strict:
-                if not msg:
-                    msg += _("try to add '{}' to skip uninstallable packages").format(
-                        "--skip-broken")
-                else:
-                    msg += _(" or '{}' to skip uninstallable packages").format("--skip-broken")
-            if cli.base.conf.best:
-                prio = cli.base.conf._get_priority("best")
-                if prio <= dnf.conf.PRIO_MAINCONFIG:
-                    if not msg:
-                        msg += _("try to add '{}' to use not only best candidate packages").format(
-                            "--nobest")
-                    else:
-                        msg += _(" or '{}' to use not only best candidate packages").format(
-                            "--nobest")
-            if base._goal.file_dep_problem_present() and 'filelists' not in cli.base.conf.optional_metadata_types:
-                if not msg:
-                    msg += _("try to add '{}' to load additional filelists metadata").format(
-                        "--setopt=optional_metadata_types=filelists")
-                else:
-                    msg += _(" or '{}' to load additional filelists metadata").format(
-                        "--setopt=optional_metadata_types=filelists")
-            if msg:
-                logger.info("({})".format(msg))
+            cli.run()
+        except dnf.exceptions.LockError:
             raise
-        if ret:
-            return ret
+        except (IOError, OSError) as e:
+            return ex_IOError(e)
 
-    cli.command.run_transaction()
-    return cli.demands.success_exit_status
+        if cli.demands.resolving:
+            try:
+                ret = resolving(cli, base)
+            except dnf.exceptions.DepsolveError as e:
+                ex_Error(e)
+                msg = ""
+                if not cli.demands.allow_erasing and base._goal.problem_conflicts(available=True):
+                    msg += _("try to add '{}' to command line to replace conflicting "
+                             "packages").format("--allowerasing")
+                if cli.base.conf.strict:
+                    if not msg:
+                        msg += _("try to add '{}' to skip uninstallable packages").format(
+                            "--skip-broken")
+                    else:
+                        msg += _(" or '{}' to skip uninstallable packages").format("--skip-broken")
+                if cli.base.conf.best:
+                    prio = cli.base.conf._get_priority("best")
+                    if prio <= dnf.conf.PRIO_MAINCONFIG:
+                        if not msg:
+                            msg += _("try to add '{}' to use not only best candidate packages").format(
+                                "--nobest")
+                        else:
+                            msg += _(" or '{}' to use not only best candidate packages").format(
+                                "--nobest")
+                if base._goal.file_dep_problem_present() and 'filelists' not in cli.base.conf.optional_metadata_types:
+                    if not msg:
+                        msg += _("try to add '{}' to load additional filelists metadata").format(
+                            "--setopt=optional_metadata_types=filelists")
+                    else:
+                        msg += _(" or '{}' to load additional filelists metadata").format(
+                            "--setopt=optional_metadata_types=filelists")
+                if msg:
+                    logger.info("({})".format(msg))
+                raise
+            if ret:
+                return ret
+
+        cli.command.run_transaction()
+        return cli.demands.success_exit_status
 
 
 def resolving(cli, base):

--- a/dnf/lock.py
+++ b/dnf/lock.py
@@ -145,3 +145,38 @@ class ProcessLock(object):
         if self.count == 1:
             os.unlink(self.target)
         self._unlock_thread()
+
+
+class FileLock(object):
+    """
+    A file lock with read/write access and blocking/non blocking mode.
+    """
+
+    def __init__(self, target, description, blocking=False, read=False):
+        self.blocking = blocking
+        self.read = read
+        self.description = description
+        self.target = target
+        self.fd = None
+
+    def __enter__(self):
+        dnf.util.ensure_dir(os.path.dirname(self.target))
+        self.fd = os.open(self.target, os.O_CREAT | os.O_RDWR, 0o644)
+        flags = fcntl.LOCK_SH if self.read else fcntl.LOCK_EX
+        if not self.blocking:
+            flags |= fcntl.LOCK_NB
+        try:
+            fcntl.flock(self.fd, flags)
+        except OSError as e:
+            os.close(self.fd)
+            self.fd = None
+            if e.errno == errno.EWOULDBLOCK:
+                msg = '%s already locked' % self.description
+                raise ProcessLockError(msg, -1)
+            raise
+
+    def __exit__(self, *exc_args):
+        if self.fd is not None:
+            fcntl.flock(self.fd, fcntl.LOCK_UN)
+            os.close(self.fd)
+            self.fd = None

--- a/dnf/lock.py
+++ b/dnf/lock.py
@@ -62,6 +62,11 @@ def build_log_lock(logdir, exit_on_lock):
                        'log', not exit_on_lock)
 
 
+def build_clean_command_lock(cachedir, exit_on_lock, read):
+    return FileLock(os.path.join(_fit_lock_dir(cachedir), 'clean_command.lock'),
+                     'clean command', not exit_on_lock, read)
+
+
 class ProcessLock(object):
     def __init__(self, target, description, blocking=False):
         self.blocking = blocking

--- a/tests/cli/test_demand.py
+++ b/tests/cli/test_demand.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import dnf.cli.demand
+from dnf.cli.demand import CleanCommandLock
 
 import tests.support
 
@@ -41,6 +42,7 @@ class DemandTest(tests.support.TestCase):
         self.assertFalse(demands.sack_activation)
         self.assertFalse(demands.root_user)
         self.assertEqual(demands.success_exit_status, 0)
+        self.assertEqual(demands.clean_command_lock, CleanCommandLock.NONE)
 
     def test_independence(self):
         d1 = dnf.cli.demand.DemandSheet()


### PR DESCRIPTION
This is yet another alternative to https://github.com/rpm-software-management/dnf/pull/2336 and https://github.com/rpm-software-management/dnf/pull/2334

For RHEL-83124 and https://github.com/rpm-software-management/dnf/issues/2268


The locking is very simple and there is no reporting on what we are waiting we could extend that in the future if we want (or if the solution is ported to dnf5 we could enhance it there).