### PR TITLE
repolist: Format number of unique packages consistently

### DIFF
--- a/dnf/cli/commands/repolist.py
+++ b/dnf/cli/commands/repolist.py
@@ -141,7 +141,7 @@ class RepoListCommand(commands.Command):
                         size += pkg._size
                         unique_pkgs.add(str(pkg))
                     ui_size = dnf.cli.format.format_number(size)
-                    ui_num_unique = dnf.cli.format.format_number(len(unique_pkgs))
+                    ui_num_unique = _num2ui_num(len(unique_pkgs))
             else:
                 enabled = False
                 if arg == 'enabled' or (arg == 'enabled-default' and not extcmds):


### PR DESCRIPTION
The number of packages should be displayed exactly, not using kilo-, mega-, or other abbreviated units.

Before the patch:
❯ dnf repoinfo fedora
...
Repo-pkgs          : 77,664
Repo-available-pkgs: 77,664
Repo-unique-NEVRAs : 76 k
...

With the patch:
❯ dnf repoinfo fedora
...
Repo-pkgs          : 77,664
Repo-available-pkgs: 77,664
Repo-unique-NEVRAs : 77,664
...

This is a follow-up to https://github.com/rpm-software-management/dnf/pull/2324